### PR TITLE
Added 'deduce_island_buffer_advanced' rule.

### DIFF
--- a/project/src/test/nurikabe/test_nurikabe_solver_advanced_rules.gd
+++ b/project/src/test/nurikabe/test_nurikabe_solver_advanced_rules.gd
@@ -60,3 +60,21 @@ func test_wall_strangle() -> void:
 		NurikabeDeduction.new(Vector2i(3, 1), CELL_WALL, WALL_STRANGLE),
 	]
 	assert_deduction(solver.deduce_wall_strangle, expected)
+
+
+func test_island_buffer_advanced() -> void:
+	grid = [
+		" 8## 3 . .## 2",
+		" .########## .",
+		" .## 3 . .####",
+		" . .###### 1##",
+		"## . .    ##  ",
+		" 2##  ##   3  ",
+		" .##   4  ####",
+		"##      ## 1##",
+	]
+	var expected: Array[NurikabeDeduction] = [
+		NurikabeDeduction.new(Vector2i(2, 5), CELL_WALL, ISLAND_BUFFER),
+		NurikabeDeduction.new(Vector2i(4, 6), CELL_WALL, ISLAND_BUFFER),
+	]
+	assert_deduction(solver.deduce_island_buffer_advanced, expected)


### PR DESCRIPTION
This is distinct from 'deduce_island_buffer' and could be a separate rule, but a human being looking at the two scenarios would struggle to understand the difference. In both cases, a cell can't be an island because it would cause a conflict for a neighboring island.