### PR TITLE
Fixed tarjan edge case; back reference in dfs child

### DIFF
--- a/project/src/test/nurikabe/fast/test_fast_chokepoint_map.gd
+++ b/project/src/test/nurikabe/fast/test_fast_chokepoint_map.gd
@@ -14,7 +14,8 @@ func test_chokepoints_1() -> void:
 		"      ",
 		"      ",
 	]
-	assert_chokepoints([Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2)])
+	var chokepoint_map: FastChokepointMap = _build_island_chokepoint_map()
+	assert_chokepoints(chokepoint_map, [Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2)])
 
 
 func test_unchoked_cell_count_1() -> void:
@@ -24,12 +25,24 @@ func test_unchoked_cell_count_1() -> void:
 		"      ",
 		"      ",
 	]
-	var chokepoint_map: FastChokepointMap = _build_chokepoint_map()
+	var chokepoint_map: FastChokepointMap = _build_island_chokepoint_map()
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 0), Vector2(1, 0)), 1)
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 0), Vector2(0, 1)), 7)
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 2), Vector2(0, 0)), 3)
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 2), Vector2(2, 2)), 5)
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(1, 3), Vector2(2, 2)), 8)
+
+
+func test_unchoked_cell_count_2() -> void:
+	grid = [
+		"  ####  ",
+		"   4    ",
+		"       6",
+		"        ",
+		" 1  ##  ",
+	]
+	var chokepoint_map: FastChokepointMap = _build_island_chokepoint_map()
+	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(3, 3), Vector2(3, 2)), 15)
 
 
 func test_chokepoints_donut() -> void:
@@ -38,7 +51,8 @@ func test_chokepoints_donut() -> void:
 		"  ##  ",
 		"      ",
 	]
-	assert_chokepoints([])
+	var chokepoint_map: FastChokepointMap = _build_island_chokepoint_map()
+	assert_chokepoints(chokepoint_map, [])
 
 
 func test_chokepoints_2() -> void:
@@ -47,7 +61,8 @@ func test_chokepoints_2() -> void:
 		"      ",
 		"##  ##",
 	]
-	assert_chokepoints([Vector2i(1, 1)])
+	var chokepoint_map: FastChokepointMap = _build_island_chokepoint_map()
+	assert_chokepoints(chokepoint_map, [Vector2i(1, 1)])
 
 
 func test_chokepoints_3() -> void:
@@ -56,7 +71,8 @@ func test_chokepoints_3() -> void:
 		"   5  ",
 		"##  ##",
 	]
-	assert_chokepoints([Vector2i(1, 1)])
+	var chokepoint_map: FastChokepointMap = _build_island_chokepoint_map()
+	assert_chokepoints(chokepoint_map, [Vector2i(1, 1)])
 
 
 func test_chokepoints_two_clues() -> void:
@@ -65,7 +81,8 @@ func test_chokepoints_two_clues() -> void:
 		"  ##  ",
 		" 3##  ",
 	]
-	assert_chokepoints([Vector2i(0, 1), Vector2(2, 1)])
+	var chokepoint_map: FastChokepointMap = _build_island_chokepoint_map()
+	assert_chokepoints(chokepoint_map, [Vector2i(0, 1), Vector2(2, 1)])
 
 
 func test_unchoked_cell_count_two_clues() -> void:
@@ -74,7 +91,7 @@ func test_unchoked_cell_count_two_clues() -> void:
 		"  ##  ",
 		" 3##  ",
 	]
-	var chokepoint_map: FastChokepointMap = _build_chokepoint_map()
+	var chokepoint_map: FastChokepointMap = _build_island_chokepoint_map()
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 0), Vector2(0, 1)), 2)
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 0), Vector2(2, 0)), 3)
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 1), Vector2(0, 0)), 1)
@@ -89,7 +106,7 @@ func test_component_cell_count_two_clues() -> void:
 		"  ##  ",
 		" 2####",
 	]
-	var chokepoint_map: FastChokepointMap = _build_chokepoint_map()
+	var chokepoint_map: FastChokepointMap = _build_island_chokepoint_map()
 	assert_eq(chokepoint_map.get_component_cell_count(Vector2(0, 0)), 3)
 	assert_eq(chokepoint_map.get_component_cell_count(Vector2(0, 1)), 3)
 	assert_eq(chokepoint_map.get_component_cell_count(Vector2(0, 2)), 3)
@@ -103,26 +120,27 @@ func test_component_cells_two_clues() -> void:
 		"  ##  ",
 		" 2####",
 	]
-	assert_component_cells(Vector2(0, 0), [Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2)])
-	assert_component_cells(Vector2(2, 0), [Vector2i(2, 0), Vector2i(2, 1)])
+	var chokepoint_map: FastChokepointMap = _build_island_chokepoint_map()
+	assert_component_cells(chokepoint_map, Vector2(0, 0), [Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2)])
+	assert_component_cells(chokepoint_map, Vector2(2, 0), [Vector2i(2, 0), Vector2i(2, 1)])
 
 
-func _build_chokepoint_map() -> FastChokepointMap:
+func _build_island_chokepoint_map() -> FastChokepointMap:
 	var board: FastBoard = FastTestUtils.init_board(grid)
 	return FastChokepointMap.new(board, func(value: String) -> bool:
 		return value.is_valid_int() or value in [CELL_EMPTY, CELL_ISLAND])
 
 
