### PR TITLE
deduce_clue_chokepoint refactoring.

### DIFF
--- a/project/src/main/nurikabe/fast/deduction_batch.gd
+++ b/project/src/main/nurikabe/fast/deduction_batch.gd
@@ -18,3 +18,7 @@ func get_changes() -> Array[Dictionary]:
 func clear() -> void:
 	deductions.clear()
 	cells.clear()
+
+
+func size() -> int:
+	return deductions.size()

--- a/project/src/main/nurikabe/fast/per_clue_chokepoint_map.gd
+++ b/project/src/main/nurikabe/fast/per_clue_chokepoint_map.gd
@@ -78,36 +78,24 @@ func find_chokepoint_cells(island_cell: Vector2i) -> Dictionary[Vector2i, String
 		
 		for neighbor: Vector2i in _board.get_neighbors(chokepoint):
 			# buffer wall between this and other clued islands
-			if _needs_buffer(island_root, neighbor):
+			if needs_buffer(island_root, neighbor):
 				result[neighbor] = CELL_WALL
 		
 		if _board.get_cell_string(chokepoint) == CELL_ISLAND and _board.get_clue_value_for_cell(chokepoint) == 0:
 			# buffer wall for any adjoining unclued islands
 			for liberty_cell in _board.get_liberties(_board.get_island_for_cell(chokepoint)):
-				if _needs_buffer(island_root, liberty_cell):
+				if needs_buffer(island_root, liberty_cell):
 					result[liberty_cell] = CELL_WALL
 	
 	return result
 
 
-## If there is exactly enough space for the island to grow, this method returns the cell changes to complete the
-## island.
-func find_snug_cells(island_cell: Vector2i) -> Dictionary[Vector2i, String]:
-	var result: Dictionary[Vector2i, String] = {}
-	var chokepoint_map: ChokepointMap = get_chokepoint_map(island_cell)
-	var clue_value: int = _board.get_clue_value_for_cell(island_cell)
-	var island_root: Vector2i = _board.get_island_root_for_cell(island_cell)
-	
-	if chokepoint_map.get_component_cell_count(island_cell) == clue_value:
-		var component_cells: Array[Vector2i] = chokepoint_map.get_component_cells(island_cell)
-		for component_cell: Vector2i in component_cells:
-			if _board.get_cell_string(component_cell) == CELL_EMPTY:
-				result[component_cell] = CELL_ISLAND
-			for neighbor: Vector2i in _board.get_neighbors(component_cell):
-				if _needs_buffer(island_root, neighbor):
-					result[neighbor] = CELL_WALL
-	
-	return result
+func get_component_cell_count(island_cell: Vector2i) -> int:
+	return get_chokepoint_map(island_cell).get_component_cell_count(island_cell)
+
+
+func get_component_cells(island_cell: Vector2i) -> Array[Vector2i]:
+	return get_chokepoint_map(island_cell).get_component_cells(island_cell)
 
 
 func _has_chokepoint_map(island_cell: Vector2i) -> bool:
@@ -165,7 +153,7 @@ func _init_reachable_clues_by_cell() -> void:
 			_reachable_clues_by_cell[cell][island.front()] = true
 
 
-func _needs_buffer(island_root: Vector2i, cell: Vector2i) -> bool:
+func needs_buffer(island_root: Vector2i, cell: Vector2i) -> bool:
 	return _claimed_by_clue.has(cell) \
 		and _claimed_by_clue[cell] != island_root \
 		and _board.get_cell_string(cell) == CELL_EMPTY

--- a/project/src/test/nurikabe/fast/test_per_clue_chokepoint_map.gd
+++ b/project/src/test/nurikabe/fast/test_per_clue_chokepoint_map.gd
@@ -48,7 +48,7 @@ func test_chokepoint_cells_clueless_island() -> void:
 	})
 
 
-func test_snug_cells() -> void:
+func test_component_cells() -> void:
 	grid = [
 		" . .  ",
 		" 5##  ",
@@ -56,12 +56,11 @@ func test_snug_cells() -> void:
 		"    ##",
 		"   . 5",
 	]
-	assert_snug_cells(Vector2i(2, 4), {
-		Vector2i(0, 2): CELL_WALL,
-		Vector2i(0, 3): CELL_ISLAND,
-		Vector2i(0, 4): CELL_ISLAND,
-		Vector2i(1, 3): CELL_ISLAND,
-	})
+	assert_component_cells(Vector2i(2, 4), [
+		Vector2i(0, 3), Vector2i(0, 4),
+		Vector2i(1, 3), Vector2i(1, 4),
+		Vector2i(2, 4),
+	])
 
 
 func test_get_reachable_clues_by_cell() -> void:
@@ -84,9 +83,11 @@ func assert_chokepoint_cells(island_cell: Vector2i, expected: Dictionary[Vector2
 	assert_eq(actual, expected)
 
 
-func assert_snug_cells(island_cell: Vector2i, expected: Dictionary[Vector2i, String]) -> void:
+func assert_component_cells(island_cell: Vector2i, expected: Array[Vector2i]) -> void:
 	var pccm: PerClueChokepointMap = init_per_clue_chokepoint_map()
-	var actual: Dictionary[Vector2i, String] = pccm.find_snug_cells(island_cell)
+	var actual: Array[Vector2i] = pccm.get_component_cells(island_cell)
+	actual.sort()
+	expected.sort()
 	assert_eq(actual, expected)
 
 


### PR DESCRIPTION
Extracted deduce_clue_chokepoint_snug, deduce_clue_chokepoint_loose. Rewrote logic for avoiding redundant checks to more simply check, 'are there new deductions'

Replaced PerClueChokepointMap.find_snug_cells() with more reusable methods: get_component_cell_count(), get_component_cells(), needs_buffer().