### PR TITLE
Improved task queue. Triggered tasks.

### DIFF
--- a/project/src/demo/nurikabe/fast/demo_fast_solver.gd
+++ b/project/src/demo/nurikabe/fast/demo_fast_solver.gd
@@ -40,6 +40,7 @@ func _ready() -> void:
 func print_grid_string() -> void:
 	%GameBoard.to_model().print_cells()
 
+
 func solve() -> void:
 	var changes: Array[Dictionary] = []
 	

--- a/project/src/main/nurikabe/fast/fast_board.gd
+++ b/project/src/main/nurikabe/fast/fast_board.gd
@@ -1,5 +1,7 @@
 class_name FastBoard
 
+const POS_NOT_FOUND: Vector2i = NurikabeUtils.POS_NOT_FOUND
+
 const CELL_EMPTY: String = NurikabeUtils.CELL_EMPTY
 const CELL_INVALID: String = NurikabeUtils.CELL_INVALID
 const CELL_ISLAND: String = NurikabeUtils.CELL_ISLAND
@@ -64,8 +66,16 @@ func get_islands_by_cell() -> Dictionary[Vector2i, Array]:
 	return get_island_group_map().groups_by_cell
 
 
+func get_island_for_cell(cell: Vector2i) -> Array[Vector2i]:
+	return get_islands_by_cell().get(cell, [] as Array[Vector2i])
+
+
 func get_island_roots_by_cell() -> Dictionary[Vector2i, Vector2i]:
 	return get_island_group_map().roots_by_cell
+
+
+func get_island_root_for_cell(cell: Vector2i) -> Vector2i:
+	return get_island_roots_by_cell().get(cell, POS_NOT_FOUND)
 
 
 func get_island_group_map() -> FastGroupMap:
@@ -83,8 +93,16 @@ func get_walls_by_cell() -> Dictionary[Vector2i, Array]:
 	return get_wall_group_map().groups_by_cell
 
 
+func get_wall_for_cell(cell: Vector2i) -> Array[Vector2i]:
+	return get_walls_by_cell().get(cell, [] as Array[Vector2i])
+
+
 func get_wall_roots_by_cell() -> Dictionary[Vector2i, Vector2i]:
 	return get_wall_group_map().roots_by_cell
+
+
+func get_wall_root_for_cell(cell: Vector2i) -> Vector2i:
+	return get_wall_roots_by_cell().get(cell, POS_NOT_FOUND)
 
 
 func get_wall_group_map() -> FastGroupMap:

--- a/project/src/main/nurikabe/fast/fast_solver.gd
+++ b/project/src/main/nurikabe/fast/fast_solver.gd
@@ -5,21 +5,35 @@ const CELL_INVALID: String = NurikabeUtils.CELL_INVALID
 const CELL_ISLAND: String = NurikabeUtils.CELL_ISLAND
 const CELL_WALL: String = NurikabeUtils.CELL_WALL
 
+const POS_NOT_FOUND: Vector2i = Vector2i(-1, -1)
+
 var deductions: DeductionBatch = DeductionBatch.new()
 var board: FastBoard
 
+var _change_history: Array[Dictionary] = []
 var _task_history: Dictionary[String, Dictionary] = {
 }
