### PR TITLE
Refactored NurikabeSolver: per-deduction reasons, test framework

### DIFF
--- a/project/src/demo/nurikabe/demo_nurikabe_solver.gd
+++ b/project/src/demo/nurikabe/demo_nurikabe_solver.gd
@@ -15,22 +15,20 @@ func _solve() -> void:
 	
 	if not %MessageLabel.text.is_empty():
 		%MessageLabel.text += "--------\n"
-	for callable: Callable in [
-		solver.deduce_joined_island,
-		solver.deduce_unclued_island,
-		solver.deduce_island_too_large,
-		solver.deduce_island_too_small,
-		solver.deduce_pools,
-		solver.deduce_split_walls,
-	]:
-		var deduction: NurikabeSolver.Deduction = callable.call(board)
-		if not deduction.changes.is_empty():
-			var deduction_name: String = callable.get_method()
-			var deduction_positions: Array[Vector2i] = []
-			for change: Dictionary[String, Variant] in deduction.changes:
-				deduction_positions.append(change["pos"])
-			%MessageLabel.text += "%s: %s\n" % [deduction_name, deduction_positions]
-			changes.append_array(deduction.changes)
+	for callable: Callable in solver.rules:
+		var deductions: Array[NurikabeDeduction] = callable.call(board)
+		if deductions.is_empty():
+			continue
+		var deduction_positions_by_reason: Dictionary[String, Array] = {}
+		for deduction: NurikabeDeduction in deductions:
+			var reason_name: String = Utils.enum_to_snake_case(NurikabeUtils.Reason, deduction["reason"])
+			if not deduction_positions_by_reason.has(reason_name):
+				deduction_positions_by_reason[reason_name] = []
+			deduction_positions_by_reason[reason_name].append(deduction["pos"])
+		for reason_name: String in deduction_positions_by_reason:
+			%MessageLabel.text += "%s: %s\n" % [reason_name, deduction_positions_by_reason[reason_name]]
+		for deduction: NurikabeDeduction in deductions:
+			changes.append(deduction.to_change())
 	
 	if changes.is_empty():
 		%MessageLabel.text += "(no changes)\n"

--- a/project/src/main/nurikabe/nurikabe_deduction.gd
+++ b/project/src/main/nurikabe/nurikabe_deduction.gd
@@ -1,0 +1,18 @@
+class_name NurikabeDeduction
+
+var pos: Vector2i
+var value: String
+var reason: NurikabeUtils.Reason
+
+func _init(init_pos: Vector2i, init_value: String, init_reason: NurikabeUtils.Reason) -> void:
+	pos = init_pos
+	value = init_value
+	reason = init_reason
+
+
+func to_change() -> Dictionary[String, Variant]:
+	return {"pos": pos, "value": value}
+
+
+func _to_string() -> String:
+	return "%s->%s (%s)" % [pos, value, Utils.enum_to_snake_case(NurikabeUtils.Reason, reason),]

--- a/project/src/main/nurikabe/nurikabe_deduction.gd.uid
+++ b/project/src/main/nurikabe/nurikabe_deduction.gd.uid
@@ -1,0 +1,1 @@
+uid://cl8akj4jdktb5

--- a/project/src/main/nurikabe/nurikabe_utils.gd
+++ b/project/src/main/nurikabe/nurikabe_utils.gd
@@ -1,6 +1,18 @@
 class_name NurikabeUtils
 extends Node
 
+enum Reason {
+	UNKNOWN_REASON,
+	
+	# rules
+	JOINED_ISLAND, # island with 2 or more clues
+	UNCLUED_ISLAND, # island with 0 clues
+	ISLAND_TOO_LARGE, # large island with a small clue
+	ISLAND_TOO_SMALL, # small island with a large clue
+	POOLS, # 2x2 grid of wall cells
+	SPLIT_WALLS, # wall cells cannot be joined
+}
+
 ## Nurikabe cells:
 ## 	['0'-'99']: Clue
 ## 	'!': Invalid (out of bounds)
