### PR TITLE
Added wall chokepoint logic.

### DIFF
--- a/project/src/demo/nurikabe/fast/demo_fast_solver.tscn
+++ b/project/src/demo/nurikabe/fast/demo_fast_solver.tscn
@@ -6,7 +6,7 @@
 
 [node name="Demo" type="Node"]
 script = ExtResource("1_hjsai")
-puzzle_path = "res://assets/demo/nurikabe/puzzles/puzzle_nikoli_1_041.txt"
+puzzle_path = "res://assets/demo/nurikabe/puzzles/puzzle_nikoli_1_061.txt"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 anchors_preset = 15
@@ -35,24 +35,24 @@ grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 6
 size_flags_vertical = 4
-grid_string = "                   4
-           4        
+grid_string = " 2           7      
+       1       8    
+                  12
+                    
+           3        
+ 7                  
+   4                
                     
                     
-             6      
- 6             6    
+11                  
+   7   8            
                     
-                 2  
+           3        
+                 1  
                     
- 4               4  
-     2       6      
-         8          
-     2              
-           2        
- 4             4   2
-     2       4      
-                   8
-       6            
+       2         3  
+             4      
+                 1  
 "
 
 [node name="TileMapGround" parent="HBoxContainer/GameBoardHolder/GameBoard" index="0"]
@@ -60,26 +60,23 @@ tile_map_data = PackedByteArray("AAAAAAAAAAAAAAAAAAABAAAAAQAAAAAAAAACAAAAAAAAAAA
 
 [node name="TileMapClue" parent="HBoxContainer/GameBoardHolder/GameBoard" index="3"]
 clues_by_cell = Dictionary[Vector2i, int]({
-Vector2i(0, 5): 6,
-Vector2i(0, 9): 4,
-Vector2i(0, 14): 4,
-Vector2i(2, 10): 2,
-Vector2i(2, 12): 2,
-Vector2i(2, 15): 2,
-Vector2i(3, 17): 6,
-Vector2i(4, 11): 8,
-Vector2i(5, 1): 4,
-Vector2i(5, 13): 2,
-Vector2i(6, 4): 6,
-Vector2i(6, 10): 6,
-Vector2i(6, 15): 4,
-Vector2i(7, 5): 6,
-Vector2i(7, 14): 4,
-Vector2i(8, 7): 2,
-Vector2i(8, 9): 4,
-Vector2i(9, 0): 4,
-Vector2i(9, 14): 2,
-Vector2i(9, 16): 8
+Vector2i(0, 0): 2,
+Vector2i(0, 5): 7,
+Vector2i(0, 9): 11,
+Vector2i(1, 6): 4,
+Vector2i(1, 10): 7,
+Vector2i(3, 1): 1,
+Vector2i(3, 10): 8,
+Vector2i(3, 15): 2,
+Vector2i(5, 4): 3,
+Vector2i(5, 12): 3,
+Vector2i(6, 0): 7,
+Vector2i(6, 16): 4,
+Vector2i(7, 1): 8,
+Vector2i(8, 13): 1,
+Vector2i(8, 15): 3,
+Vector2i(8, 17): 1,
+Vector2i(9, 2): 12
 })
 
 [node name="CursorableArea" parent="HBoxContainer/GameBoardHolder/GameBoard" index="5"]

--- a/project/src/main/nurikabe/fast/fast_board.gd
+++ b/project/src/main/nurikabe/fast/fast_board.gd
@@ -69,6 +69,12 @@ func get_island_chokepoint_map() -> FastChokepointMap:
 		_build_island_chokepoint_map)
 
 
