### PR TITLE
Added per-clue chokepoint logic.

### DIFF
--- a/project/src/main/nurikabe/fast/fast_board.gd
+++ b/project/src/main/nurikabe/fast/fast_board.gd
@@ -69,6 +69,12 @@ func get_island_chokepoint_map() -> FastChokepointMap:
 		_build_island_chokepoint_map)
 
 
+func get_per_clue_chokepoint_map() -> PerClueChokepointMap:
+	return _get_cached(
+		"per_clue_chokepoint_map",
+		_build_per_clue_chokepoint_map)
+
+
 func set_cell_string(cell_pos: Vector2i, value: String) -> void:
 	_cache.clear()
 	cells[cell_pos] = value
@@ -198,6 +204,10 @@ func _build_island_group_map() -> FastGroupMap:
 func _build_island_chokepoint_map() -> FastChokepointMap:
 	return FastChokepointMap.new(self, func(value: String) -> bool:
 		return value.is_valid_int() or value in [CELL_EMPTY, CELL_ISLAND])
+
+
+func _build_per_clue_chokepoint_map() -> PerClueChokepointMap:
+	return PerClueChokepointMap.new(self)
 
 
 func _build_wall_group_map() -> FastGroupMap:

--- a/project/src/main/nurikabe/fast/fast_solver.gd
+++ b/project/src/main/nurikabe/fast/fast_solver.gd
@@ -188,6 +188,21 @@ func deduce_island_chokepoint(chokepoint: Vector2i) -> void:
 				"island_chokepoint %s" % [clue_cell])
 
 
+func deduce_clue_chokepoint(island_cell: Vector2i) -> void:
+	var island: Array[Vector2i] = board.get_island_for_cell(island_cell)
+	var result: Dictionary[Vector2i, String] = board.get_per_clue_chokepoint_map().choke_island(island_cell)
+	for choked_cell in result:
+		if not _can_deduce(board, choked_cell):
+			continue
+		if result[choked_cell] == CELL_ISLAND:
+			if choked_cell in board.get_liberties(island):
+				deductions.add_deduction(choked_cell, CELL_ISLAND, "island_expansion %s" % [island_cell])
+			else:
+				deductions.add_deduction(choked_cell, CELL_ISLAND, "island_chokepoint %s" % [island_cell])
+		else:
+			deductions.add_deduction(choked_cell, CELL_WALL, "island_buffer %s" % [island_cell])
+
+
 func deduce_island_of_one(clue_cell: Vector2i) -> void:
 	if not board.get_cell_string(clue_cell) == "1":
 		return
@@ -333,6 +348,10 @@ func enqueue_island_chokepoints() -> void:
 	var chokepoints: Array[Vector2i] = board.get_island_chokepoint_map().chokepoints_by_cell.keys()
 	for chokepoint: Vector2i in chokepoints:
 		schedule_task(deduce_island_chokepoint.bind(chokepoint), 230)
+	
+	var islands: Array[Array] = board.get_islands()
+	for island: Array[Vector2i] in islands:
+		schedule_task(deduce_clue_chokepoint.bind(island.front()), 225)
 
 
 func enqueue_islands() -> void:

