### PR TITLE
DemoFastSolver handles idle steps differently.

### DIFF
--- a/project/src/demo/nurikabe/fast/demo_fast_solver.gd
+++ b/project/src/demo/nurikabe/fast/demo_fast_solver.gd
@@ -52,11 +52,20 @@ func solve() -> void:
 		_show_message("--------")
 	
 	var idle_steps: int = 0
-	while changes.size() < 5 and idle_steps < 10:
+	while idle_steps < 2 * solver.board.cells.size() and not solver.board.is_filled() and changes.size() < 5:
+		var old_filled_cell_count: int = solver.board.get_filled_cell_count()
+		
+		if not solver.has_scheduled_tasks():
+			solver.schedule_tasks()
+		if not solver.has_scheduled_tasks():
+			break
 		solver.step()
 		changes = solver.get_changes()
-		if solver.is_queue_empty():
+		
+		if old_filled_cell_count == solver.board.get_filled_cell_count():
 			idle_steps += 1
+		else:
+			idle_steps = 0
 	
 	if changes.is_empty():
 		_show_message("(no changes)")
@@ -80,9 +89,13 @@ func performance_test() -> void:
 	var start_time: float = Time.get_ticks_usec()
 	
 	var idle_steps: int = 0
-	while idle_steps < 200 and not solver.board.is_filled():
+	while idle_steps < 2 * solver.board.cells.size() and not solver.board.is_filled():
 		var old_filled_cell_count: int = solver.board.get_filled_cell_count()
 		
+		if not solver.has_scheduled_tasks():
+			solver.schedule_tasks()
+		if not solver.has_scheduled_tasks():
+			break
 		solver.step()
 		solver.apply_changes()
 		

--- a/project/src/main/nurikabe/fast/fast_solver.gd
+++ b/project/src/main/nurikabe/fast/fast_solver.gd
@@ -100,6 +100,10 @@ func has_scheduled_task(callable: Callable) -> bool:
 	return not get_scheduled_task(callable).is_empty()
 
 
+func has_scheduled_tasks() -> bool:
+	return not _task_queue.is_empty()
+
+
 func get_scheduled_task(callable: Callable) -> Dictionary[String, Variant]:
 	var key: String = _task_key(callable)
 	var result: Dictionary[String, Variant]
@@ -126,9 +130,6 @@ func schedule_task(callable: Callable, priority: int) -> void:
 
 
 func step() -> void:
-	if _task_queue.is_empty():
-		schedule_tasks()
-	
 	if not _task_queue.is_empty():
 		run_next_task()
 


### PR DESCRIPTION
Before, it would repeatedly call step, which scheduled tasks when the queue was empty. But sometimes there would be 200 'check if this cell is unreachable' tasks in a row, and they would all result in nothing happening, causing the solver to exit early.

Now, it explicitly schedules tasks when the queue is empty. Sometimes there are 200 'check if this cell is unreachable' tasks in a row, but its threshold is much higher. However, it also exits early if no tasks are scheduled.