### PR TITLE
Avoid enqueuing ~300 'deduce_empty_square' tasks.

### DIFF
--- a/project/src/demo/nurikabe/fast/demo_fast_solver.gd
+++ b/project/src/demo/nurikabe/fast/demo_fast_solver.gd
@@ -52,7 +52,7 @@ func solve() -> void:
 		_show_message("--------")
 	
 	var idle_steps: int = 0
-	while idle_steps < 2 * solver.board.cells.size() and not solver.board.is_filled() and changes.size() < 5:
+	while idle_steps < 100 and not solver.board.is_filled() and changes.size() < 5:
 		var old_filled_cell_count: int = solver.board.get_filled_cell_count()
 		
 		if not solver.has_scheduled_tasks():
@@ -89,7 +89,7 @@ func performance_test() -> void:
 	var start_time: float = Time.get_ticks_usec()
 	
 	var idle_steps: int = 0
-	while idle_steps < 2 * solver.board.cells.size() and not solver.board.is_filled():
+	while idle_steps < 100 and not solver.board.is_filled():
 		var old_filled_cell_count: int = solver.board.get_filled_cell_count()
 		
 		if not solver.has_scheduled_tasks():

--- a/project/src/main/nurikabe/fast/fast_solver.gd
+++ b/project/src/main/nurikabe/fast/fast_solver.gd
@@ -417,6 +417,8 @@ func enqueue_unreachable_squares() -> void:
 	for cell: Vector2i in board.cells:
 		if not _can_deduce(board, cell):
 			continue
+		if board.get_global_reachability_map().get_clue_reachability(cell) == GlobalReachabilityMap.ClueReachability.REACHABLE:
+			continue
 		schedule_task(deduce_unreachable_square.bind(cell), 235)
 
 


### PR DESCRIPTION
The old logic used to enqueue a reachability check for every square. These checks were fast, but required a lot of overhead just as far as creating a task, adding it to the queue, popping it from the queue, etc.

The new logic performs the reachability check during the enqueue step, only adding a task if the square isn't reachability.

Improves Puzzle #41 performance by ~20% (430 ms -> 350 ms)