### PR TITLE
Final basic techniques: surrounded_wall, surrounded_island

### DIFF
--- a/project/src/main/nurikabe/nurikabe_utils.gd
+++ b/project/src/main/nurikabe/nurikabe_utils.gd
@@ -18,14 +18,19 @@ enum Reason {
 	SPLIT_WALLS, # wall cells cannot be joined
 	
 	# basic techniques
-	SURROUNDED_SQUARE, # empty square surrounded by walls
+	SURROUNDED_WALL, # empty square surrounded by walls
+	SURROUNDED_ISLAND, # empty square surrounded by islands
 	WALL_EXPANSION, # wall with only one direction to expand
 	WALL_CONTINUITY, # two walls disconnected by a chokepoint
 	ISLAND_EXPANSION, # island with only one direction to expand
 	CORNER_ISLAND, # island with only two directions to expand
 	HIDDEN_ISLAND_EXPANSION, # island which can only expand through a chokepoint
 	ISLAND_MOAT, # wall which preserves space for an island to grow
+	ISLAND_CONTINUITY, # clueless island which must find a clued island
+	SURROUND_COMPLETE_ISLAND, # surround complete islands with walls
+	AVOID_POOLS, # avoid creating a 2x2 grid of wall cells
 	UNREACHABLE_SQUARE, # empty square which no clue can 'reach'
+	SEPARATE_CLUED_ISLANDS, # wall between two clued islands
 }
 
 ## Nurikabe cells:
@@ -55,14 +60,19 @@ const POOLS: Reason = Reason.POOLS
 const SPLIT_WALLS: Reason = Reason.SPLIT_WALLS
 
 ## Basic techniques
-const SURROUNDED_SQUARE: Reason = Reason.SURROUNDED_SQUARE
+const SURROUNDED_WALL: Reason = Reason.SURROUNDED_WALL
+const SURROUNDED_ISLAND: Reason = Reason.SURROUNDED_ISLAND
 const WALL_EXPANSION: Reason = Reason.WALL_EXPANSION
 const WALL_CONTINUITY: Reason = Reason.WALL_CONTINUITY
 const ISLAND_EXPANSION: Reason = Reason.ISLAND_EXPANSION
 const CORNER_ISLAND: Reason = Reason.CORNER_ISLAND
 const HIDDEN_ISLAND_EXPANSION: Reason = Reason.HIDDEN_ISLAND_EXPANSION
 const ISLAND_MOAT: NurikabeUtils.Reason = Reason.ISLAND_MOAT
+const ISLAND_CONTINUITY: Reason = Reason.ISLAND_CONTINUITY
+const SURROUND_COMPLETE_ISLAND: Reason = Reason.SURROUND_COMPLETE_ISLAND
+const AVOID_POOLS: Reason = Reason.AVOID_POOLS
 const UNREACHABLE_SQUARE: Reason = Reason.UNREACHABLE_SQUARE
+const SEPARATE_CLUED_ISLANDS: Reason = Reason.SEPARATE_CLUED_ISLANDS
 
 const ERROR_FG_COLOR: Color = Color.WHITE
 const ERROR_BG_COLOR: Color = Color("ff5a5a")

--- a/project/src/test/nurikabe/test_nurikabe_solver.gd
+++ b/project/src/test/nurikabe/test_nurikabe_solver.gd
@@ -23,14 +23,19 @@ const POOLS: NurikabeUtils.Reason = NurikabeUtils.POOLS
 const SPLIT_WALLS: NurikabeUtils.Reason = NurikabeUtils.SPLIT_WALLS
 
 ## Basic techniques
-const SURROUNDED_SQUARE: NurikabeUtils.Reason = NurikabeUtils.SURROUNDED_SQUARE
+const SURROUNDED_WALL: NurikabeUtils.Reason = NurikabeUtils.SURROUNDED_WALL
+const SURROUNDED_ISLAND: NurikabeUtils.Reason = NurikabeUtils.SURROUNDED_ISLAND
 const WALL_EXPANSION: NurikabeUtils.Reason = NurikabeUtils.WALL_EXPANSION
 const WALL_CONTINUITY: NurikabeUtils.Reason = NurikabeUtils.WALL_CONTINUITY
 const ISLAND_EXPANSION: NurikabeUtils.Reason = NurikabeUtils.ISLAND_EXPANSION
 const CORNER_ISLAND: NurikabeUtils.Reason = NurikabeUtils.CORNER_ISLAND
 const HIDDEN_ISLAND_EXPANSION: NurikabeUtils.Reason = NurikabeUtils.HIDDEN_ISLAND_EXPANSION
 const ISLAND_MOAT: NurikabeUtils.Reason = NurikabeUtils.ISLAND_MOAT