-var _task_queue: Array[Callable] = [
+var _task_queue: Array[Dictionary] = [
 ]
 
 func apply_changes() -> void:
-	board.set_cell_strings(deductions.get_changes())
+	var changes: Array[Dictionary] = deductions.get_changes()
+	for change: Dictionary[String, Variant] in changes:
+		var history_item: Dictionary[String, Variant] = {}
+		history_item["pos"] = change["pos"]
+		history_item["value"] = change["value"]
+		history_item["tick"] = board.get_filled_cell_count()
+	
+	_change_history.append_array(changes)
+	board.set_cell_strings(changes)
 	deductions.clear()
+	
+	_react_to_changes(changes)
 
 
 func clear() -> void:
 	deductions.clear()
+	_change_history.clear()
 	_task_history.clear()
 	_task_queue.clear()
 
@@ -33,24 +47,55 @@ func get_changes() -> Array[Dictionary]:
 
 
 func schedule_tasks() -> void:
-	if _task_queue.is_empty() and not _task_history.has("enqueue_islands_of_one"):
-		schedule_task(enqueue_islands_of_one.bind())
+	if get_last_run(enqueue_islands_of_one) == -1:
+		schedule_task(enqueue_islands_of_one, 1000)
 	
-	if _task_queue.is_empty() and not _task_history.has("enqueue_adjacent_clues"):
-		schedule_task(enqueue_adjacent_clues.bind())
+	if get_last_run(enqueue_adjacent_clues) == -1:
+		schedule_task(enqueue_adjacent_clues, 1000)
 	
-	if _task_queue.is_empty() and not _task_history.has("enqueue_clued_islands"):
-		schedule_task(enqueue_clued_islands.bind())
+	if get_last_run(enqueue_clued_islands) == -1:
+		schedule_task(enqueue_clued_islands, 150)
 	
-	if _task_queue.is_empty() and not _task_history.has("enqueue_wall_expansions"):
-		schedule_task(enqueue_wall_expansions.bind())
+	if get_last_run(enqueue_wall_expansions) == -1:
+		schedule_task(enqueue_wall_expansions, 145)
 	
-	if _task_queue.is_empty() and not _task_history.has("enqueue_island_dividers"):
-		schedule_task(enqueue_island_dividers.bind())
+	if get_last_run(enqueue_island_dividers) == -1:
+		schedule_task(enqueue_island_dividers, 140)
 
 
-func schedule_task(callable: Callable) -> void:
-	_task_queue.append(callable)
+func get_last_run(callable: Callable) -> int:
+	var task_key: String = _task_key(callable)
+	var history_item: Dictionary[String, Variant] = _task_history.get(task_key, {} as Dictionary[String, Variant])
+	return -1 if history_item.is_empty() else history_item["last_run"]
+
+
+func has_scheduled_task(callable: Callable) -> bool:
+	return not get_scheduled_task(callable).is_empty()
+
+
+func get_scheduled_task(callable: Callable) -> Dictionary[String, Variant]:
+	var key: String = _task_key(callable)
+	var result: Dictionary[String, Variant]
+	for task: Dictionary[String, Variant] in _task_queue:
+		if task["key"] == key:
+			result = task
+			break
+	return result
+
+
+func schedule_task(callable: Callable, priority: int) -> void:
+	var scheduled_task: Dictionary[String, Variant] = get_scheduled_task(callable)
+	var tasks_dirty: bool = false
+	if scheduled_task.is_empty():
+		var key: String = _task_key(callable)
+		_task_queue.append({"key": key, "callable": callable, "priority": priority} as Dictionary[String, Variant])
+		tasks_dirty = true
+	elif scheduled_task["priority"] != priority:
+		scheduled_task["priority"] = priority
+		tasks_dirty = true
+	if tasks_dirty:
+		_task_queue.sort_custom(func(a: Dictionary[String, Variant], b: Dictionary[String, Variant]) -> bool:
+			return a.priority > b.priority)
 
 
 func step() -> void:
@@ -63,9 +108,10 @@ func step() -> void:
 
 func print_queue() -> void:
 	var strings: Array[String] = []
-	for callable: Callable in _task_queue:
-		strings.append("%s %s" % [callable.get_method(), callable.get_bound_arguments()])
-	print(str(strings))
+	print("task_queue.size=%s; filled_cells=%s" % [_task_queue.size(), board.get_filled_cell_count()])
+	for task: Dictionary[String, Variant] in _task_queue:
+		strings.append(" priority=%s: %s" % [task["priority"], task["key"]])
+	print("\n".join(strings))
 
 
 func run_all_tasks() -> void:
@@ -77,11 +123,11 @@ func run_next_task() -> void:
 	if _task_queue.is_empty():
 		return
 	
-	var next_technique: Callable = _task_queue.pop_front()
-	_task_history[next_technique.get_method()] = {
+	var next_task: Dictionary[String, Variant] = _task_queue.pop_front()
+	_task_history[next_task["key"]] = {
 		"last_run": board.get_filled_cell_count()
 	} as Dictionary[String, Variant]
-	next_technique.call()
+	next_task["callable"].call()
 
 
 func deduce_adjacent_clues(clue_cell: Vector2i) -> void:
@@ -107,32 +153,31 @@ func deduce_island_of_one(clue_cell: Vector2i) -> void:
 			"island_of_one %s" % [clue_cell])
 
 
-func deduce_clued_island(island_group: Array[Vector2i]) -> void:
-	var clue_value: int = board.get_clue_for_group(island_group)
+func deduce_clued_island(island_cell: Vector2i) -> void:
+	var island: Array[Vector2i] = board.get_island_for_cell(island_cell)
+	var clue_value: int = board.get_clue_for_group(island)
 	if clue_value == 0:
 		# unclued group
 		return
-	var liberties: Array[Vector2i] = board.get_liberties(island_group)
-	if clue_value == island_group.size():
+	var liberties: Array[Vector2i] = board.get_liberties(island)
+	if clue_value == island.size():
 		for liberty: Vector2i in liberties:
 			if not _can_deduce(board, liberty):
 				continue
-			deductions.add_deduction(liberty, CELL_WALL, "island_moat %s" % [island_group[0]])
-	elif liberties.size() == 1 and clue_value == island_group.size() + 1:
+			deductions.add_deduction(liberty, CELL_WALL, "island_moat %s" % [island[0]])
+	elif liberties.size() == 1 and clue_value == island.size() + 1:
 		if _can_deduce(board, liberties[0]):
-			deductions.add_deduction(liberties[0], CELL_ISLAND, "island_expansion %s" % [island_group[0]])
+			deductions.add_deduction(liberties[0], CELL_ISLAND, "island_expansion %s" % [island[0]])
 		for new_wall_cell: Vector2i in board.get_neighbors(liberties[0]):
 			if _can_deduce(board, new_wall_cell):
-				deductions.add_deduction(new_wall_cell, CELL_WALL, "island_moat %s" % [island_group[0]])
-	elif liberties.size() == 1 and clue_value > island_group.size():
+				deductions.add_deduction(new_wall_cell, CELL_WALL, "island_moat %s" % [island[0]])
+	elif liberties.size() == 1 and clue_value > island.size():
 		if _can_deduce(board, liberties[0]):
-			deductions.add_deduction(liberties[0], CELL_ISLAND, "island_expansion %s" % [island_group[0]])
+			deductions.add_deduction(liberties[0], CELL_ISLAND, "island_expansion %s" % [island[0]])
 
 
-func deduce_island_divider(island_group: Array[Vector2i]) -> void:
-	var liberties: Array[Vector2i] = board.get_liberties(island_group)
-	var island_roots_by_cell: Dictionary[Vector2i, Vector2i] \
-			= board.get_island_roots_by_cell()
+func deduce_island_divider(island_cell: Vector2i) -> void:
+	var liberties: Array[Vector2i] = board.get_liberties(board.get_island_for_cell(island_cell))
 	for liberty: Vector2i in liberties:
 		if not _can_deduce(board, liberty):
 			continue
@@ -140,61 +185,61 @@ func deduce_island_divider(island_group: Array[Vector2i]) -> void:
 		for neighbor_cell: Vector2i in board.get_neighbors(liberty):
 			if board.get_clue_value_for_cell(neighbor_cell) == 0:
 				continue
-			var neighbor_root: Vector2i = island_roots_by_cell[neighbor_cell]
+			var neighbor_root: Vector2i = board.get_island_root_for_cell(neighbor_cell)
 			clued_neighbor_roots[neighbor_root] = true
 		if clued_neighbor_roots.size() >= 2:
 			deductions.add_deduction(liberty, CELL_WALL, "island_divider %s %s"
 					% [clued_neighbor_roots.keys()[0], clued_neighbor_roots.keys()[1]])
 
 
-func deduce_wall(wall_group: Array[Vector2i]) -> void:
-	var liberties: Array[Vector2i] = board.get_liberties(wall_group)
+func deduce_wall(wall_cell: Vector2i) -> void:
+	var liberties: Array[Vector2i] = board.get_liberties(board.get_wall_for_cell(wall_cell))
 	if liberties.size() == 1 and board.get_walls().size() >= 2:
-		deductions.add_deduction(liberties[0], CELL_WALL, "wall_expansion %s" % [wall_group.front()])
+		deductions.add_deduction(liberties[0], CELL_WALL, "wall_expansion %s" % [wall_cell])
 
 
 func enqueue_adjacent_clues() -> void:
 	for cell: Vector2i in board.cells:
 		if board.get_cell_string(cell).is_valid_int():
-			_task_queue.append(deduce_adjacent_clues.bind(cell))
+			schedule_task(deduce_adjacent_clues.bind(cell), 1100)
 
 
 func enqueue_clued_islands() -> void:
 	var islands: Array[Array] = board.get_islands()
-	for island_group: Array[Vector2i] in islands:
-		var clue_value: int = board.get_clue_for_group(island_group)
+	for island: Array[Vector2i] in islands:
+		var clue_value: int = board.get_clue_for_group(island)
 		if clue_value == 0:
 			# unclued island
 			continue
-		var liberties: Array[Vector2i] = board.get_liberties(island_group)
+		var liberties: Array[Vector2i] = board.get_liberties(island)
 		if liberties.size() > 0:
-			_task_queue.append(deduce_clued_island.bind(island_group))
+			schedule_task(deduce_clued_island.bind(island.front()), 250)
 
 
 func enqueue_island_dividers() -> void:
 	var islands: Array[Array] = board.get_islands()
-	for island_group: Array[Vector2i] in islands:
-		var clue_value: int = board.get_clue_for_group(island_group)
+	for island: Array[Vector2i] in islands:
+		var clue_value: int = board.get_clue_for_group(island)
 		if clue_value == 0:
 			# unclued island
 			continue
-		var liberties: Array[Vector2i] = board.get_liberties(island_group)
+		var liberties: Array[Vector2i] = board.get_liberties(island)
 		if liberties.size() > 0:
-			_task_queue.append(deduce_island_divider.bind(island_group))
+			schedule_task(deduce_island_divider.bind(island.front()), 240)
 
 
 func enqueue_islands_of_one() -> void:
 	for cell: Vector2i in board.cells:
 		if board.get_cell_string(cell) == "1":
-			_task_queue.append(deduce_island_of_one.bind(cell))
+			schedule_task(deduce_island_of_one.bind(cell), 1100)
 
 
 func enqueue_wall_expansions() -> void:
 	var walls: Array[Array] = board.get_walls()
-	for wall_group: Array[Vector2i] in walls:
-		var liberties: Array[Vector2i] = board.get_liberties(wall_group)
+	for wall: Array[Vector2i] in walls:
+		var liberties: Array[Vector2i] = board.get_liberties(wall)
 		if liberties.size() > 0:
-			_task_queue.append(deduce_wall.bind(wall_group))
+			schedule_task(deduce_wall.bind(wall.front()), 245)
 
 
 func _can_deduce(target_board: FastBoard, cell: Vector2i) -> bool:
@@ -207,3 +252,39 @@ func _find_adjacent_clues(cell: Vector2i) -> Array[Vector2i]:
 		if board.get_cell_string(neighbor_cell).is_valid_int():
 			result.append(neighbor_cell)
 	return result
+
+
+func _react_to_changes(changes: Array[Dictionary]) -> void:
+	var affected_wall_roots: Dictionary[Vector2i, bool] = {}
+	var affected_island_roots: Dictionary[Vector2i, bool] = {}
+	var cells_to_check: Dictionary[Vector2i, bool] = {}
+	for change: Dictionary[String, Variant] in changes:
+		var cell: Vector2i = change["pos"]
+		cells_to_check[cell] = true
+		for neighbor: Vector2i in board.get_neighbors(cell):
+			cells_to_check[neighbor] = true
+	for cell_to_check: Vector2i in cells_to_check:
+		var wall_root: Vector2i = board.get_wall_root_for_cell(cell_to_check)
+		if wall_root != POS_NOT_FOUND:
+			affected_wall_roots[wall_root] = true
+		var island_root: Vector2i = board.get_island_root_for_cell(cell_to_check)
+		if island_root != POS_NOT_FOUND:
+			affected_island_roots[island_root] = true
+	
+	for wall_root: Vector2i in affected_wall_roots:
+		var wall: Array[Vector2i] = board.get_wall_for_cell(wall_root)
+		if board.get_liberties(wall).size() > 0:
+			schedule_task(deduce_wall.bind(wall_root), 345)
+	
+	for island_root: Vector2i in affected_island_roots:
+		var island: Array[Vector2i] = board.get_island_for_cell(island_root)
+		if board.get_clue_for_group(island) != 0 and board.get_liberties(island).size() > 0:
+			schedule_task(deduce_clued_island.bind(island_root), 350)
+
+
+func _task_key(callable: Callable) -> String:
+	var key: String = callable.get_method()
+	var args: Array[Variant] = callable.get_bound_arguments()
+	if not args.is_empty():
+		key += ":" + JSON.stringify(args)
+	return key

--- a/project/src/main/nurikabe/fast/test_fast_solver.gd
+++ b/project/src/main/nurikabe/fast/test_fast_solver.gd
@@ -1,1 +1,0 @@
-extends Node

--- a/project/src/main/nurikabe/fast/test_fast_solver.gd.uid
+++ b/project/src/main/nurikabe/fast/test_fast_solver.gd.uid
@@ -1,1 +1,0 @@
-uid://5oaqiw1souwk

--- a/project/src/main/nurikabe/slow/nurikabe_utils.gd
+++ b/project/src/main/nurikabe/slow/nurikabe_utils.gd
@@ -17,4 +17,6 @@ const ERROR_BG_COLOR: Color = Color("ff5a5a")
 const CLUE_LOWLIGHT_COLOR: Color = Color("bbbbbb")
 const CLUE_COLOR: Color = Color("666666")
 
+const POS_NOT_FOUND: Vector2i = Vector2i(-1, -1)
+
 const NEIGHBOR_DIRS: Array[Vector2i] = [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]

--- a/project/src/test/nurikabe/fast/test_fast_solver_queue.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver_queue.gd
@@ -1,0 +1,14 @@
+extends TestFastSolver
+
+func test_has_scheduled_task() -> void:
+	assert_eq(solver.has_scheduled_task(solver.enqueue_islands_of_one), false)
+	solver.schedule_task(solver.enqueue_islands_of_one, 100)
+	assert_eq(solver.has_scheduled_task(solver.enqueue_islands_of_one), true)
+
+
+func test_get_scheduled_task() -> void:
+	assert_eq(solver.get_scheduled_task(solver.enqueue_islands_of_one), {} as Dictionary[String, Variant])
+	solver.schedule_task(solver.enqueue_islands_of_one, 100)
+	var scheduled_task: Dictionary[String, Variant] = solver.get_scheduled_task(solver.enqueue_islands_of_one)
+	assert_eq(scheduled_task.get("priority"), 100)
+	assert_eq(scheduled_task.get("callable"), solver.enqueue_islands_of_one)

--- a/project/src/test/nurikabe/fast/test_fast_solver_queue.gd.uid
+++ b/project/src/test/nurikabe/fast/test_fast_solver_queue.gd.uid
@@ -1,0 +1,1 @@
+uid://bjes4ip1eyqy3


### PR DESCRIPTION
FastSolver can now react to changes. When walls and islands are expanded, it checks neighboring walls and islands for additional rules.

Task queue now includes a priority field.

Added more methods for FastBoard:
  get_island_for_cell
  get_island_root_for_cell
  get_wall_for_cell
  get_wall_root_for_cell

Added change_history field to fast_solver. This isn't used yet, but allows for more complex 'react to changes' logic in the future.

deduce_xxx methods now operate on cells, not groups. This makes it easier to view the queue, and avoids redundant calls where three scheduled tasks each want to inspect the wall with:
  (0, 1)
  (0, 1) (1, 1)
  (0, 1) (1, 1) (2, 1) (etc...)