### PR TITLE
Improved hidden island logic. ISLAND_MOAT rule.

### DIFF
--- a/project/src/main/nurikabe/nurikabe_board_model.gd
+++ b/project/src/main/nurikabe/nurikabe_board_model.gd
@@ -113,6 +113,11 @@ func get_clue_cells(group: Array[Vector2i]) -> Array[Vector2i]:
 	return clue_cells
 
 
+func get_clue_value(group: Array[Vector2i]) -> int:
+	var clue_cells: Array[Vector2i] = get_clue_cells(group)
+	return get_cell_string(clue_cells[0]).to_int() if clue_cells.size() == 1 else 0
+
+
 func get_pool_cells() -> Array[Vector2i]:
 	var pool_cells: Dictionary[Vector2i, bool] = {}
 	for next_cell: Vector2i in cells:

--- a/project/src/main/nurikabe/nurikabe_utils.gd
+++ b/project/src/main/nurikabe/nurikabe_utils.gd
@@ -24,6 +24,7 @@ enum Reason {
 	ISLAND_EXPANSION, # island with only one direction to expand
 	CORNER_ISLAND, # island with only two directions to expand
 	HIDDEN_ISLAND_EXPANSION, # island which can only expand through a chokepoint
+	ISLAND_MOAT, # wall which preserves space for an island to grow
 }
 
 ## Nurikabe cells:
@@ -59,6 +60,7 @@ const WALL_CONTINUITY: Reason = Reason.WALL_CONTINUITY
 const ISLAND_EXPANSION: Reason = Reason.ISLAND_EXPANSION
 const CORNER_ISLAND: Reason = Reason.CORNER_ISLAND
 const HIDDEN_ISLAND_EXPANSION: Reason = Reason.HIDDEN_ISLAND_EXPANSION
+const ISLAND_MOAT: NurikabeUtils.Reason = Reason.ISLAND_MOAT
 
 const ERROR_FG_COLOR: Color = Color.WHITE
 const ERROR_BG_COLOR: Color = Color("ff5a5a")

--- a/project/src/test/nurikabe/test_nurikabe_solver.gd
+++ b/project/src/test/nurikabe/test_nurikabe_solver.gd
@@ -29,6 +29,7 @@ const WALL_CONTINUITY: NurikabeUtils.Reason = NurikabeUtils.WALL_CONTINUITY
 const ISLAND_EXPANSION: NurikabeUtils.Reason = NurikabeUtils.ISLAND_EXPANSION
 const CORNER_ISLAND: NurikabeUtils.Reason = NurikabeUtils.CORNER_ISLAND
 const HIDDEN_ISLAND_EXPANSION: NurikabeUtils.Reason = NurikabeUtils.HIDDEN_ISLAND_EXPANSION
+const ISLAND_MOAT: NurikabeUtils.Reason = NurikabeUtils.ISLAND_MOAT
 
 var solver: NurikabeSolver = NurikabeSolver.new()
 var grid: Array[String] = []

--- a/project/src/test/nurikabe/test_nurikabe_solver_rules.gd
+++ b/project/src/test/nurikabe/test_nurikabe_solver_rules.gd
@@ -1,5 +1,90 @@
 extends TestNurikabeSolver
 