+const ISLAND_CONTINUITY: NurikabeUtils.Reason = NurikabeUtils.ISLAND_CONTINUITY
+const SURROUND_COMPLETE_ISLAND: NurikabeUtils.Reason = NurikabeUtils.SURROUND_COMPLETE_ISLAND
+const AVOID_POOLS: NurikabeUtils.Reason = NurikabeUtils.AVOID_POOLS
 const UNREACHABLE_SQUARE: NurikabeUtils.Reason = NurikabeUtils.UNREACHABLE_SQUARE
+const SEPARATE_CLUED_ISLANDS: NurikabeUtils.Reason = NurikabeUtils.SEPARATE_CLUED_ISLANDS
 
 var solver: NurikabeSolver = NurikabeSolver.new()
 var grid: Array[String] = []

--- a/project/src/test/nurikabe/test_nurikabe_solver_rules.gd
+++ b/project/src/test/nurikabe/test_nurikabe_solver_rules.gd
@@ -92,7 +92,7 @@ func test_deduce_joined_island_2() -> void:
 		"      ",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(1, 0), CELL_WALL, JOINED_ISLAND),
+		NurikabeDeduction.new(Vector2i(1, 0), CELL_WALL, SEPARATE_CLUED_ISLANDS),
 	]
 	assert_deduction(solver.deduce_joined_island(init_model()), expected)
 
@@ -105,9 +105,9 @@ func test_deduce_joined_island_3() -> void:
 		"        ",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(1, 0), CELL_WALL, JOINED_ISLAND),
-		NurikabeDeduction.new(Vector2i(0, 1), CELL_WALL, JOINED_ISLAND),
-		NurikabeDeduction.new(Vector2i(2, 1), CELL_WALL, JOINED_ISLAND),
+		NurikabeDeduction.new(Vector2i(1, 0), CELL_WALL, SEPARATE_CLUED_ISLANDS),
+		NurikabeDeduction.new(Vector2i(0, 1), CELL_WALL, SEPARATE_CLUED_ISLANDS),
+		NurikabeDeduction.new(Vector2i(2, 1), CELL_WALL, SEPARATE_CLUED_ISLANDS),
 	]
 	assert_deduction(solver.deduce_joined_island(init_model()), expected)
 
@@ -121,7 +121,7 @@ func test_deduce_joined_island_mistake() -> void:
 		" 2   2",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(1, 4), CELL_WALL, JOINED_ISLAND),
+		NurikabeDeduction.new(Vector2i(1, 4), CELL_WALL, SEPARATE_CLUED_ISLANDS),
 	]
 	assert_deduction(solver.deduce_joined_island(init_model()), expected)
 
@@ -178,8 +178,8 @@ func test_unclued_island_surrounded_square() -> void:
 		"  ##  ## 5  ",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(0, 3), CELL_WALL, SURROUNDED_SQUARE),
-		NurikabeDeduction.new(Vector2i(2, 3), CELL_WALL, SURROUNDED_SQUARE),
+		NurikabeDeduction.new(Vector2i(0, 3), CELL_WALL, SURROUNDED_WALL),
+		NurikabeDeduction.new(Vector2i(2, 3), CELL_WALL, SURROUNDED_WALL),
 	]
 	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
 
@@ -191,7 +191,7 @@ func test_deduce_unclued_island_chokepoint() -> void:
 		"  ##  ",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(1, 1), CELL_ISLAND, UNCLUED_ISLAND),
+		NurikabeDeduction.new(Vector2i(1, 1), CELL_ISLAND, ISLAND_CONTINUITY),
 	]
 	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
 
@@ -203,8 +203,8 @@ func test_deduce_unclued_island_chokepoint_2() -> void:
 		" .    ",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(1, 0), CELL_ISLAND, UNCLUED_ISLAND),
