### PR TITLE
NurikabeSolver: Basic Rules

### DIFF
--- a/project/src/demo/nurikabe/demo_nurikabe_solver.gd
+++ b/project/src/demo/nurikabe/demo_nurikabe_solver.gd
@@ -1,0 +1,38 @@
+extends Node
+## [b]Keys:[/b][br]
+## 	[kbd]Q[/kbd]: Solve.
+
+func _input(event: InputEvent) -> void:
+	match Utils.key_press(event):
+		KEY_Q:
+			_solve()
+
+
+func _solve() -> void:
+	var board: NurikabeBoardModel = %GameBoard.to_model()
+	var solver: NurikabeSolver = NurikabeSolver.new()
+	var changes: Array[Dictionary] = []
+	
+	if not %MessageLabel.text.is_empty():
+		%MessageLabel.text += "--------\n"
+	for callable: Callable in [
+		solver.deduce_joined_island,
+		solver.deduce_unclued_island,
+		solver.deduce_island_too_large,
+		solver.deduce_island_too_small,
+		solver.deduce_pools,
+		solver.deduce_split_walls,
+	]:
+		var deduction: NurikabeSolver.Deduction = callable.call(board)
+		if not deduction.changes.is_empty():
+			var deduction_name: String = callable.get_method()
+			var deduction_positions: Array[Vector2i] = []
+			for change: Dictionary[String, Variant] in deduction.changes:
+				deduction_positions.append(change["pos"])
+			%MessageLabel.text += "%s: %s\n" % [deduction_name, deduction_positions]
+			changes.append_array(deduction.changes)
+	
+	if changes.is_empty():
+		%MessageLabel.text += "(no changes)\n"
+	
+	%GameBoard.set_cell_strings(changes)

--- a/project/src/demo/nurikabe/demo_nurikabe_solver.gd.uid
+++ b/project/src/demo/nurikabe/demo_nurikabe_solver.gd.uid
@@ -1,0 +1,1 @@
+uid://cbtm562mid2d8

