### PR TITLE
Added long island deduction. Bumps performance by 40%.

### DIFF
--- a/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
@@ -76,6 +76,114 @@ func test_enqueue_island_chokepoints_snug() -> void:
 	assert_deduction(solver.enqueue_island_chokepoints, expected)
 
 
+func test_enqueue_island_chokepoints_long() -> void:
+	grid = [
+		"    ####",
+		" 2  ## .",
+		"       .",
+		"        ",
+		" 6      ",
+		"       5",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(3, 3), CELL_ISLAND, "long_island (3, 5)"),
+		FastDeduction.new(Vector2i(3, 4), CELL_ISLAND, "long_island (3, 5)"),
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
+func test_enqueue_island_chokepoints_long_2() -> void:
+	grid = [
+		"    ####",
+		" 2  ## .",
+		"       .",
+		"        ",
+		" 5      ",
+		"       .",
+		"     7 .",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(3, 3), CELL_ISLAND, "long_island (3, 5)"),
+		FastDeduction.new(Vector2i(3, 4), CELL_ISLAND, "long_island (3, 5)"),
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
+func test_enqueue_island_chokepoints_long_3() -> void:
+	grid = [
+		"  ##  ",
+		"   .  ",
+		"      ",
+		"      ",
+		"      ",
+		"      ",
+		"      ",
+		"   7  ",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(1, 2), CELL_ISLAND, "long_island (1, 7)"),
+		FastDeduction.new(Vector2i(1, 3), CELL_ISLAND, "long_island (1, 7)"),
+		FastDeduction.new(Vector2i(1, 4), CELL_ISLAND, "long_island (1, 7)"),
+		FastDeduction.new(Vector2i(1, 5), CELL_ISLAND, "long_island (1, 7)"),
+		FastDeduction.new(Vector2i(1, 6), CELL_ISLAND, "long_island (1, 7)"),
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
+func test_enqueue_island_chokepoints_long_4() -> void:
+	grid = [
+		"  ##  ",
+		"   .  ",
+		"      ",
+		"      ",
+		"      ",
+		"      ",
+		"      ",
+		"   8  ",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(1, 2), CELL_ISLAND, "long_island (1, 7)"),
+		FastDeduction.new(Vector2i(1, 3), CELL_ISLAND, "long_island (1, 7)"),
+		FastDeduction.new(Vector2i(1, 4), CELL_ISLAND, "long_island (1, 7)"),
+		FastDeduction.new(Vector2i(1, 5), CELL_ISLAND, "long_island (1, 7)"),
+		FastDeduction.new(Vector2i(1, 6), CELL_ISLAND, "long_island (1, 7)"),
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
+func test_enqueue_island_chokepoints_long_invalid_too_short() -> void:
+	# the long island deduction can't apply to clues which are too close; they could swerve
+	grid = [
+		"  ##  ",
+		"   .  ",
+		"      ",
+		"      ",
+		"      ",
+		"      ",
+		"      ",
+		"   9  ",
+	]
+	var expected: Array[FastDeduction] = [
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
+func test_enqueue_island_chokepoints_long_invalid_bendy() -> void:
+	# the long island deduction can't apply to diagonal clues
+	grid = [
+		"    ####",
+		" 2  ## .",
+		"       .",
+		"        ",
+		" 7      ",
+		"       .",
+		"     5 .",
+	]
+	var expected: Array[FastDeduction] = [
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
 func test_enqueue_island_dividers() -> void:
 	grid = [
 		" .   3",

--- a/project/src/test/nurikabe/fast/test_per_clue_chokepoint_map.gd
+++ b/project/src/test/nurikabe/fast/test_per_clue_chokepoint_map.gd
@@ -64,6 +64,20 @@ func test_snug_cells() -> void:
 	})
 
 
+func test_get_reachable_clues_by_cell() -> void:
+	grid = [
+		"    ####",
+		" 2  ## .",
+		"       .",
+		"        ",
+		" 6      ",
+		"       5",
+	]
+	var pccm: PerClueChokepointMap = init_per_clue_chokepoint_map()
+	var reachable_clues_by_cell: Dictionary[Vector2i, Dictionary] = pccm.get_reachable_clues_by_cell()
+	assert_eq([Vector2i(3, 5)], reachable_clues_by_cell.get(Vector2i(3, 1), {} as Dictionary[Vector2i, bool]).keys())
+
+
 func assert_chokepoint_cells(island_cell: Vector2i, expected: Dictionary[Vector2i, String]) -> void:
 	var pccm: PerClueChokepointMap = init_per_clue_chokepoint_map()
 	var actual: Dictionary[Vector2i, String] = pccm.find_chokepoint_cells(island_cell)


### PR DESCRIPTION
This new 'long island deduction' is featured in Nikoli #71, and occurs when a clue is really far away from an unclued island. If it's the only clue that can reach the island, and it's in a straight vertical/horizontal line, we can deduce that all the cells in that line are islands.

This improves Nikoli #71 performance by about 40% (10000 ms -> 7300 ms)

Surprisingly, we still need to bifurcate the same amount for Nikoli #71, we just bifurcate later.

before: stops=13, scenarios=306, duration=10186.727
after: stops=13, scenarios=254, duration=7276.637