--- a/project/src/main/nurikabe/fast/per_clue_chokepoint_map.gd
+++ b/project/src/main/nurikabe/fast/per_clue_chokepoint_map.gd
@@ -1,0 +1,123 @@
+class_name PerClueChokepointMap
+
+const CELL_EMPTY: String = NurikabeUtils.CELL_EMPTY
+const CELL_INVALID: String = NurikabeUtils.CELL_INVALID
+const CELL_ISLAND: String = NurikabeUtils.CELL_ISLAND
+const CELL_WALL: String = NurikabeUtils.CELL_WALL
+
+var _board: FastBoard
+
+var _adjacent_clues_by_cell: Dictionary[Vector2i, int] = {}
+var _chokepoint_map_by_clue: Dictionary[Vector2i, ChokepointMap] = {}
+var _claimed_by_clue: Dictionary[Vector2i, Vector2i] = {}
+
+var _visitable: Dictionary[Vector2i, bool] = {}
+
+func _init(init_board: FastBoard) -> void:
+	_board = init_board
+	
+	var islands: Array[Array] = _board.get_islands()
+	
+	# collect visitable cells (empty cells, or clueless islands)
+	for cell: Vector2i in _board.cells:
+		if _board.get_cell_string(cell) in [CELL_ISLAND, CELL_EMPTY] \
+				and _board.get_clue_value_for_cell(cell) == 0:
+			_visitable[cell] = true
+	
+	# seed queue from islands
+	for island: Array[Vector2i] in islands:
+		var clue_value: int = _board.get_clue_for_group(island)
+		if clue_value == 0:
+			continue
+		for liberty: Vector2i in _board.get_liberties(island):
+			if _adjacent_clues_by_cell.has(liberty):
+				# cell is adjacent to two or more islands, so no islands can reach it
+				_adjacent_clues_by_cell[liberty] += 1
+				_visitable.erase(liberty)
+			else:
+				_adjacent_clues_by_cell[liberty] = 1
+				_claimed_by_clue[liberty] = island.front()
+				_visitable.erase(liberty)
+
+
+func _get_chokepoint_map(island_cell: Vector2i) -> ChokepointMap:
+	var island_root: Vector2i = _board.get_island_root_for_cell(island_cell)
+	return _chokepoint_map_by_clue.get(island_root)
+
+
+func _has_chokepoint_map(island_cell: Vector2i) -> bool:
+	var island_root: Vector2i = _board.get_island_root_for_cell(island_cell)
+	return _chokepoint_map_by_clue.has(island_root)
+
+
+func _init_chokepoint_map(island_cell: Vector2i) -> void:
+	var reach_score_by_cell: Dictionary[Vector2i, int] = {}
+	var queue: Array[Vector2i] = [island_cell]
+	
+	var island: Array[Vector2i] = _board.get_island_for_cell(island_cell)
+	var clue_value: int = _board.get_clue_value_for_cell(island_cell)
+	var reachability: int = clue_value - island.size()
+	for other_island_cell: Vector2i in island:
+		reach_score_by_cell[other_island_cell] = reachability + 1
+	for liberty: Vector2i in _board.get_liberties(island):
+		if reach_score_by_cell.has(liberty):
+			# cell is adjacent to two or more islands, so no islands can reach it
+			reach_score_by_cell[liberty] = 0
+			_adjacent_clues_by_cell[liberty] += 1
+			continue
+		reach_score_by_cell[liberty] = reachability
+		queue.append(liberty)
+	
+	# propagate reachability using breadth-first expansion
+	while not queue.is_empty():
+		var cell: Vector2i = queue.pop_front()
+		
+		for neighbor: Vector2i in _board.get_neighbors(cell):
+			if not _visitable.has(neighbor):
+				continue
+			if reach_score_by_cell.has(neighbor):
+				# already visited
+				continue
+			
+			reach_score_by_cell[neighbor] = reach_score_by_cell[cell] - 1
+			queue.append(neighbor)
+	
+	_chokepoint_map_by_clue[island.front()] = ChokepointMap.new(reach_score_by_cell.keys())
+
+
+func choke_island(island_cell: Vector2i) -> Dictionary[Vector2i, String]:
+	if not _has_chokepoint_map(island_cell):
+		_init_chokepoint_map(island_cell)
+	
+	var result: Dictionary[Vector2i, String] = {}
+	
+	var chokepoint_map: ChokepointMap = _get_chokepoint_map(island_cell)
+	var clue_value: int = _board.get_clue_value_for_cell(island_cell)
+	for chokepoint: Vector2i in chokepoint_map.chokepoints_by_cell:
+		var unchoked_cell_count: int = chokepoint_map.get_unchoked_cell_count(chokepoint, island_cell)
+		if unchoked_cell_count >= clue_value:
+			continue
+		
+		var island_root: Vector2i = _board.get_island_root_for_cell(island_cell)
+		if _board.get_cell_string(chokepoint) == CELL_EMPTY:
+			# the chokepoint itself must be an island
+			result[chokepoint] = CELL_ISLAND
+		
+		for neighbor_cell: Vector2i in _board.get_neighbors(chokepoint):
+			# buffer wall between this and other clued islands
+			if _needs_buffer(island_root, neighbor_cell):
+				result[neighbor_cell] = CELL_WALL
+		
+		if _board.get_cell_string(chokepoint) == CELL_ISLAND and _board.get_clue_value_for_cell(chokepoint) == 0:
+			# buffer wall for any adjoining unclued islands
+			for liberty_cell in _board.get_liberties(_board.get_island_for_cell(chokepoint)):
+				if _needs_buffer(island_root, liberty_cell):
+					result[liberty_cell] = CELL_WALL
+	
+	return result
+
+
+func _needs_buffer(island_root: Vector2i, cell: Vector2i) -> bool:
+	return _claimed_by_clue.has(cell) \
+		and _claimed_by_clue[cell] != island_root \
+		and _board.get_cell_string(cell) == CELL_EMPTY

