### PR TITLE
Bugs: start time NPE, chokepoint performance

### DIFF
--- a/project/src/main/nurikabe/fast/fast_solver.gd
+++ b/project/src/main/nurikabe/fast/fast_solver.gd
@@ -650,7 +650,7 @@ func run_bifurcation_step() -> void:
 	elif not _bifurcation_engine.is_queue_empty():
 		schedule_task(run_bifurcation_step, 10)
 	
-	if _bifurcation_engine.is_queue_empty():
+	if _bifurcation_engine.is_queue_empty() and metrics.has("bifurcation_start_time"):
 		var bifurcation_duration: int = (Time.get_ticks_usec() - metrics["bifurcation_start_time"])
 		metrics.erase("bifurcation_start_time")
 		

--- a/project/src/main/nurikabe/fast/per_clue_chokepoint_map.gd
+++ b/project/src/main/nurikabe/fast/per_clue_chokepoint_map.gd
@@ -133,7 +133,8 @@ func _init_chokepoint_map(island_cell: Vector2i) -> void:
 				continue
 			
 			reach_score_by_cell[neighbor] = reach_score_by_cell[cell] - 1
-			queue.append(neighbor)
+			if reach_score_by_cell[neighbor] > 1:
+				queue.append(neighbor)
 	
 	_chokepoint_map_by_clue[island.front()] = ChokepointMap.new(reach_score_by_cell.keys())
 


### PR DESCRIPTION
Fixed error when bifurcating without calling schedule_tasks to schedule the bifurcation tasks. This occured during gut tests.

Fixed unnecessary BFS recursion in chokepoint map. The chokepoint map was traversing the entire puzzle, essentially deducing "There's a chokepoint across the board for this '2' clue... but it's so far away, that the 2 can be fulfilled, even if the chokepoint is set." It now, instad, stops traversing the tree early and does not treat it as a chokepoint.

This chokepoint tweak improves Nikoli #71 performance by about 30% (13060 ms -> 9730 ms)