@@ -11,6 +23,16 @@ const CELL_EMPTY := ""
 const CELL_INVALID := "!"
 const CELL_ISLAND := "."
 const CELL_WALL := "##"
+
+const UNKNOWN_REASON: Reason = Reason.UNKNOWN_REASON
+
+## Rules
+const JOINED_ISLAND: Reason = Reason.JOINED_ISLAND
+const UNCLUED_ISLAND: Reason = Reason.UNCLUED_ISLAND
+const ISLAND_TOO_LARGE: Reason = Reason.ISLAND_TOO_LARGE
+const ISLAND_TOO_SMALL: Reason = Reason.ISLAND_TOO_SMALL
+const POOLS: Reason = Reason.POOLS
+const SPLIT_WALLS: Reason = Reason.SPLIT_WALLS
 
 const ERROR_FG_COLOR: Color = Color.WHITE
 const ERROR_BG_COLOR: Color = Color("ff5a5a")

--- a/project/src/test/nurikabe/test_nurikabe_solver.gd
+++ b/project/src/test/nurikabe/test_nurikabe_solver.gd
@@ -1,263 +1,39 @@
+class_name TestNurikabeSolver
 extends GutTest
+## Framework for testing the Nurikabe Solver.
+
+const CELL_EMPTY: String = NurikabeUtils.CELL_EMPTY
+const CELL_INVALID: String = NurikabeUtils.CELL_INVALID
+const CELL_ISLAND: String = NurikabeUtils.CELL_ISLAND
+const CELL_WALL: String = NurikabeUtils.CELL_WALL
+
+const UNKNOWN_REASON: NurikabeUtils.Reason = NurikabeUtils.UNKNOWN_REASON
+
+## Rules
+const JOINED_ISLAND: NurikabeUtils.Reason = NurikabeUtils.JOINED_ISLAND
+const UNCLUED_ISLAND: NurikabeUtils.Reason = NurikabeUtils.UNCLUED_ISLAND
+const ISLAND_TOO_LARGE: NurikabeUtils.Reason = NurikabeUtils.ISLAND_TOO_LARGE
+const ISLAND_TOO_SMALL: NurikabeUtils.Reason = NurikabeUtils.ISLAND_TOO_SMALL
+const POOLS: NurikabeUtils.Reason = NurikabeUtils.POOLS
+const SPLIT_WALLS: NurikabeUtils.Reason = NurikabeUtils.SPLIT_WALLS
 
 var solver: NurikabeSolver = NurikabeSolver.new()
 var grid: Array[String] = []
 
