### PR TITLE
Split wall enhancement: corner walls.

### DIFF
--- a/project/src/main/nurikabe/nurikabe_solver.gd
+++ b/project/src/main/nurikabe/nurikabe_solver.gd
@@ -229,9 +229,12 @@ func deduce_pools(board: NurikabeBoardModel) -> Array[NurikabeDeduction]:
 
 
 func deduce_split_walls(board: NurikabeBoardModel) -> Array[NurikabeDeduction]:
+	var deduction_cells: Dictionary[Vector2i, bool] = {}
 	var deductions: Array[NurikabeDeduction] = []
 	var wall_count: int = _largest_non_empty_wall_groups(board).size()
 	for cell: Vector2i in board.cells:
+		if cell in deduction_cells:
+			continue
 		if board.get_cell_string(cell) != CELL_EMPTY:
 			continue
 		
@@ -244,7 +247,22 @@ func deduce_split_walls(board: NurikabeBoardModel) -> Array[NurikabeDeduction]:
 			var reason: NurikabeUtils.Reason = WALL_CONTINUITY
 			if wall_mask in [0, 1, 2, 4, 8]:
 				reason = WALL_EXPANSION
+			deduction_cells[cell] = true
 			deductions.append(NurikabeDeduction.new(cell, CELL_WALL, reason))
+	
+	for cell: Vector2i in board.cells:
+		if cell in deduction_cells:
+			continue
+		if board.get_cell_string(cell) != CELL_EMPTY:
+			continue
+		
+		var trial: NurikabeBoardModel = board.duplicate()
+		trial.set_cell_string(cell, CELL_WALL)
+		var trial_wall_count: int = _largest_non_empty_wall_groups(trial).size()
+		if trial_wall_count > wall_count:
+			deduction_cells[cell] = true
+			deductions.append(NurikabeDeduction.new(cell, CELL_ISLAND, SPLIT_WALLS))
+	
 	return deductions
 
 

--- a/project/src/test/nurikabe/test_nurikabe_solver_rules.gd
+++ b/project/src/test/nurikabe/test_nurikabe_solver_rules.gd
@@ -423,3 +423,15 @@ func test_no_split_walls_2() -> void:
 		NurikabeDeduction.new(Vector2i(0, 1), CELL_WALL, WALL_EXPANSION),
 	]
 	assert_deduction(solver.deduce_split_walls(init_model()), expected)
+
+
+func test_no_split_walls_3() -> void:
+	grid = [
+		"      ",
+		"##   .",
+		"## 4  ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(2, 2), CELL_ISLAND, SPLIT_WALLS),
+	]
+	assert_deduction(solver.deduce_split_walls(init_model()), expected)


### PR DESCRIPTION
Now checks for corners walled in by islands, which must also be islands to avoid a split wall scenario. This is not mentioned on the conceptis puzzles page, we may need to name it.