--- a/project/src/main/nurikabe/fast/per_clue_chokepoint_map.gd.uid
+++ b/project/src/main/nurikabe/fast/per_clue_chokepoint_map.gd.uid
@@ -1,0 +1,1 @@
+uid://dkx8cfcqd1s3x

--- a/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
@@ -37,6 +37,20 @@ func test_enqueue_islands_island_expansion_2() -> void:
 	assert_deduction(solver.enqueue_island_chokepoints, expected)
 
 
+func test_enqueue_islands_island_chokepoint_1() -> void:
+	grid = [
+		"   2####",
+		"       5",
+		"        ",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "island_buffer (3, 1)"),
+		FastDeduction.new(Vector2i(1, 2), CELL_ISLAND, "island_chokepoint (3, 1)"),
+		FastDeduction.new(Vector2i(2, 2), CELL_ISLAND, "island_chokepoint (3, 1)"),
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
 func test_enqueue_islands_island_expansion_and_moat() -> void:
 	grid = [
 		" 2    ",

--- a/project/src/test/nurikabe/fast/test_per_clue_chokepoint_map.gd
+++ b/project/src/test/nurikabe/fast/test_per_clue_chokepoint_map.gd
@@ -1,0 +1,59 @@
+extends GutTest
+
+const CELL_EMPTY: String = NurikabeUtils.CELL_EMPTY
+const CELL_INVALID: String = NurikabeUtils.CELL_INVALID
+const CELL_ISLAND: String = NurikabeUtils.CELL_ISLAND
+const CELL_WALL: String = NurikabeUtils.CELL_WALL
+
+var grid: Array[String] = []
+
+func test_choke_island_small() -> void:
+	grid = [
+		"   2####",
+		"       5",
+		"        ",
+	]
+	assert_choke_island(Vector2i(3, 1), {
+		Vector2i(1, 1): CELL_WALL,
+		Vector2i(1, 2): CELL_ISLAND,
+		Vector2i(2, 2): CELL_ISLAND,
+	})
+	assert_choke_island(Vector2i(1, 0), {
+	})
+
+
+func test_choke_island_large() -> void:
+	grid = [
+		"   2####",
+		"       5",
+		"     . .",
+	]
+	assert_choke_island(Vector2i(3, 1), {
+		Vector2i(1, 1): CELL_WALL,
+		Vector2i(1, 2): CELL_ISLAND,
+	})
+
+
+func test_choke_island_clueless_island() -> void:
+	grid = [
+		"        ",
+		" . 5####",
+		"       5",
+		" . .    ",
+	]
+	assert_choke_island(Vector2i(3, 2), {
+		Vector2i(0, 2): CELL_WALL,
+		Vector2i(1, 2): CELL_WALL,
+		Vector2i(2, 3): CELL_ISLAND,
+	})
+
+
+func assert_choke_island(island_cell: Vector2i, expected: Dictionary[Vector2i, String]) -> void:
+	var pccm: PerClueChokepointMap = init_per_clue_chokepoint_map()
+	var actual: Dictionary[Vector2i, String] = pccm.choke_island(island_cell)
+	assert_eq(actual, expected)
+
+
+func init_per_clue_chokepoint_map() -> PerClueChokepointMap:
+	var board: FastBoard = FastTestUtils.init_board(grid)
+	return PerClueChokepointMap.new(board)

--- a/project/src/test/nurikabe/fast/test_per_clue_chokepoint_map.gd.uid
+++ b/project/src/test/nurikabe/fast/test_per_clue_chokepoint_map.gd.uid
@@ -1,0 +1,1 @@
+uid://dykeik5vqq7ib


### PR DESCRIPTION
The old chokepoint logic checked globally, "are there any cells which act as chokepoints for the puzzle as a whole." The new chokepoint logic checks on a per-clue basis, "are there any cells which act as chokepoints for a particular clue." It can catch more complex cases like an 8 which is squeezed against a wall by a nearby 4, even though all of the cells are technically still reachable.