### PR TITLE
Corner islands. Remove extra calls. Syntactic sugar.

### DIFF
--- a/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
@@ -73,6 +73,18 @@ func test_enqueue_island_dividers() -> void:
 	assert_deduction(solver.enqueue_island_dividers, expected)
 
 
+func test_enqueue_islands_corner_island() -> void:
+	# The cell at (1, 1) can't be an island or it would block the 2 island from growing.
+	grid = [
+		" 2  ####",
+		"    ## 1",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "corner_island (0, 0)"),
+	]
+	assert_deduction(solver.enqueue_islands, expected)
+
+
 func test_enqueue_islands_island_expansion_1() -> void:
 	grid = [
 		" 4    ",


### PR DESCRIPTION
Added 'corner island' logic -- if an island can only expand two ways, any shared liberties must be walls.

Fixed frivolous tasks: deduce_island_chokepoint for non-empty cells, deduce_wall_chokepoint for non-empty cells, deduce_clue_chokepoint for completed islands.

Syntactic sugar: FastSolver now consistently checks 'liberties is empty' for walls/islands. This could probably be exposed as a method on FastBoard, since people often want to know 'is this island complete'.