-func test_deduce_joined_island_2() -> void:
-	grid = [
-		" 3   3",
-		"      ",
-		"      ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_WALL},
-		], NurikabeSolver.DeductionReason.JOINED_ISLAND)
-	assert_deduction(solver.deduce_joined_island(init_model()), expected)
-
-
-func test_deduce_joined_island_3() -> void:
-	grid = [
-		" 1      ",
-		"   2   3",
-		"        ",
-		"        ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_WALL},
-			{"pos": Vector2i(0, 1), "value": NurikabeUtils.CELL_WALL},
-			{"pos": Vector2i(2, 1), "value": NurikabeUtils.CELL_WALL},
-		], NurikabeSolver.DeductionReason.JOINED_ISLAND)
-	assert_deduction(solver.deduce_joined_island(init_model()), expected)
-
-
-func test_deduce_joined_island_mistake() -> void:
-	grid = [
-		" 2 . 2",
-		"      ",
-		"      ",
-		"      ",
-		" 2   2",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(1, 4), "value": NurikabeUtils.CELL_WALL},
-		], NurikabeSolver.DeductionReason.JOINED_ISLAND)
-	assert_deduction(solver.deduce_joined_island(init_model()), expected)
-
-
-func test_deduce_joined_island_none() -> void:
-	grid = [
-		" 2    ",
-		"     2",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-		], NurikabeSolver.DeductionReason.JOINED_ISLAND)
-	assert_deduction(solver.deduce_joined_island(init_model()), expected)
-
-
-func test_deduce_unclued_island_invalid() -> void:
-	# the grid already has an island with no clue; don't perform this deduction
-	grid = [
-		" .##  ",
-		"##   2",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-		], NurikabeSolver.DeductionReason.UNCLUED_ISLAND)
-	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
-
-
-func test_deduce_unclued_island_invalid_2() -> void:
-	# the grid already has an island with no clue; don't perform this deduction
-	grid = [
-		"## 3##",
-		"## .  ",
-		"      ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-		], NurikabeSolver.DeductionReason.UNCLUED_ISLAND)
-	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
-
-
-func test_deduce_unclued_island_1() -> void:
-	grid = [
-		" 2  ##",
-		"####  ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(2, 1), "value": NurikabeUtils.CELL_WALL},
-		], NurikabeSolver.DeductionReason.UNCLUED_ISLAND)
-	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
-
-
-func test_deduce_unclued_island_chokepoint() -> void:
-	grid = [
-		"  ##  ",
-		" 3   .",
-		"  ##  ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(1, 1), "value": NurikabeUtils.CELL_ISLAND},
-		], NurikabeSolver.DeductionReason.UNCLUED_ISLAND)
-	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
-
-
-func test_deduce_unclued_island_chokepoint_2() -> void:
-	grid = [
-		" 5    ",
-		"##    ",
-		" .    ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_ISLAND},
-			{"pos": Vector2i(1, 2), "value": NurikabeUtils.CELL_ISLAND},
-		], NurikabeSolver.DeductionReason.UNCLUED_ISLAND)
-	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
-
-
-func test_deduce_island_too_large_1() -> void:
-	grid = [
-		" 2 .  ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(2, 0), "value": NurikabeUtils.CELL_WALL},
-		], NurikabeSolver.DeductionReason.ISLAND_TOO_LARGE)
-	assert_deduction(solver.deduce_island_too_large(init_model()), expected)
-
-
-func test_deduce_island_too_large_2() -> void:
-	grid = [
-		" 2 .  ",
-		"      ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(0, 1), "value": NurikabeUtils.CELL_WALL},
-			{"pos": Vector2i(1, 1), "value": NurikabeUtils.CELL_WALL},
-			{"pos": Vector2i(2, 0), "value": NurikabeUtils.CELL_WALL},
-		], NurikabeSolver.DeductionReason.ISLAND_TOO_LARGE)
-	assert_deduction(solver.deduce_island_too_large(init_model()), expected)
-
-
-func test_deduce_island_too_large_invalid() -> void:
-	# the island is already too large; don't perform this deduction
-	grid = [
-		" 2 . .",
-		"      ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-		], NurikabeSolver.DeductionReason.ISLAND_TOO_LARGE)
-	assert_deduction(solver.deduce_island_too_large(init_model()), expected)
-
-
-func test_island_too_small_1() -> void:
-	grid = [
-		" 3    ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_ISLAND},
-			{"pos": Vector2i(2, 0), "value": NurikabeUtils.CELL_ISLAND},
-		], NurikabeSolver.DeductionReason.ISLAND_TOO_SMALL)
-	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
-
-
-func test_island_too_small_multiple() -> void:
-	grid = [
-		" 2    ",
-		"##    ",
-		"##   3",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_ISLAND},
-		], NurikabeSolver.DeductionReason.ISLAND_TOO_SMALL)
-	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
-
-
-func test_island_too_small_chokepoint() -> void:
-	grid = [
-		" 4    ",
-		"##  ##",
-		"      ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_ISLAND},
-			{"pos": Vector2i(1, 1), "value": NurikabeUtils.CELL_ISLAND},
-		], NurikabeSolver.DeductionReason.ISLAND_TOO_SMALL)
-	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
-
-
-func test_island_too_small_chokepoint_2() -> void:
-	grid = [
-		" 4  ##",
-		"##  ##",
-		"      ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_ISLAND},
-			{"pos": Vector2i(1, 1), "value": NurikabeUtils.CELL_ISLAND},
-			{"pos": Vector2i(1, 2), "value": NurikabeUtils.CELL_ISLAND},
-		], NurikabeSolver.DeductionReason.ISLAND_TOO_SMALL)
-	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
-
-
-func test_pools_1() -> void:
-	grid = [
-		" 4    ",
-		"    ##",
-		"  ####",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(1, 1), "value": NurikabeUtils.CELL_ISLAND},
-		], NurikabeSolver.DeductionReason.POOLS)
-	assert_deduction(solver.deduce_pools(init_model()), expected)
-
-
-func test_pools_cut_off() -> void:
-	grid = [
-		" 5    ",
-		"  ##  ",
-		"  ##  ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(0, 1), "value": NurikabeUtils.CELL_ISLAND},
-			{"pos": Vector2i(1, 0), "value": NurikabeUtils.CELL_ISLAND},
-			{"pos": Vector2i(2, 0), "value": NurikabeUtils.CELL_ISLAND},
-			{"pos": Vector2i(2, 1), "value": NurikabeUtils.CELL_ISLAND},
-		], NurikabeSolver.DeductionReason.POOLS)
-	assert_deduction(solver.deduce_pools(init_model()), expected)
-
-
-func test_no_split_walls_1() -> void:
-	grid = [
-		" 3##  ",
-		"     3",
-		"  ##  ",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(1, 1), "value": NurikabeUtils.CELL_WALL},
-		], NurikabeSolver.DeductionReason.SPLIT_WALLS)
-	assert_deduction(solver.deduce_split_walls(init_model()), expected)
-
-
-func test_no_split_walls_2() -> void:
-	grid = [
-		"## 4  ",
-		"      ",
-		"    ##",
-	]
-	var expected: NurikabeSolver.Deduction = NurikabeSolver.Deduction.new([
-			{"pos": Vector2i(0, 1), "value": NurikabeUtils.CELL_WALL},
-		], NurikabeSolver.DeductionReason.SPLIT_WALLS)
-	assert_deduction(solver.deduce_split_walls(init_model()), expected)
-
-
-func assert_deduction(actual: NurikabeSolver.Deduction, expected: NurikabeSolver.Deduction) -> void:
-	assert_eq(sorted_changes(actual.changes), sorted_changes(expected.changes))
-	assert_eq(actual.reason, expected.reason)
+func assert_deduction(actual: Array[NurikabeDeduction], expected: Array[NurikabeDeduction]) -> void:
+	var actual_str_array: Array[String] = deductions_to_strings(actual)
+	var expected_str_array: Array[String] = deductions_to_strings(expected)
+	assert_eq(actual_str_array, expected_str_array)
 
 
 func init_model() -> NurikabeBoardModel:
 	return NurikabeTestUtils.init_model(grid)
 
 