-		NurikabeDeduction.new(Vector2i(1, 2), CELL_ISLAND, UNCLUED_ISLAND),
+		NurikabeDeduction.new(Vector2i(1, 0), CELL_ISLAND, ISLAND_CONTINUITY),
+		NurikabeDeduction.new(Vector2i(1, 2), CELL_ISLAND, ISLAND_CONTINUITY),
 	]
 	assert_deduction(solver.deduce_unclued_island(init_model()), expected)
 
@@ -214,7 +214,7 @@ func test_deduce_island_too_large_1() -> void:
 		" 2 .  ",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(2, 0), CELL_WALL, ISLAND_TOO_LARGE),
+		NurikabeDeduction.new(Vector2i(2, 0), CELL_WALL, SURROUND_COMPLETE_ISLAND),
 	]
 	assert_deduction(solver.deduce_island_too_large(init_model()), expected)
 
@@ -225,9 +225,9 @@ func test_deduce_island_too_large_2() -> void:
 		"      ",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(0, 1), CELL_WALL, ISLAND_TOO_LARGE),
-		NurikabeDeduction.new(Vector2i(1, 1), CELL_WALL, ISLAND_TOO_LARGE),
-		NurikabeDeduction.new(Vector2i(2, 0), CELL_WALL, ISLAND_TOO_LARGE),
+		NurikabeDeduction.new(Vector2i(0, 1), CELL_WALL, SURROUND_COMPLETE_ISLAND),
+		NurikabeDeduction.new(Vector2i(1, 1), CELL_WALL, SURROUND_COMPLETE_ISLAND),
+		NurikabeDeduction.new(Vector2i(2, 0), CELL_WALL, SURROUND_COMPLETE_ISLAND),
 	]
 	assert_deduction(solver.deduce_island_too_large(init_model()), expected)
 
@@ -381,7 +381,7 @@ func test_pools_1() -> void:
 		"  ####",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(1, 1), CELL_ISLAND, POOLS),
+		NurikabeDeduction.new(Vector2i(1, 1), CELL_ISLAND, AVOID_POOLS),
 	]
 	assert_deduction(solver.deduce_pools(init_model()), expected)
 
@@ -393,10 +393,10 @@ func test_pools_cut_off() -> void:
 		"  ##  ",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(0, 1), CELL_ISLAND, POOLS),
-		NurikabeDeduction.new(Vector2i(1, 0), CELL_ISLAND, POOLS),
-		NurikabeDeduction.new(Vector2i(2, 0), CELL_ISLAND, POOLS),
-		NurikabeDeduction.new(Vector2i(2, 1), CELL_ISLAND, POOLS),
+		NurikabeDeduction.new(Vector2i(0, 1), CELL_ISLAND, AVOID_POOLS),
+		NurikabeDeduction.new(Vector2i(1, 0), CELL_ISLAND, AVOID_POOLS),
+		NurikabeDeduction.new(Vector2i(2, 0), CELL_ISLAND, AVOID_POOLS),
+		NurikabeDeduction.new(Vector2i(2, 1), CELL_ISLAND, AVOID_POOLS),
 	]
 	assert_deduction(solver.deduce_pools(init_model()), expected)
 
@@ -432,7 +432,7 @@ func test_no_split_walls_3() -> void:
 		"## 4  ",
 	]
 	var expected: Array[NurikabeDeduction] = [
-		NurikabeDeduction.new(Vector2i(2, 2), CELL_ISLAND, SPLIT_WALLS),
+		NurikabeDeduction.new(Vector2i(2, 2), CELL_ISLAND, SURROUNDED_ISLAND),
 	]
 	assert_deduction(solver.deduce_split_walls(init_model()), expected)
 


### PR DESCRIPTION
All NurikabeSolver steps are now attributed to a basic technique, not a rule. This will make it easier for tutorials or when guiding the player. It is better to say "You can surround this island with walls" rather than "If the square at 2x2 were an island, the island would be too big." The former is more like something a person would say, the latter is more like something a computer would say.

Simplified deduce_split_walls logic; the old logic tried making something a wall to see if it resulted in a split wall. But the inverse of the 'unclued_island' logic is simpler and faster.

Changed SURROUNDED_SQUARE to SURROUNDED_WALL/SURROUNDED_ISLAND. There was no word for the old SURROUNDED_ISLAND logic.

Added ISLAND_CONTINUITY, SURROUND_COMPLETE_ISLAND, AVOID_POOLS, SEPARATE_CLUED_ISLANDS logic. These steps were already done, but they were done with the rule names instead of a basic technique name.