### PR TITLE
Fast island connector logic. -1 for invalid island clues.

### DIFF
--- a/project/src/main/nurikabe/fast/fast_board.gd
+++ b/project/src/main/nurikabe/fast/fast_board.gd
@@ -30,7 +30,7 @@ func get_cell_string(cell_pos: Vector2i) -> String:
 
 ## Returns the clue value for the specified group of cells.[br]
 ## [br]
-## If zero clues or multiple clues are present, returns 0.
+## If zero clues are present, returns 0. If multiple clues are present, returns -1.
 func get_clue_for_group(group: Array[Vector2i]) -> int:
 	return _get_cached(
 		"clue_for_group %s" % ["-" if group.is_empty() else str(group[0])],
@@ -270,7 +270,7 @@ func _build_clue_value(group: Array[Vector2i]) -> int:
 		if cells[cell].is_valid_int():
 			if result > 0:
 				# too many clues
-				result = 0
+				result = -1
 				break
 			result = cells[cell].to_int()
 	return result

--- a/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
@@ -11,7 +11,7 @@ func test_clued_islands_add_island_moat() -> void:
 		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "island_moat (0, 0)"),
 		FastDeduction.new(Vector2i(0, 2), CELL_WALL, "island_moat (0, 0)"),
 	]
-	assert_deduction(solver.enqueue_clued_islands, expected)
+	assert_deduction(solver.enqueue_islands, expected)
 
 
 func test_clued_islands_island_expansion() -> void:
@@ -23,7 +23,7 @@ func test_clued_islands_island_expansion() -> void:
 	var expected: Array[FastDeduction] = [
 		FastDeduction.new(Vector2i(1, 0), CELL_ISLAND, "island_expansion (0, 0)"),
 	]
-	assert_deduction(solver.enqueue_clued_islands, expected)
+	assert_deduction(solver.enqueue_islands, expected)
 
 
 func test_clued_islands_island_expansion_and_moat() -> void:
@@ -37,7 +37,7 @@ func test_clued_islands_island_expansion_and_moat() -> void:
 		FastDeduction.new(Vector2i(2, 0), CELL_WALL, "island_moat (0, 0)"),
 		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "island_moat (0, 0)"),
 	]
-	assert_deduction(solver.enqueue_clued_islands, expected)
+	assert_deduction(solver.enqueue_islands, expected)
 
 
 func test_wall_expansions_1() -> void:
@@ -150,3 +150,15 @@ func test_wall_bubble_surrounded_square() -> void:
 		FastDeduction.new(Vector2i(2, 3), CELL_WALL, "wall_bubble"),
 	]
 	assert_deduction(solver.enqueue_unreachable_squares, expected)
+
+
+func test_island_connector() -> void:
+	grid = [
+		"     6",
+		"##    ",
+		" .    ",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(1, 2), CELL_ISLAND, "island_connector (0, 2)"),
+	]
+	assert_deduction(solver.enqueue_islands, expected)


### PR DESCRIPTION
Invalid islands with multiple clues now return -1, to prevent the solver from making incorrect deductions.