### PR TITLE
Added 'island_snug' rule.

### DIFF
--- a/project/src/main/nurikabe/fast/fast_chokepoint_map.gd
+++ b/project/src/main/nurikabe/fast/fast_chokepoint_map.gd
@@ -15,6 +15,18 @@ func _init(init_board: FastBoard, init_cell_filter: Callable) -> void:
 	_cell_filter = init_cell_filter
 
 
+func get_component_cell_count(cell: Vector2i) -> int:
+	if _chokepoint_map == null:
+		_build_chokepoint_map()
+	return _chokepoint_map.get_component_cell_count(cell)
+
+
+func get_component_cells(cell: Vector2i) -> Array[Vector2i]:
+	if _chokepoint_map == null:
+		_build_chokepoint_map()
+	return _chokepoint_map.get_component_cells(cell)
+
+
 func get_unchoked_cell_count(chokepoint: Vector2i, cell: Vector2i) -> int:
 	if _chokepoint_map == null:
 		_build_chokepoint_map()

--- a/project/src/main/nurikabe/fast/fast_solver.gd
+++ b/project/src/main/nurikabe/fast/fast_solver.gd
@@ -205,6 +205,10 @@ func deduce_clued_island(island_cell: Vector2i) -> void:
 		# unclued/invalid group
 		return
 	var liberties: Array[Vector2i] = board.get_liberties(island)
+	if liberties.size() == 0:
+		# sealed group
+		return
+	
 	if clue_value == island.size():
 		for liberty: Vector2i in liberties:
 			if not _can_deduce(board, liberty):
@@ -219,6 +223,12 @@ func deduce_clued_island(island_cell: Vector2i) -> void:
 	elif liberties.size() == 1 and clue_value > island.size():
 		if _can_deduce(board, liberties[0]):
 			deductions.add_deduction(liberties[0], CELL_ISLAND, "island_expansion %s" % [island[0]])
+	else:
+		var component_cell_count: int = board.get_island_chokepoint_map().get_component_cell_count(island_cell)
+		if component_cell_count == clue_value:
+			for deduction_cell: Vector2i in board.get_island_chokepoint_map().get_component_cells(island_cell):
+				if _can_deduce(board, deduction_cell):
+					deductions.add_deduction(deduction_cell, CELL_ISLAND, "island_snug %s" % [island_cell])
 
 
 func deduce_unclued_island(island_cell: Vector2i) -> void:

--- a/project/src/test/nurikabe/fast/test_fast_chokepoint_map.gd
+++ b/project/src/test/nurikabe/fast/test_fast_chokepoint_map.gd
@@ -83,6 +83,30 @@ func test_unchoked_cell_count_two_clues() -> void:
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 2), Vector2(2, 0)), 3)
 
 
+func test_component_cell_count_two_clues() -> void:
+	grid = [
+		"  ## 2",
+		"  ##  ",
+		" 2####",
+	]
+	var chokepoint_map: FastChokepointMap = _build_chokepoint_map()
+	assert_eq(chokepoint_map.get_component_cell_count(Vector2(0, 0)), 3)
+	assert_eq(chokepoint_map.get_component_cell_count(Vector2(0, 1)), 3)
+	assert_eq(chokepoint_map.get_component_cell_count(Vector2(0, 2)), 3)
+	assert_eq(chokepoint_map.get_component_cell_count(Vector2(2, 0)), 2)
+	assert_eq(chokepoint_map.get_component_cell_count(Vector2(2, 1)), 2)
+
+
+func test_component_cells_two_clues() -> void:
+	grid = [
+		"  ## 2",
+		"  ##  ",
+		" 2####",
+	]
+	assert_component_cells(Vector2(0, 0), [Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2)])
+	assert_component_cells(Vector2(2, 0), [Vector2i(2, 0), Vector2i(2, 1)])
+
+
 func _build_chokepoint_map() -> FastChokepointMap:
 	var board: FastBoard = FastTestUtils.init_board(grid)
 	return FastChokepointMap.new(board, func(value: String) -> bool:
@@ -95,3 +119,11 @@ func assert_chokepoints(expected_chokepoints: Array[Vector2i]) -> void:
 	var actual_chokepoints: Array[Vector2i] = chokepoint_map.chokepoints_by_cell.keys()
 	actual_chokepoints.sort()
 	assert_eq(actual_chokepoints, expected_chokepoints)
+
+
+func assert_component_cells(cell: Vector2i, expected_cells: Array[Vector2i]) -> void:
+	var chokepoint_map: FastChokepointMap = _build_chokepoint_map()
+	expected_cells.sort()
+	var actual_cells: Array[Vector2i] = chokepoint_map.get_component_cells(cell)
+	actual_cells.sort()
+	assert_eq(actual_cells, expected_cells)

--- a/project/src/test/nurikabe/fast/test_fast_solver.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver.gd
@@ -20,7 +20,7 @@ func assert_deduction(callable: Callable, expected: Array[FastDeduction]) -> voi
 	solver.run_all_tasks()
 	var actual_str_array: Array[String] = deductions_to_strings(solver.deductions.deductions)
 	var expected_str_array: Array[String] = deductions_to_strings(expected)
-	assert_eq(actual_str_array, expected_str_array)
+	assert_eq(str(actual_str_array), str(expected_str_array))
 
 
 func deductions_to_strings(deductions: Array[FastDeduction]) -> Array[String]:

--- a/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
@@ -77,6 +77,19 @@ func test_enqueue_islands_island_moat() -> void:
 	assert_deduction(solver.enqueue_islands, expected)
 
 
+func test_enqueue_islands_island_snug() -> void:
+	grid = [
+		"   4  ",
+		"####  ",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(0, 0), CELL_ISLAND, "island_snug (1, 0)"),
+		FastDeduction.new(Vector2i(2, 0), CELL_ISLAND, "island_snug (1, 0)"),
+		FastDeduction.new(Vector2i(2, 1), CELL_ISLAND, "island_snug (1, 0)"),
+	]
+	assert_deduction(solver.enqueue_islands, expected)
+
+
 func test_enqueue_unreachable_squares_1() -> void:
 	grid = [
 		" 4    ",


### PR DESCRIPTION
Added 'island_snug' rule.

This is a new rule specific to the fast solver. The slow solver
made every cell on the board a wall one at a time (n), counted
uncompletable islands for each of those board variants (n^2) resulting
in an O(n^3) slog. However, the slow solver also was unable to
distinguish between those cases, merely calling them all 'island
expansion'

The fast solver instead generates a DFS map (n) and can then calculate
the component size for each clue (1), and if it finds a clue which is in
the perfect size enclosure, it marks all empty cells as islands. This is
O(n) and very fast. I intend to demonstrate how fast with an upcoming
performance test.