### PR TITLE
Added unclued island divider logic.

### DIFF
--- a/project/src/main/nurikabe/nurikabe_solver.gd
+++ b/project/src/main/nurikabe/nurikabe_solver.gd
@@ -105,6 +105,21 @@ func deduce_island_divider(board: NurikabeBoardModel) -> void:
 			continue
 		if clued_neighbor_count_by_cell[cell] >= 2:
 			solver_pass.add_deduction(cell, CELL_WALL, ISLAND_DIVIDER)
+	
+	var smallest_island_groups: Array[Array] = board.find_smallest_island_groups()
+	var neighbor_groups_by_empty_cell: Dictionary[Vector2i, Array] \
+			= _neighbor_groups_by_empty_cell(board, smallest_island_groups)
+	for group: Array[Vector2i] in smallest_island_groups:
+		# If the island is 1 less than its desired size, find its liberties
+		if board.get_clue_value(group) != group.size() + 1:
+			continue
+		var liberty_cells: Array[Vector2i] = _find_liberties(board, group)
+		for liberty_cell: Vector2i in liberty_cells:
+			if not _can_deduce(board, liberty_cell):
+				continue
+			var neighbor_groups: Array[Array] = neighbor_groups_by_empty_cell.get(liberty_cell, [] as Array[Array])
+			if neighbor_groups.size() >= 2:
+				solver_pass.add_deduction(liberty_cell, CELL_WALL, ISLAND_DIVIDER)
 
 
 ## Find empty areas surrounded by walls. These areas must be walls.

--- a/project/src/main/nurikabe/nurikabe_utils.gd
+++ b/project/src/main/nurikabe/nurikabe_utils.gd
@@ -23,7 +23,7 @@ enum Reason {
 	ISLAND_BUFFER, # add a wall to preserve space for an island to grow
 	ISLAND_CHOKEPOINT, # expand an island through a chokepoint
 	ISLAND_CONNECTOR, # connect a clueless island to a clued island
-	ISLAND_DIVIDER, # fill in a square to keep two clued islands apart
+	ISLAND_DIVIDER, # fill in a square to keep two islands apart
 	ISLAND_EXPANSION, # expand an island in the only possible direction
 	ISLAND_MOAT, # seal a completed island with walls
 	POOL_TRIPLET, # fill in the fourth cell to prevent a 2x2 grid of wall cells

--- a/project/src/test/nurikabe/test_nurikabe_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/test_nurikabe_solver_basic_techniques.gd
@@ -112,6 +112,21 @@ func test_island_divider_3() -> void:
 	assert_deduction(solver.deduce_island_divider, expected)
 
 
+func test_island_divider_unclued() -> void:
+	grid = [
+		"            ",
+		"   2        ",
+		"     .      ",
+		"         9  ",
+		"            ",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(1, 2), CELL_WALL, ISLAND_DIVIDER),
+		NurikabeDeduction.new(Vector2i(2, 1), CELL_WALL, ISLAND_DIVIDER),
+	]
+	assert_deduction(solver.deduce_island_divider, expected)
+
+
 func test_island_divider_mistake() -> void:
 	grid = [
 		" 2 . 2",


### PR DESCRIPTION
The old 'island divider' logic didn't cover the case where a 2 should stay divided from a nearby unclued island.