--- a/project/src/demo/nurikabe/demo_nurikabe_solver.tscn
+++ b/project/src/demo/nurikabe/demo_nurikabe_solver.tscn
@@ -1,0 +1,78 @@
+[gd_scene load_steps=4 format=4 uid="uid://cwg0gsspishux"]
+
+[ext_resource type="PackedScene" uid="uid://b06aw2k2o1thk" path="res://src/main/nurikabe/game_board.tscn" id="1_p5ylp"]
+[ext_resource type="Script" uid="uid://cbtm562mid2d8" path="res://src/demo/nurikabe/demo_nurikabe_solver.gd" id="1_yqxth"]
+[ext_resource type="FontFile" uid="uid://pq4x38hcbx4h" path="res://assets/main/ui/baloo2.ttf" id="3_8djyv"]
+
+[node name="Demo" type="Node"]
+script = ExtResource("1_yqxth")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="GameBoardHolder" type="Control" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="GameBoard" parent="HBoxContainer/GameBoardHolder" instance=ExtResource("1_p5ylp")]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -326.0
+offset_top = -295.0
+offset_right = -326.0
+offset_bottom = -295.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 6
+size_flags_vertical = 4
+grid_string = " 2                 2
+             2      
+   2     7          
+                    
+             3   3  
+     2         3    
+ 2     4            
+                    
+   1         2   4  "
+
+[node name="TileMapGround" parent="HBoxContainer/GameBoardHolder/GameBoard" index="0"]
+tile_map_data = PackedByteArray("AAAAAAAAAAAAAAAAAAABAAAAAQAAAAAAAAACAAAAAAAAAAAAAAADAAAAAQAAAAAAAAAEAAAAAAAAAAAAAAAFAAAAAQAAAAAAAAAGAAAAAAAAAAAAAAAHAAAAAQAAAAAAAAAIAAAAAAAAAAAAAAAJAAAAAQAAAAAAAAAAAAEAAQAAAAAAAAABAAEAAAAAAAAAAAACAAEAAQAAAAAAAAADAAEAAAAAAAAAAAAEAAEAAQAAAAAAAAAFAAEAAAAAAAAAAAAGAAEAAQAAAAAAAAAHAAEAAAAAAAAAAAAIAAEAAQAAAAAAAAAJAAEAAAAAAAAAAAAAAAIAAAAAAAAAAAABAAIAAQAAAAAAAAACAAIAAAAAAAAAAAADAAIAAQAAAAAAAAAEAAIAAAAAAAAAAAAFAAIAAQAAAAAAAAAGAAIAAAAAAAAAAAAHAAIAAQAAAAAAAAAIAAIAAAAAAAAAAAAJAAIAAQAAAAAAAAAAAAMAAQAAAAAAAAABAAMAAAAAAAAAAAACAAMAAQAAAAAAAAADAAMAAAAAAAAAAAAEAAMAAQAAAAAAAAAFAAMAAAAAAAAAAAAGAAMAAQAAAAAAAAAHAAMAAAAAAAAAAAAIAAMAAQAAAAAAAAAJAAMAAAAAAAAAAAAAAAQAAAAAAAAAAAABAAQAAQAAAAAAAAACAAQAAAAAAAAAAAADAAQAAQAAAAAAAAAEAAQAAAAAAAAAAAAFAAQAAQAAAAAAAAAGAAQAAAAAAAAAAAAHAAQAAQAAAAAAAAAIAAQAAAAAAAAAAAAJAAQAAQAAAAAAAAAAAAUAAQAAAAAAAAABAAUAAAAAAAAAAAACAAUAAQAAAAAAAAADAAUAAAAAAAAAAAAEAAUAAQAAAAAAAAAFAAUAAAAAAAAAAAAGAAUAAQAAAAAAAAAHAAUAAAAAAAAAAAAIAAUAAQAAAAAAAAAJAAUAAAAAAAAAAAAAAAYAAAAAAAAAAAABAAYAAQAAAAAAAAACAAYAAAAAAAAAAAADAAYAAQAAAAAAAAAEAAYAAAAAAAAAAAAFAAYAAQAAAAAAAAAGAAYAAAAAAAAAAAAHAAYAAQAAAAAAAAAIAAYAAAAAAAAAAAAJAAYAAQAAAAAAAAAAAAcAAQAAAAAAAAABAAcAAAAAAAAAAAACAAcAAQAAAAAAAAADAAcAAAAAAAAAAAAEAAcAAQAAAAAAAAAFAAcAAAAAAAAAAAAGAAcAAQAAAAAAAAAHAAcAAAAAAAAAAAAIAAcAAQAAAAAAAAAJAAcAAAAAAAAAAAAAAAgAAAAAAAAAAAABAAgAAQAAAAAAAAACAAgAAAAAAAAAAAADAAgAAQAAAAAAAAAEAAgAAAAAAAAAAAAFAAgAAQAAAAAAAAAGAAgAAAAAAAAAAAAHAAgAAQAAAAAAAAAIAAgAAAAAAAAAAAAJAAgAAQAAAAAAAAA=")
+
+[node name="TileMapClue" parent="HBoxContainer/GameBoardHolder/GameBoard" index="3"]
+clues_by_cell = Dictionary[Vector2i, int]({
+Vector2i(0, 0): 2,
+Vector2i(0, 6): 2,
+Vector2i(1, 2): 2,
+Vector2i(1, 8): 1,
+Vector2i(2, 5): 2,
+Vector2i(3, 6): 4,
+Vector2i(4, 2): 7,
+Vector2i(6, 1): 2,
+Vector2i(6, 4): 3,
+Vector2i(6, 8): 2,
+Vector2i(7, 5): 3,
+Vector2i(8, 4): 3,
+Vector2i(8, 8): 4,
+Vector2i(9, 0): 2
+})
+
+[node name="CursorableArea" parent="HBoxContainer/GameBoardHolder/GameBoard" index="5"]
+cursorable_rect = Rect2(0, 0, 2560, 2304)
+
+[node name="MessageLabel" type="RichTextLabel" parent="HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_fonts/normal_font = ExtResource("3_8djyv")
+theme_override_font_sizes/normal_font_size = 32
+
+[editable path="HBoxContainer/GameBoardHolder/GameBoard"]

--- a/project/src/main/nurikabe/nurikabe_solver.gd
+++ b/project/src/main/nurikabe/nurikabe_solver.gd
@@ -1,0 +1,207 @@
+class_name NurikabeSolver
+
+enum DeductionReason {
+	UNKNOWN,
+	JOINED_ISLAND, # island with 2 or more clues
+	UNCLUED_ISLAND, # island with 0 clues
+	ISLAND_TOO_LARGE, # large island with a small clue
+	ISLAND_TOO_SMALL, # small island with a large clue
+	POOLS, # 2x2 grid of wall cells
+	SPLIT_WALLS, # wall cells cannot be joined
+}
+
+const CELL_EMPTY: String = NurikabeUtils.CELL_EMPTY
+const CELL_INVALID: String = NurikabeUtils.CELL_INVALID
+const CELL_ISLAND: String = NurikabeUtils.CELL_ISLAND
+const CELL_WALL: String = NurikabeUtils.CELL_WALL
+
+func deduce_joined_island(board: NurikabeBoardModel) -> Deduction:
+	var deduction: Deduction = Deduction.new([], DeductionReason.JOINED_ISLAND)
+	
+	# Find the number of single-clue islands bordering each empty cell, store it in neighbor_map.
+	#
+	# -1: invalid
+	# 0: bordering 0 islands with exactly one clue
+	# 1: bordering 1 island with exactly one clue
+	# n: bordering n islands with exactly one clue
+	var neighbor_map: Dictionary[Vector2i, int] = {}
+	for cell: Vector2i in board.cells:
+		neighbor_map[cell] = 0
+	for group: Array[Vector2i] in board.find_smallest_island_groups():
+		if board.get_clue_cells(group).size() != 1:
+			continue
+		var seen: Dictionary[Vector2i, bool] = {}
+		for cell: Vector2i in group:
+			for neighbor_cell: Vector2i in board.get_neighbors(cell):
+				if seen.has(neighbor_cell) or board.get_cell_string(neighbor_cell) != CELL_EMPTY:
+					continue
+				neighbor_map[neighbor_cell] += 1
+				seen[neighbor_cell] = true
+	
+	# Fill in empty cells bordering 2 or more islands with a wall.
+	for cell: Vector2i in neighbor_map.keys():
+		if neighbor_map[cell] >= 2:
+			deduction.append(cell, CELL_WALL)
+	
+	return deduction
+
+
+func deduce_unclued_island(board: NurikabeBoardModel) -> Deduction:
+	var deduction: Deduction = Deduction.new([], DeductionReason.UNCLUED_ISLAND)
+	
+	# Find islands without any clues. These islands must be walls.
+	for group: Array[Vector2i] in board.find_largest_island_groups():
+		var only_empty_cells: bool = true
+		for cell: Vector2i in group:
+			if board.get_cell_string(cell) != CELL_EMPTY:
+				only_empty_cells = false
+				break
+		if only_empty_cells:
+			for cell: Vector2i in group:
+				deduction.append(cell, CELL_WALL)
+	
+	# If making an empty cell a wall creates a new unclued island, this cell must be an island.
+	var unclued_island_count: int = _unclued_island_count(board)
+	for cell: Vector2i in board.cells:
+		if board.get_cell_string(cell) != CELL_EMPTY:
+			continue
+		
+		var trial: NurikabeBoardModel = board.duplicate()
+		trial.cells[cell] = CELL_WALL
+		var trial_unclued_island_count: int = _unclued_island_count(trial)
+		if trial_unclued_island_count > unclued_island_count:
+			deduction.append(cell, CELL_ISLAND)
+	
+	return deduction
+
+
+func deduce_island_too_large(board: NurikabeBoardModel) -> Deduction:
+	var deduction: Deduction = Deduction.new([], DeductionReason.ISLAND_TOO_LARGE)
+	
+	# Find islands which cannot grow any larger, store them in complete_islands.
+	var complete_islands: Array[Array] = []
+	for group: Array[Vector2i] in board.find_smallest_island_groups():
+		var clue_cells: Array[Vector2i] = board.get_clue_cells(group)
+		if clue_cells.size() == 1 and board.get_cell_string(clue_cells[0]).to_int() == group.size():
+			complete_islands.append(group)
+	
+	# Fill in all empty cells neighboring a complete island.
+	var seen: Dictionary[Vector2i, bool] = {}
+	for group: Array[Vector2i] in complete_islands:
+		for cell: Vector2i in group:
+			for neighbor_cell: Vector2i in board.get_neighbors(cell):
+				if seen.has(neighbor_cell) or board.get_cell_string(neighbor_cell) != CELL_EMPTY:
+					continue
+				deduction.append(neighbor_cell, NurikabeUtils.CELL_WALL)
+				seen[neighbor_cell] = true
+	
+	return deduction
+
+
+func deduce_island_too_small(board: NurikabeBoardModel) -> Deduction:
+	var deduction: Deduction = Deduction.new([], DeductionReason.ISLAND_TOO_SMALL)
+	
+	# If making an empty cell a wall creates an uncompletable island, this cell must be an island.
+	var uncompletable_island_count: int = _uncompletable_island_count(board)
+	for cell: Vector2i in board.cells:
+		if board.get_cell_string(cell) != CELL_EMPTY:
+			continue
+		
+		var trial: NurikabeBoardModel = board.duplicate()
+		trial.cells[cell] = CELL_WALL
+		var trial_uncompletable_island_count: int = _uncompletable_island_count(trial)
+		if trial_uncompletable_island_count > uncompletable_island_count:
+			deduction.append(cell, CELL_ISLAND)
+	
+	return deduction
+
+
+func deduce_pools(board: NurikabeBoardModel) -> Deduction:
+	var deduction: Deduction = Deduction.new([], DeductionReason.POOLS)
+	var pool_count: int = board.get_pool_cells().size()
+	for cell: Vector2i in board.cells:
+		if board.get_cell_string(cell) != CELL_EMPTY:
+			continue
+		
+		var trial: NurikabeBoardModel = board.duplicate()
+		trial.cells[cell] = CELL_WALL
+		for group: Array[Vector2i] in _empty_islands(trial):
+			for group_cell: Vector2i in group:
+				trial.cells[group_cell] = CELL_WALL
+		var trial_pool_count: int = trial.get_pool_cells().size()
+		if trial_pool_count > pool_count:
+			deduction.append(cell, CELL_ISLAND)
+	return deduction
+
+
+func deduce_split_walls(board: NurikabeBoardModel) -> Deduction:
+	var deduction: Deduction = Deduction.new([], DeductionReason.SPLIT_WALLS)
+	var wall_count: int = _largest_non_empty_wall_groups(board).size()
+	for cell: Vector2i in board.cells:
+		if board.get_cell_string(cell) != CELL_EMPTY:
+			continue
+		
+		var trial: NurikabeBoardModel = board.duplicate()
+		trial.cells[cell] = CELL_ISLAND
+		var trial_wall_count: int = _largest_non_empty_wall_groups(trial).size()
+		if trial_wall_count > wall_count:
+			trial.find_largest_wall_groups()
+			deduction.append(cell, CELL_WALL)
+	return deduction
+
+
+func _largest_non_empty_wall_groups(board: NurikabeBoardModel) -> Array[Array]:
+	var result: Array[Array] = []
+	for group: Array[Vector2i] in board.find_largest_wall_groups():
+		var only_empty_cells: bool = true
+		for cell: Vector2i in group:
+			if board.get_cell_string(cell) != CELL_EMPTY:
+				only_empty_cells = false
+				break
+		if not only_empty_cells:
+			result.append(group)
+	return result
+
+
+func _empty_islands(board: NurikabeBoardModel) -> Array[Array]:
+	var result: Array[Array] = []
+	var groups: Array[Array] = board.find_largest_island_groups()
+	for group: Array[Vector2i] in groups:
+		var only_empty_cells: bool = true
+		for cell: Vector2i in group:
+			if board.get_cell_string(cell) != CELL_EMPTY:
+				only_empty_cells = false
+				break
+		if only_empty_cells:
+			result.append(group)
+	return result
+
+
+func _unclued_island_count(board: NurikabeBoardModel) -> int:
+	var result: int = 0
+	for group: Array[Vector2i] in board.find_largest_island_groups():
+		var clue_cells: Array[Vector2i] = board.get_clue_cells(group)
+		if clue_cells.size() == 0:
+			result += 1
+	return result
+
+
+func _uncompletable_island_count(board: NurikabeBoardModel) -> int:
+	var result: int = 0
+	for group: Array[Vector2i] in board.find_largest_island_groups():
+		var clue_cells: Array[Vector2i] = board.get_clue_cells(group)
+		if clue_cells.size() == 1 and board.get_cell_string(clue_cells[0]).to_int() > group.size():
+			result += 1
+	return result
+
+
+class Deduction:
+	var changes: Array[Dictionary]
+	var reason: DeductionReason
+	
+	func _init(init_changes: Array[Dictionary] = [], init_reason: DeductionReason = DeductionReason.UNKNOWN) -> void:
+		changes = init_changes
+		reason = init_reason
+	
+	func append(pos: Vector2i, value: String) -> void:
+		changes.append({"pos": pos, "value": value})

--- a/project/src/main/nurikabe/nurikabe_solver.gd.uid
+++ b/project/src/main/nurikabe/nurikabe_solver.gd.uid
@@ -1,0 +1,1 @@
+uid://b14i87loelo4q

--- a/project/src/main/utils/utils.gd
+++ b/project/src/main/utils/utils.gd
@@ -2,6 +2,11 @@
 class_name Utils
 ## Contains global utilities.
 
+const NUM_SCANCODES := {
+	KEY_0: 0, KEY_1: 1, KEY_2: 2, KEY_3: 3, KEY_4: 4,
+	KEY_5: 5, KEY_6: 6, KEY_7: 7, KEY_8: 8, KEY_9: 9,
+}
+
 ## Recursively finds all files with the given extension starting at [param path].
 static func find_files(path: String, file_extension: String) -> Array[String]:
 	var found_files: Array[String] = []
@@ -31,6 +36,19 @@ static func find_files(path: String, file_extension: String) -> Array[String]:
 		file = dir.get_next()
 	
 	return found_files
+
+
+## Returns [0-9] for a number key event, or -1 if the event is not a number key event.
+static func key_num(event: InputEvent) -> int:
+	return NUM_SCANCODES.get(key_press(event), -1)
+
+
+## Returns the [member InputEventKey.keycode] for a key press event, or -1 if the event is not a key press event.
+static func key_press(event: InputEvent) -> int:
+	var keycode := -1
+	if event is InputEventKey and event.is_pressed() and not event.is_echo():
+		keycode = event.keycode
+	return keycode
 
 
 ## Invalidates a tween if it is already active.[br]

--- a/project/src/test/nurikabe/test_nurikabe_solver.gd
+++ b/project/src/test/nurikabe/test_nurikabe_solver.gd
@@ -1,0 +1,251 @@
+extends GutTest
+
+var solver: NurikabeSolver = NurikabeSolver.new()
+var grid: Array[String] = []
+
+func test_deduce_joined_island_2() -> void:
+	grid = [
+		" 3   3",
+		"      ",
+		"      ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_WALL},
+		], NurikabeSolver.DeductionReason.JOINED_ISLAND)
+	assert_deduction(solver.deduce_joined_island(init_model()), expected)
+
+
+func test_deduce_joined_island_3() -> void:
+	grid = [
+		" 1      ",
+		"   2   3",
+		"        ",
+		"        ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_WALL},
+			{"pos": Vector2i(0, 1), "value": NurikabeUtils.CELL_WALL},
+			{"pos": Vector2i(2, 1), "value": NurikabeUtils.CELL_WALL},
+		], NurikabeSolver.DeductionReason.JOINED_ISLAND)
+	assert_deduction(solver.deduce_joined_island(init_model()), expected)
+
+
+func test_deduce_joined_island_mistake() -> void:
+	grid = [
+		" 2 . 2",
+		"      ",
+		"      ",
+		"      ",
+		" 2   2",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(1, 4), "value": NurikabeUtils.CELL_WALL},
+		], NurikabeSolver.DeductionReason.JOINED_ISLAND)
+	assert_deduction(solver.deduce_joined_island(init_model()), expected)
+
+
+func test_deduce_joined_island_none() -> void:
+	grid = [
+		" 2    ",
+		"     2",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+		], NurikabeSolver.DeductionReason.JOINED_ISLAND)
+	assert_deduction(solver.deduce_joined_island(init_model()), expected)
+
+
+func test_deduce_unclued_island_invalid() -> void:
+	# the grid already has an island with no clue; don't perform this deduction
+	grid = [
+		" .##  ",
+		"##   2",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+		], NurikabeSolver.DeductionReason.UNCLUED_ISLAND)
+	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
+
+
+func test_deduce_unclued_island_1() -> void:
+	grid = [
+		" 2  ##",
+		"####  ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(2, 1), "value": NurikabeUtils.CELL_WALL},
+		], NurikabeSolver.DeductionReason.UNCLUED_ISLAND)
+	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
+
+
+func test_deduce_unclued_island_chokepoint() -> void:
+	grid = [
+		"  ##  ",
+		" 3   .",
+		"  ##  ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(1, 1), "value": NurikabeUtils.CELL_ISLAND},
+		], NurikabeSolver.DeductionReason.UNCLUED_ISLAND)
+	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
+
+
+func test_deduce_unclued_island_chokepoint_2() -> void:
+	grid = [
+		" 5    ",
+		"##    ",
+		" .    ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_ISLAND},
+			{"pos": Vector2i(1, 2), "value": NurikabeUtils.CELL_ISLAND},
+		], NurikabeSolver.DeductionReason.UNCLUED_ISLAND)
+	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
+
+
+func test_deduce_island_too_large_1() -> void:
+	grid = [
+		" 2 .  ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(2, 0), "value": NurikabeUtils.CELL_WALL},
+		], NurikabeSolver.DeductionReason.ISLAND_TOO_LARGE)
+	assert_deduction(solver.deduce_island_too_large(init_model()), expected)
+
+
+func test_deduce_island_too_large_2() -> void:
+	grid = [
+		" 2 .  ",
+		"      ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(0, 1), "value": NurikabeUtils.CELL_WALL},
+			{"pos": Vector2i(1, 1), "value": NurikabeUtils.CELL_WALL},
+			{"pos": Vector2i(2, 0), "value": NurikabeUtils.CELL_WALL},
+		], NurikabeSolver.DeductionReason.ISLAND_TOO_LARGE)
+	assert_deduction(solver.deduce_island_too_large(init_model()), expected)
+
+
+func test_deduce_island_too_large_invalid() -> void:
+	# the island is already too large; don't perform this deduction
+	grid = [
+		" 2 . .",
+		"      ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+		], NurikabeSolver.DeductionReason.ISLAND_TOO_LARGE)
+	assert_deduction(solver.deduce_island_too_large(init_model()), expected)
+
+
+func test_island_too_small_1() -> void:
+	grid = [
+		" 3    ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_ISLAND},
+			{"pos": Vector2i(2, 0), "value": NurikabeUtils.CELL_ISLAND},
+		], NurikabeSolver.DeductionReason.ISLAND_TOO_SMALL)
+	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
+
+
+func test_island_too_small_multiple() -> void:
+	grid = [
+		" 2    ",
+		"##    ",
+		"##   3",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_ISLAND},
+		], NurikabeSolver.DeductionReason.ISLAND_TOO_SMALL)
+	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
+
+
+func test_island_too_small_chokepoint() -> void:
+	grid = [
+		" 4    ",
+		"##  ##",
+		"      ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_ISLAND},
+			{"pos": Vector2i(1, 1), "value": NurikabeUtils.CELL_ISLAND},
+		], NurikabeSolver.DeductionReason.ISLAND_TOO_SMALL)
+	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
+
+
+func test_island_too_small_chokepoint_2() -> void:
+	grid = [
+		" 4  ##",
+		"##  ##",
+		"      ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_ISLAND},
+			{"pos": Vector2i(1, 1), "value": NurikabeUtils.CELL_ISLAND},
+			{"pos": Vector2i(1, 2), "value": NurikabeUtils.CELL_ISLAND},
+		], NurikabeSolver.DeductionReason.ISLAND_TOO_SMALL)
+	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
+
+
+func test_pools_1() -> void:
+	grid = [
+		" 4    ",
+		"    ##",
+		"  ####",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(1, 1), "value": NurikabeUtils.CELL_ISLAND},
+		], NurikabeSolver.DeductionReason.POOLS)
+	assert_deduction(solver.deduce_pools(init_model()), expected)
+
+
+func test_pools_cut_off() -> void:
+	grid = [
+		" 5    ",
+		"  ##  ",
+		"  ##  ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(0, 1), "value": NurikabeUtils.CELL_ISLAND},
+			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_ISLAND},
+			{"pos": Vector2i(2, 0), "value": NurikabeUtils.CELL_ISLAND},
+			{"pos": Vector2i(2, 1), "value": NurikabeUtils.CELL_ISLAND},
+		], NurikabeSolver.DeductionReason.POOLS)
+	assert_deduction(solver.deduce_pools(init_model()), expected)
+
+
+func test_no_split_walls_1() -> void:
+	grid = [
+		" 3##  ",
+		"     3",
+		"  ##  ",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(1, 1), "value": NurikabeUtils.CELL_WALL},
+		], NurikabeSolver.DeductionReason.SPLIT_WALLS)
+	assert_deduction(solver.deduce_split_walls(init_model()), expected)
+
+
+func test_no_split_walls_2() -> void:
+	grid = [
+		"## 4  ",
+		"      ",
+		"    ##",
+	]
+	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
+			{"pos": Vector2i(0, 1), "value": NurikabeUtils.CELL_WALL},
+		], NurikabeSolver.DeductionReason.SPLIT_WALLS)
+	assert_deduction(solver.deduce_split_walls(init_model()), expected)
+
+
+func assert_deduction(actual: NurikabeSolver.Deduction, expected: NurikabeSolver.Deduction) -> void:
+	assert_eq(sorted_changes(actual.changes), sorted_changes(expected.changes))
+	assert_eq(actual.reason, expected.reason)
+
+
+func init_model() -> NurikabeBoardModel:
+	return NurikabeTestUtils.init_model(grid)
+
+
+func sorted_changes(changes: Array[Dictionary]) -> Array[Dictionary]:
+	var result: Array[Dictionary] = changes.duplicate()
+	result.sort_custom(func(a: Dictionary, b: Dictionary) -> bool: return a["pos"] < b["pos"])
+	return result

--- a/project/src/test/nurikabe/test_nurikabe_solver.gd.uid
+++ b/project/src/test/nurikabe/test_nurikabe_solver.gd.uid
@@ -1,0 +1,1 @@
+uid://rshvi2lgfc2g


### PR DESCRIPTION
Added deductions for basic rules:
-An island cannot have two or more clues.
-An island cannot have zero clues.
-The number of squares in an island cannot be larger than the value of the clue. -The number of squares in an island cannot be smaller than the value of the clue. -There are no wall areas of 2x2 or larger.
-A wall can’t be separated from other walls.

The solver can solve about 25% of the introductory 9x10 puzzle.