+func get_wall_chokepoint_map() -> FastChokepointMap:
+	return _get_cached(
+		"wall_chokepoint_map",
+		_build_wall_chokepoint_map)
+
+
 func get_per_clue_chokepoint_map() -> PerClueChokepointMap:
 	return _get_cached(
 		"per_clue_chokepoint_map",
@@ -204,6 +210,14 @@ func _build_island_group_map() -> FastGroupMap:
 func _build_island_chokepoint_map() -> FastChokepointMap:
 	return FastChokepointMap.new(self, func(value: String) -> bool:
 		return value.is_valid_int() or value in [CELL_EMPTY, CELL_ISLAND])
+
+
+func _build_wall_chokepoint_map() -> FastChokepointMap:
+	return FastChokepointMap.new(self,
+		func(value: String) -> bool:
+			return value in [CELL_EMPTY, CELL_WALL],
+		func(cell: Vector2i) -> bool:
+			return get_cell_string(cell) == CELL_WALL)
 
 
 func _build_per_clue_chokepoint_map() -> PerClueChokepointMap:

--- a/project/src/main/nurikabe/fast/fast_chokepoint_map.gd
+++ b/project/src/main/nurikabe/fast/fast_chokepoint_map.gd
@@ -11,11 +11,13 @@ var chokepoints_by_cell: Dictionary[Vector2i, bool]:
 
 var _board: FastBoard
 var _cell_filter: Callable
+var _special_cell_filter: Callable
 var _chokepoint_map: ChokepointMap
 
-func _init(init_board: FastBoard, init_cell_filter: Callable) -> void:
+func _init(init_board: FastBoard, init_cell_filter: Callable, init_special_cell_filter: Callable = Callable()) -> void:
 	_board = init_board
 	_cell_filter = init_cell_filter
+	_special_cell_filter = init_special_cell_filter
 
 
 func get_component_cell_count(cell: Vector2i) -> int:
@@ -30,10 +32,22 @@ func get_component_cells(cell: Vector2i) -> Array[Vector2i]:
 	return _chokepoint_map.get_component_cells(cell)
 
 
+func get_component_special_count(cell: Vector2i) -> int:
+	if _chokepoint_map == null:
+		_build_chokepoint_map()
+	return _chokepoint_map.get_component_special_count(cell)
+
+
 func get_unchoked_cell_count(chokepoint: Vector2i, cell: Vector2i) -> int:
 	if _chokepoint_map == null:
 		_build_chokepoint_map()
 	return _chokepoint_map.get_unchoked_cell_count(chokepoint, cell)
+
+
+func get_unchoked_special_count(chokepoint: Vector2i, cell: Vector2i) -> int:
+	if _chokepoint_map == null:
+		_build_chokepoint_map()
+	return _chokepoint_map.get_unchoked_special_count(chokepoint, cell)
 
 
 func _build_chokepoint_map() -> void:
@@ -41,4 +55,4 @@ func _build_chokepoint_map() -> void:
 	for cell: Vector2i in _board.cells:
 		if _cell_filter.call(_board.get_cell_string(cell)):
 			cells.append(cell)
-	_chokepoint_map = ChokepointMap.new(cells)
+	_chokepoint_map = ChokepointMap.new(cells, _special_cell_filter)

--- a/project/src/test/nurikabe/fast/test_fast_chokepoint_map.gd
+++ b/project/src/test/nurikabe/fast/test_fast_chokepoint_map.gd
@@ -125,10 +125,34 @@ func test_component_cells_two_clues() -> void:
 	assert_component_cells(chokepoint_map, Vector2(2, 0), [Vector2i(2, 0), Vector2i(2, 1)])
 
 
+func test_special_cell_count_1() -> void:
+	grid = [
+		" 3##  ",
+		"     3",
+		"####  ",
+	]
+	var chokepoint_map: FastChokepointMap = _build_wall_chokepoint_map()
+	assert_eq(chokepoint_map.get_unchoked_special_count(Vector2i(1, 1), Vector2i(0, 1)), 2)
+	assert_eq(chokepoint_map.get_unchoked_special_count(Vector2i(1, 1), Vector2i(0, 2)), 2)
+	assert_eq(chokepoint_map.get_unchoked_special_count(Vector2i(1, 1), Vector2i(1, 0)), 1)
+	assert_eq(chokepoint_map.get_unchoked_special_count(Vector2i(1, 1), Vector2i(1, 2)), 2)
+	assert_eq(chokepoint_map.get_unchoked_special_count(Vector2i(1, 1), Vector2i(2, 0)), 1)
+	assert_eq(chokepoint_map.get_unchoked_special_count(Vector2i(1, 1), Vector2i(2, 2)), 2)
+
+
 func _build_island_chokepoint_map() -> FastChokepointMap:
 	var board: FastBoard = FastTestUtils.init_board(grid)
 	return FastChokepointMap.new(board, func(value: String) -> bool:
 		return value.is_valid_int() or value in [CELL_EMPTY, CELL_ISLAND])
+
+
+func _build_wall_chokepoint_map() -> FastChokepointMap:
+	var board: FastBoard = FastTestUtils.init_board(grid)
+	return FastChokepointMap.new(board,
+		func(value: String) -> bool:
+			return value in [CELL_EMPTY, CELL_WALL],
+		func(cell: Vector2i) -> bool:
+			return board.get_cell_string(cell) == CELL_WALL)
 
 
 func assert_chokepoints(chokepoint_map: FastChokepointMap,

--- a/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
@@ -203,6 +203,18 @@ func test_enqueue_unreachable_squares_wall_bubble() -> void:
 	assert_deduction(solver.enqueue_unreachable_squares, expected)
 
 
+func test_enqueue_wall_chokepoints() -> void:
+	grid = [
+		" 3##  ",
+		"     3",
+		"####  ",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "wall_connector (1, 0)"),
+	]
+	assert_deduction(solver.enqueue_wall_chokepoints, expected)
+
+
 func test_enqueue_walls_pool_triplet_1() -> void:
 	grid = [
 		" 4    ",


### PR DESCRIPTION
Detecting clue chokepoints required our chokepoint map to answer questions about size. Detecting wall checkpoints required our chokepoint map to answer questions about walls. That information is embedded in the basic chokepoint map as 'special cells'. This is generic, so it could potentially be used in the future to answer questions like 'does this branch of the DFS tree contain a clue cell' or something like that.