### PR TITLE
Added wall weaver deduction.

### DIFF
--- a/project/src/main/nurikabe/fast/per_clue_chokepoint_map.gd
+++ b/project/src/main/nurikabe/fast/per_clue_chokepoint_map.gd
@@ -98,6 +98,25 @@ func get_component_cells(island_cell: Vector2i) -> Array[Vector2i]:
 	return get_chokepoint_map(island_cell).get_component_cells(island_cell)
 
 
+## Builds a GroupMap of all wall regions that would exist if this clue's entire reachable island area were filled
+## in.[br]
+## [br]
+## In effect, this "excludes" the clue's component cells by treating them as solid islands, and groups every remaining
+## wall or unreachable empty cell into contiguous wall components.[br]
+## [br]
+## Used to detect whether filling the island could create a split wall.
+func get_wall_exclusion_map(island_cell: Vector2i) -> GroupMap:
+	var component_cell_set: Dictionary[Vector2i, bool] = {}
+	for component_cell in get_component_cells(island_cell):
+		component_cell_set[component_cell] = true
+	var cells: Array[Vector2i] = []
+	for cell: Vector2i in _board.cells:
+		var value: String = _board.get_cell_string(cell)
+		if value == CELL_WALL or (value == CELL_EMPTY and not cell in component_cell_set):
+			cells.append(cell)
+	return GroupMap.new(cells)
+
+
 func _has_chokepoint_map(island_cell: Vector2i) -> bool:
 	var island_root: Vector2i = _board.get_island_root_for_cell(island_cell)
 	return _chokepoint_map_by_clue.has(island_root)

--- a/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
@@ -1,5 +1,34 @@
 extends TestFastSolver
 
+func test_enqueue_island_chokepoints_wall_weaver_1() -> void:
+	grid = [
+		"#### 4 .  ",
+		" 7####    ",
+		" .   .  ##",
+		"      ## 1",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(3, 2), CELL_WALL, "wall_weaver (0, 1)"),
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
+func test_enqueue_island_chokepoints_wall_weaver_2() -> void:
+	grid = [
+		"## 6    ##",
+		"##      ##",
+		"##    ## 4",
+		" 1##     .",
+		"##   3## .",
+		"          ",
+	]
+	var expected: Array[FastDeduction] = [
+		FastDeduction.new(Vector2i(1, 2), CELL_WALL, "wall_weaver (1, 0)"),
+		FastDeduction.new(Vector2i(3, 1), CELL_WALL, "wall_weaver (1, 0)"),
+	]
+	assert_deduction(solver.enqueue_island_chokepoints, expected)
+
+
 func test_enqueue_island_chokepoints_adjacent() -> void:
 	grid = [
 		"   4  ",


### PR DESCRIPTION
Reduces bifurcation count. Improves solution speed by 50% (7700 ms -> 5100 ms)

Before: stops=13, scenarios=254, duration=6423.988
After: stops=10, scenarios=130, duration=3741.715