-func assert_chokepoints(expected_chokepoints: Array[Vector2i]) -> void:
-	var chokepoint_map: FastChokepointMap = _build_chokepoint_map()
+func assert_chokepoints(chokepoint_map: FastChokepointMap,
+		expected_chokepoints: Array[Vector2i]) -> void:
 	expected_chokepoints.sort()
 	var actual_chokepoints: Array[Vector2i] = chokepoint_map.chokepoints_by_cell.keys()
 	actual_chokepoints.sort()
 	assert_eq(actual_chokepoints, expected_chokepoints)
 
 
-func assert_component_cells(cell: Vector2i, expected_cells: Array[Vector2i]) -> void:
-	var chokepoint_map: FastChokepointMap = _build_chokepoint_map()
+func assert_component_cells(chokepoint_map: FastChokepointMap, cell: Vector2i,
+		expected_cells: Array[Vector2i]) -> void:
 	expected_cells.sort()
 	var actual_cells: Array[Vector2i] = chokepoint_map.get_component_cells(cell)
 	actual_cells.sort()

--- a/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
@@ -1,5 +1,66 @@
 extends TestFastSolver
 
+func test_enqueue_island_chokepoints_adjacent() -> void:
+	grid = [
+		"   4  ",
+		"####  ",
+		"      ",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(2, 0), CELL_ISLAND, "island_expansion (1, 0)"),
+		FastDeduction.new(Vector2i(2, 1), CELL_ISLAND, "island_chokepoint (1, 0)"),
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
+func test_enqueue_island_chokepoints_distant() -> void:
+	grid = [
+		"   2####",
+		"       5",
+		"        ",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "island_buffer (3, 1)"),
+		FastDeduction.new(Vector2i(1, 2), CELL_ISLAND, "island_chokepoint (3, 1)"),
+		FastDeduction.new(Vector2i(2, 2), CELL_ISLAND, "island_chokepoint (3, 1)"),
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
+func test_enqueue_island_chokepoints_false_positive() -> void:
+	grid = [
+		"  ####  ",
+		"   4    ",
+		"       8",
+		"        ",
+		"        ",
+		"        ",
+		"        ",
+		"        ",
+		"    ##  ",
+	]
+	var expected: Array[FastDeduction] = [
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
+func test_enqueue_island_chokepoints_snug() -> void:
+	grid = [
+		" . .  ",
+		" 5##  ",
+		"  ####",
+		"    ##",
+		"   . 5",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(0, 2), CELL_WALL, "island_buffer (1, 4)"),
+		FastDeduction.new(Vector2i(0, 3), CELL_ISLAND, "island_snug (1, 4)"),
+		FastDeduction.new(Vector2i(0, 4), CELL_ISLAND, "island_snug (1, 4)"),
+		FastDeduction.new(Vector2i(1, 3), CELL_ISLAND, "island_snug (1, 4)"),
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
 func test_enqueue_island_dividers() -> void:
 	grid = [
 		" .   3",
@@ -22,50 +83,6 @@ func test_enqueue_islands_island_expansion_1() -> void:
 		FastDeduction.new(Vector2i(1, 0), CELL_ISLAND, "island_expansion (0, 0)"),
 	]
 	assert_deduction(solver.enqueue_islands, expected)
-
-
-func test_enqueue_islands_island_expansion_2() -> void:
-	grid = [
-		"   4  ",
-		"####  ",
-		"      ",
-	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(2, 0), CELL_ISLAND, "island_expansion (1, 0)"),
-		FastDeduction.new(Vector2i(2, 1), CELL_ISLAND, "island_chokepoint (1, 0)"),
-	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
-
-
-func test_enqueue_islands_island_chokepoint_1() -> void:
-	grid = [
-		"   2####",
-		"       5",
-		"        ",
-	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "island_buffer (3, 1)"),
-		FastDeduction.new(Vector2i(1, 2), CELL_ISLAND, "island_chokepoint (3, 1)"),
-		FastDeduction.new(Vector2i(2, 2), CELL_ISLAND, "island_chokepoint (3, 1)"),
-	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
-
-
-func test_enqueue_islands_island_chokepoint_snug() -> void:
-	grid = [
-		" . .  ",
-		" 5##  ",
-		"  ####",
-		"    ##",
-		"   . 5",
-	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(0, 2), CELL_WALL, "island_buffer (1, 4)"),
-		FastDeduction.new(Vector2i(0, 3), CELL_ISLAND, "island_snug (1, 4)"),
-		FastDeduction.new(Vector2i(0, 4), CELL_ISLAND, "island_snug (1, 4)"),
-		FastDeduction.new(Vector2i(1, 3), CELL_ISLAND, "island_snug (1, 4)"),
-	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_islands_island_expansion_and_moat() -> void:


### PR DESCRIPTION
For cases where removing a chokepoint allowed a child node to remain connected to the dfs root through a back reference, the tarjan chokepoint map would return an incorrect value as though the child was disconnected.

The chokepoint map now handles this case correctly.