+func test_uncompletable_islands_good() -> void:
+	grid = [
+		" 3   3",
+		"      ",
+		"      ",
+	]
+	var board: NurikabeBoardModel = init_model()
+	assert_eq(solver.get_uncompletable_island_count(board), 0)
+
+
+func test_uncompletable_islands_walled_in_1() -> void:
+	grid = [
+		" 3## 3",
+		"##    ",
+		"      ",
+	]
+	var board: NurikabeBoardModel = init_model()
+	assert_eq(solver.get_uncompletable_island_count(board), 1)
+
+
+func test_uncompletable_islands_walled_in_2() -> void:
+	grid = [
+		" 3## 3",
+		"  ##  ",
+		"####  ",
+	]
+	var board: NurikabeBoardModel = init_model()
+	assert_eq(solver.get_uncompletable_island_count(board), 1)
+
+
+func test_uncompletable_islands_walled_in_3() -> void:
+	grid = [
+		" 3## 3",
+		" .## .",
+		"#### .",
+	]
+	var board: NurikabeBoardModel = init_model()
+	assert_eq(solver.get_uncompletable_island_count(board), 1)
+
+
+func test_uncompletable_islands_too_close_1() -> void:
+	grid = [
+		" 3## 2",
+		" . .  ",
+		"      ",
+	]
+	var board: NurikabeBoardModel = init_model()
+	assert_eq(solver.get_uncompletable_island_count(board), 1)
+
+
+func test_uncompletable_islands_too_close_2() -> void:
+	grid = [
+		"#### 3",
+		" 3##  ",
+		" . .  ",
+		"      ",
+	]
+	var board: NurikabeBoardModel = init_model()
+	assert_eq(solver.get_uncompletable_island_count(board), 1)
+
+
+func test_uncompletable_islands_too_close_3() -> void:
+	grid = [
+		"#### 2",
+		" . .  ",
+		"      ",
+		" 4    ",
+	]
+	var board: NurikabeBoardModel = init_model()
+	assert_eq(solver.get_uncompletable_island_count(board), 1)
+
+
+func test_uncompletable_islands_too_close_4() -> void:
+	grid = [
+		" 1## . .",
+		"####   5",
+		"## . .  ",
+		"        ",
+		"        ",
+		" 5      ",
+	]
+	var board: NurikabeBoardModel = init_model()
+	assert_eq(solver.get_uncompletable_island_count(board), 1)
+
+
 func test_deduce_joined_island_2() -> void:
 	grid = [
 		" 3   3",
@@ -171,12 +256,14 @@ func test_island_too_small_1() -> void:
 
 func test_island_too_small_multiple() -> void:
 	grid = [
-		" 2    ",
-		"##    ",
-		"##   3",
+		" 2      ",
+		"##      ",
+		"##     4",
 	]
 	var expected: Array[NurikabeDeduction] = [
 		NurikabeDeduction.new(Vector2i(1, 0), CELL_ISLAND, ISLAND_EXPANSION),
+		NurikabeDeduction.new(Vector2i(1, 1), CELL_WALL, ISLAND_MOAT),
+		NurikabeDeduction.new(Vector2i(2, 0), CELL_WALL, ISLAND_MOAT),
 	]
 	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
 
@@ -219,7 +306,8 @@ func test_island_too_small_hidden_island_expansion_1() -> void:
 		"        ",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(2, 2), CELL_WALL, HIDDEN_ISLAND_EXPANSION),
+		NurikabeDeduction.new(Vector2i(2, 2), CELL_WALL, ISLAND_MOAT),
+		NurikabeDeduction.new(Vector2i(3, 2), CELL_ISLAND, ISLAND_EXPANSION),
 	]
 	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
 
@@ -235,7 +323,25 @@ func test_island_too_small_hidden_island_expansion_2() -> void:
 		" 5      ",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(2, 2), CELL_WALL, HIDDEN_ISLAND_EXPANSION),
+		NurikabeDeduction.new(Vector2i(2, 2), CELL_WALL, ISLAND_MOAT)
+	]
+	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
+
+
+func test_island_too_small_hidden_island_expansion_3() -> void:
+	# The cell at (2, 2) can't be an island or it would block the top 5 island from growing.
+	grid = [
+		" 1##   5",
+		"####    ",
+		"## 3    ",
+		"        ",
+		"        ",
+		"        ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(2, 2), CELL_WALL, ISLAND_MOAT),
+		NurikabeDeduction.new(Vector2i(3, 1), CELL_ISLAND, ISLAND_EXPANSION),
+		NurikabeDeduction.new(Vector2i(3, 2), CELL_ISLAND, HIDDEN_ISLAND_EXPANSION),
 	]
 	assert_deduction(solver.deduce_island_too_small(init_model()), expected)
 
@@ -256,11 +362,11 @@ func test_island_too_small_invalid() -> void:
 func test_island_too_small_only_two_directions() -> void:
 	# The cell at (2, 3) can't be an island or it would block the 2 island from growing.
 	grid = [
-		" . . .  ",
-		" 7##    ",
-		"## 2    ",
-		"        ",
-		"       1",
+		" . . .    ",
+		" 7##      ",
+		"## 2      ",
+		"          ",
+		"       1  ",
 	]
 	var expected: Array[NurikabeDeduction] = [
 		NurikabeDeduction.new(Vector2i(2, 3), CELL_WALL, CORNER_ISLAND),


### PR DESCRIPTION
Before, the 'hidden island' logic would expand an island once, and see if that blocked in any islands. This had a shortcoming where it only saw 'one space into the future' and would not predict if an island with a large clue would eventually be blocked.

The new 'hidden island' logic is simpler, and relies on a new 'uncompletable island' algorithm which flood fills each clue, avoiding other clues. This also organically brought about a new 'island_moat' rule to cover the unusual cases where cells have to be walls to avoid blocking an island.