-func sorted_changes(changes: Array[Dictionary]) -> Array[Dictionary]:
-	var result: Array[Dictionary] = changes.duplicate()
-	result.sort_custom(func(a: Dictionary, b: Dictionary) -> bool: return a["pos"] < b["pos"])
+func deductions_to_strings(changes: Array[NurikabeDeduction]) -> Array[String]:
+	var result: Array[String] = []
+	var sorted_changes: Array[NurikabeDeduction] = changes.duplicate()
+	sorted_changes.sort_custom(func(a: NurikabeDeduction, b: NurikabeDeduction) -> bool: return a.pos < b.pos)
+	for change: NurikabeDeduction in sorted_changes:
+		result.append(str(change))
 	return result

--- a/project/src/test/nurikabe/test_nurikabe_solver.gd.uid
+++ b/project/src/test/nurikabe/test_nurikabe_solver.gd.uid
@@ -1,1 +1,1 @@
-uid://rshvi2lgfc2g
+uid://cxkhqc5tlbtbm

--- a/project/src/test/nurikabe/test_nurikabe_solver_rules.gd
+++ b/project/src/test/nurikabe/test_nurikabe_solver_rules.gd
@@ -1,0 +1,245 @@
+extends TestNurikabeSolver
+
+func test_deduce_joined_island_2() -> void:
+	grid = [
+		" 3   3",
+		"      ",
+		"      ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(1, 0), CELL_WALL, JOINED_ISLAND),
+	]
+	assert_deduction(solver.deduce_joined_island(init_model()), expected)
+
+
+func test_deduce_joined_island_3() -> void:
+	grid = [
+		" 1      ",
+		"   2   3",
+		"        ",
+		"        ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(1, 0), CELL_WALL, JOINED_ISLAND),
+		NurikabeDeduction.new(Vector2i(0, 1), CELL_WALL, JOINED_ISLAND),
+		NurikabeDeduction.new(Vector2i(2, 1), CELL_WALL, JOINED_ISLAND),
+	]
+	assert_deduction(solver.deduce_joined_island(init_model()), expected)
+
+
+func test_deduce_joined_island_mistake() -> void:
+	grid = [
+		" 2 . 2",
+		"      ",
+		"      ",
+		"      ",
+		" 2   2",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(1, 4), CELL_WALL, JOINED_ISLAND),
+	]
+	assert_deduction(solver.deduce_joined_island(init_model()), expected)
+
+
+func test_deduce_joined_island_none() -> void:
+	grid = [
+		" 2    ",
+		"     2",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		]
+	assert_deduction(solver.deduce_joined_island(init_model()), expected)
+
+
+func test_deduce_unclued_island_invalid() -> void:
+	# the grid already has an island with no clue; don't perform this deduction
+	grid = [
+		" .##  ",
+		"##   2",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		]
+	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
+
+
+func test_deduce_unclued_island_invalid_2() -> void:
+	# the grid already has an island with no clue; don't perform this deduction
+	grid = [
+		"## 3##",
+		"## .  ",
+		"      ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		]
+	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
+
+
+func test_deduce_unclued_island_1() -> void:
+	grid = [
+		" 2  ##",
+		"####  ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(2, 1), CELL_WALL, UNCLUED_ISLAND),
+	]
+	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
+
+
+func test_deduce_unclued_island_chokepoint() -> void:
+	grid = [
+		"  ##  ",
+		" 3   .",
+		"  ##  ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(1, 1), CELL_ISLAND, UNCLUED_ISLAND),
+	]
+	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
+
+
+func test_deduce_unclued_island_chokepoint_2() -> void:
+	grid = [
+		" 5    ",
+		"##    ",
+		" .    ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(1, 0), CELL_ISLAND, UNCLUED_ISLAND),
+		NurikabeDeduction.new(Vector2i(1, 2), CELL_ISLAND, UNCLUED_ISLAND),
+	]
+	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
+
+
+func test_deduce_island_too_large_1() -> void:
+	grid = [
+		" 2 .  ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(2, 0), CELL_WALL, ISLAND_TOO_LARGE),
+	]
+	assert_deduction(solver.deduce_island_too_large(init_model()), expected)
+
+
+func test_deduce_island_too_large_2() -> void:
+	grid = [
+		" 2 .  ",
+		"      ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(0, 1), CELL_WALL, ISLAND_TOO_LARGE),
+		NurikabeDeduction.new(Vector2i(1, 1), CELL_WALL, ISLAND_TOO_LARGE),
+		NurikabeDeduction.new(Vector2i(2, 0), CELL_WALL, ISLAND_TOO_LARGE),
+	]
+	assert_deduction(solver.deduce_island_too_large(init_model()), expected)
+
+
+func test_deduce_island_too_large_invalid() -> void:
+	# the island is already too large; don't perform this deduction
+	grid = [
+		" 2 . .",
+		"      ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+	]
+	assert_deduction(solver.deduce_island_too_large(init_model()), expected)
+
+
+func test_island_too_small_1() -> void:
+	grid = [
+		" 3    ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(1, 0), CELL_ISLAND, ISLAND_TOO_SMALL),
+		NurikabeDeduction.new(Vector2i(2, 0), CELL_ISLAND, ISLAND_TOO_SMALL),
+	]
+	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
+
+
+func test_island_too_small_multiple() -> void:
+	grid = [
+		" 2    ",
+		"##    ",
+		"##   3",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(1, 0), CELL_ISLAND, ISLAND_TOO_SMALL),
+	]
+	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
+
+
+func test_island_too_small_chokepoint() -> void:
+	grid = [
+		" 4    ",
+		"##  ##",
+		"      ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(1, 0), CELL_ISLAND, ISLAND_TOO_SMALL),
+		NurikabeDeduction.new(Vector2i(1, 1), CELL_ISLAND, ISLAND_TOO_SMALL),
+	]
+	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
+
+
+func test_island_too_small_chokepoint_2() -> void:
+	grid = [
+		" 4  ##",
+		"##  ##",
+		"      ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(1, 0), CELL_ISLAND, ISLAND_TOO_SMALL),
+		NurikabeDeduction.new(Vector2i(1, 1), CELL_ISLAND, ISLAND_TOO_SMALL),
+		NurikabeDeduction.new(Vector2i(1, 2), CELL_ISLAND, ISLAND_TOO_SMALL),
+	]
+	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
+
+
+func test_pools_1() -> void:
+	grid = [
+		" 4    ",
+		"    ##",
+		"  ####",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(1, 1), CELL_ISLAND, POOLS),
+	]
+	assert_deduction(solver.deduce_pools(init_model()), expected)
+
+
+func test_pools_cut_off() -> void:
+	grid = [
+		" 5    ",
+		"  ##  ",
+		"  ##  ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(0, 1), CELL_ISLAND, POOLS),
+		NurikabeDeduction.new(Vector2i(1, 0), CELL_ISLAND, POOLS),
+		NurikabeDeduction.new(Vector2i(2, 0), CELL_ISLAND, POOLS),
+		NurikabeDeduction.new(Vector2i(2, 1), CELL_ISLAND, POOLS),
+	]
+	assert_deduction(solver.deduce_pools(init_model()), expected)
+
+
+func test_no_split_walls_1() -> void:
+	grid = [
+		" 3##  ",
+		"     3",
+		"  ##  ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(1, 1), CELL_WALL, SPLIT_WALLS),
+	]
+	assert_deduction(solver.deduce_split_walls(init_model()), expected)
+
+
+func test_no_split_walls_2() -> void:
+	grid = [
+		"## 4  ",
+		"      ",
+		"    ##",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(0, 1), CELL_WALL, SPLIT_WALLS),
+	]
+	assert_deduction(solver.deduce_split_walls(init_model()), expected)

--- a/project/src/test/nurikabe/test_nurikabe_solver_rules.gd.uid
+++ b/project/src/test/nurikabe/test_nurikabe_solver_rules.gd.uid
@@ -1,0 +1,1 @@
+uid://rshvi2lgfc2g


### PR DESCRIPTION
NurikabeSolver now returns an array of deductions which each have a separate reason. This allows, for example, to run a single check for adjacent clues, but then to return different reasons based on whether those clues are adjacent or diagonal.

We already have several compound deductions. For example, the unclued island check fills in empty islands without any clues, but also checks whether making an empty cell a wall creates a new unclued island. Conceptis Puzzles's solving techniques separate these into two techniques, called 'island continuity' and 'surrounded square'. Adding support for these techniques is much easier if we allow for methods to return lists of deductions with different reasons.

Extracted 'TestNurikabeSolver' test framework, so that we can split our tests up by type (rules, basic deductions, starting deductions, etc)