### PR TITLE
FastDeduction enums. Tests pass in strings.

### DIFF
--- a/project/src/demo/nurikabe/fast/demo_fast_solver.gd
+++ b/project/src/demo/nurikabe/fast/demo_fast_solver.gd
@@ -86,7 +86,7 @@ func step() -> void:
 				push_error("Illegal change: %s == %s" % [cell_pos, solver.board.get_cell_string(cell_pos)])
 		
 		for deduction: FastDeduction in solver.deductions.deductions:
-			_show_message("%s: %s" % [deduction.pos, deduction.reason])
+			_show_message(str(deduction))
 		
 		solver.apply_changes()
 		%GameBoard.set_cell_strings(changes)

--- a/project/src/main/nurikabe/fast/bifurcation_scenario.gd
+++ b/project/src/main/nurikabe/fast/bifurcation_scenario.gd
@@ -20,7 +20,7 @@ func _build() -> void:
 	_initial_validation_result = board.validate()
 	solver.board = board.duplicate()
 	for assumption_cell in assumptions:
-		solver.add_deduction(assumption_cell, assumptions[assumption_cell], "bifurcation")
+		solver.add_deduction(assumption_cell, assumptions[assumption_cell], FastDeduction.Reason.ASSUMPTION)
 	solver.apply_changes()
 	_last_validation_result = solver.board.validate()
 

--- a/project/src/main/nurikabe/fast/deduction_batch.gd
+++ b/project/src/main/nurikabe/fast/deduction_batch.gd
@@ -3,8 +3,10 @@ class_name DeductionBatch
 var deductions: Array[FastDeduction] = []
 var cells: Dictionary[Vector2i, bool]
 
-func add_deduction(pos: Vector2i, value: String, reason: String) -> void:
-	deductions.append(FastDeduction.new(pos, value, reason))
+func add_deduction(pos: Vector2i, value: String,
+		reason: FastDeduction.Reason = FastDeduction.Reason.UNKNOWN,
+		reason_cells: Array[Vector2i] = []) -> void:
+	deductions.append(FastDeduction.new(pos, value, reason, reason_cells))
 	cells[pos] = true
 
 

--- a/project/src/main/nurikabe/fast/fast_deduction.gd
+++ b/project/src/main/nurikabe/fast/fast_deduction.gd
@@ -1,13 +1,49 @@
 class_name FastDeduction
 
+enum Reason {
+	UNKNOWN,
+	
+	# starting techniques
+	ISLAND_OF_ONE, # surround single-square island with walls
+	ADJACENT_CLUES, # wall off a liberty shared between two clues
+	
+	# basic techniques
+	CORNER_ISLAND, # add a wall diagonally from an island with only two liberties
+	ISLAND_BUFFER, # add a wall to preserve space for an island to grow
+	ISLAND_CHOKEPOINT, # expand an island through a narrow passage
+	ISLAND_CONNECTOR, # connect a clueless island to a clued island
+	ISLAND_DIVIDER, # add a wall to keep two islands apart
+	ISLAND_EXPANSION, # expand an island to a cell needed to fulfill its clue
+	ISLAND_MOAT, # seal a completed island with walls
+	ISLAND_SNUG, # fill an island when its reachable space matches its clue
+	LONG_ISLAND, # extend a stretched island along its only viable axis
+	POOL_CHOKEPOINT, # add an island to avoid isolating or trapping a small wall region
+	POOL_TRIPLET, # add an island to avoid a 2x2 wall area
+	UNREACHABLE_CELL, # add a wall where no clue can reach
+	WALL_BUBBLE, # wall in a cell surrounded by walls
+	WALL_CONNECTOR, # connect two walls through a chokepoint
+	WALL_EXPANSION, # expand a wall in the only possible direction
+	WALL_WEAVER, # finish an island in a way which preserves wall connectivity
+	
+	# advanced techniques
+	ASSUMPTION, # unproven assumption made when bifurcating
+	ISLAND_BATTLEGROUND, # bifurcate two clues with adjacent liberties
+	ISLAND_STRANGLE, # bifurcate options for completing an island, walling off impossible ones
+	WALL_STRANGLE, # bifurcate options where extending an island would create a split wall
+}
+
 var pos: Vector2i
 var value: String
-var reason: String
+var reason: Reason
+var reason_cells: Array[Vector2i]
 
-func _init(init_pos: Vector2i, init_value: String, init_reason: String) -> void:
+func _init(init_pos: Vector2i, init_value: String,
+		init_reason: Reason = Reason.UNKNOWN,
+		init_reason_cells: Array[Vector2i] = []) -> void:
 	pos = init_pos
 	value = init_value
 	reason = init_reason
+	reason_cells = init_reason_cells
 
 
 func to_change() -> Dictionary[String, Variant]:
@@ -15,4 +51,5 @@ func to_change() -> Dictionary[String, Variant]:
 
 
 func _to_string() -> String:
-	return "%s->%s (%s)" % [pos, value, reason,]
+	var cells_str: String = "" if reason_cells.is_empty() else " " + " ".join(reason_cells)
+	return "%s->%s %s%s" % [pos, value, Utils.enum_to_snake_case(Reason, reason), cells_str]

--- a/project/src/main/nurikabe/slow/nurikabe_solver.gd
+++ b/project/src/main/nurikabe/slow/nurikabe_solver.gd
@@ -1,7 +1,7 @@
 class_name NurikabeSolver
 
 enum Reason {
-	UNKNOWN_REASON,
+	UNKNOWN,
 	
 	# starting techniques
 	ISLAND_OF_ONE, # surround single-square island with walls
@@ -45,7 +45,7 @@ const CELL_INVALID: String = NurikabeUtils.CELL_INVALID
 const CELL_ISLAND: String = NurikabeUtils.CELL_ISLAND
 const CELL_WALL: String = NurikabeUtils.CELL_WALL
 
-const UNKNOWN_REASON: Reason = Reason.UNKNOWN_REASON
+const UNKNOWN: Reason = Reason.UNKNOWN
 
 ## Starting techniques
 const ISLAND_OF_ONE: Reason = Reason.ISLAND_OF_ONE

--- a/project/src/test/nurikabe/fast/test_fast_solver.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver.gd
@@ -14,12 +14,11 @@ func before_each() -> void:
 	solver.clear()
 
 
-func assert_deduction(callable: Callable, expected: Array[FastDeduction]) -> void:
+func assert_deductions(callable: Callable, expected_str_array: Array[String]) -> void:
 	solver.board = FastTestUtils.init_board(grid)
 	callable.call()
 	solver.run_all_tasks()
 	var actual_str_array: Array[String] = deductions_to_strings(solver.deductions.deductions)
-	var expected_str_array: Array[String] = deductions_to_strings(expected)
 	assert_eq(str(actual_str_array), str(expected_str_array))
 
 

--- a/project/src/test/nurikabe/fast/test_fast_solver_advanced_techniques.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver_advanced_techniques.gd
@@ -12,10 +12,10 @@ func test_enqueue_island_battleground_invalid_board() -> void:
 		" .##   4  ####",
 		"##      ## 1##",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(4, 6), CELL_WALL, "island_battleground (3, 6) (5, 5)"),
+	var expected: Array[String] = [
+		"(4, 6)->## island_battleground (3, 6) (5, 5)",
 	]
-	assert_deduction(solver.enqueue_island_battleground, expected)
+	assert_deductions(solver.enqueue_island_battleground, expected)
 
 
 func test_enqueue_island_battleground() -> void:
@@ -29,10 +29,10 @@ func test_enqueue_island_battleground() -> void:
 		" 1##   4  ####",
 		"##      ## 1##",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(4, 6), CELL_WALL, "island_battleground (3, 6) (5, 5)"),
+	var expected: Array[String] = [
+		"(4, 6)->## island_battleground (3, 6) (5, 5)",
 	]
-	assert_deduction(solver.enqueue_island_battleground, expected)
+	assert_deductions(solver.enqueue_island_battleground, expected)
 
 
 func test_enqueue_island_battleground_unclued() -> void:
@@ -43,9 +43,9 @@ func test_enqueue_island_battleground_unclued() -> void:
 		" .  ",
 		" 7##",
 	]
-	var expected: Array[FastDeduction] = [
+	var expected: Array[String] = [
 	]
-	assert_deduction(solver.enqueue_island_battleground, expected)
+	assert_deductions(solver.enqueue_island_battleground, expected)
 
 
 func test_enqueue_wall_strangle() -> void:
@@ -57,10 +57,10 @@ func test_enqueue_wall_strangle() -> void:
 		"            ",
 		"            ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(3, 1), CELL_WALL, "wall_strangle (1, 1)"),
+	var expected: Array[String] = [
+		"(3, 1)->## wall_strangle (1, 1)",
 	]
-	assert_deduction(solver.enqueue_wall_strangle, expected)
+	assert_deductions(solver.enqueue_wall_strangle, expected)
 
 
 func test_enqueue_wall_strangle_one_wall() -> void:
@@ -68,9 +68,9 @@ func test_enqueue_wall_strangle_one_wall() -> void:
 		" 6 . . .",
 		"  ####  ",
 	]
-	var expected: Array[FastDeduction] = [
+	var expected: Array[String] = [
 	]
-	assert_deduction(solver.enqueue_wall_strangle, expected)
+	assert_deductions(solver.enqueue_wall_strangle, expected)
 
 
 func test_enqueue_island_strangle() -> void:
@@ -79,10 +79,10 @@ func test_enqueue_island_strangle() -> void:
 		" .          ",
 		"     . 4 .  ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 2), CELL_WALL, "island_strangle (2, 2)"),
-		FastDeduction.new(Vector2i(2, 1), CELL_WALL, "island_strangle (2, 2)"),
-		FastDeduction.new(Vector2i(3, 1), CELL_WALL, "island_strangle (2, 2)"),
-		FastDeduction.new(Vector2i(4, 1), CELL_WALL, "island_strangle (2, 2)"),
+	var expected: Array[String] = [
+		"(1, 2)->## island_strangle (2, 2)",
+		"(2, 1)->## island_strangle (2, 2)",
+		"(3, 1)->## island_strangle (2, 2)",
+		"(4, 1)->## island_strangle (2, 2)",
 	]
-	assert_deduction(solver.enqueue_island_strangle, expected)
+	assert_deductions(solver.enqueue_island_strangle, expected)

--- a/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver_basic_techniques.gd
@@ -7,10 +7,10 @@ func test_enqueue_island_chokepoints_wall_weaver_1() -> void:
 		" .   .  ##",
 		"      ## 1",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(3, 2), CELL_WALL, "wall_weaver (0, 1)"),
+	var expected: Array[String] = [
+		"(3, 2)->## wall_weaver (0, 1)",
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_wall_weaver_2() -> void:
@@ -22,11 +22,11 @@ func test_enqueue_island_chokepoints_wall_weaver_2() -> void:
 		"##   3## .",
 		"          ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 2), CELL_WALL, "wall_weaver (1, 0)"),
-		FastDeduction.new(Vector2i(3, 1), CELL_WALL, "wall_weaver (1, 0)"),
+	var expected: Array[String] = [
+		"(1, 2)->## wall_weaver (1, 0)",
+		"(3, 1)->## wall_weaver (1, 0)",
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_wall_weaver_3() -> void:
@@ -39,11 +39,11 @@ func test_enqueue_island_chokepoints_wall_weaver_3() -> void:
 		"## .         .",
 		"############  ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 4), CELL_WALL, "wall_weaver (4, 2)"),
-		FastDeduction.new(Vector2i(2, 3), CELL_WALL, "wall_weaver (4, 2)"),
+	var expected: Array[String] = [
+		"(1, 4)->## wall_weaver (4, 2)",
+		"(2, 3)->## wall_weaver (4, 2)",
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_adjacent() -> void:
@@ -53,11 +53,11 @@ func test_enqueue_island_chokepoints_adjacent() -> void:
 		"      ",
 		" 3    ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(2, 0), CELL_ISLAND, "island_expansion (1, 0)"),
-		FastDeduction.new(Vector2i(2, 1), CELL_ISLAND, "island_chokepoint (1, 0)"),
+	var expected: Array[String] = [
+		"(2, 0)->. island_expansion (1, 0)",
+		"(2, 1)->. island_chokepoint (1, 0)",
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_distant() -> void:
@@ -66,12 +66,12 @@ func test_enqueue_island_chokepoints_distant() -> void:
 		"       5",
 		"        ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "island_buffer (3, 1)"),
-		FastDeduction.new(Vector2i(1, 2), CELL_ISLAND, "island_chokepoint (3, 1)"),
-		FastDeduction.new(Vector2i(2, 2), CELL_ISLAND, "island_chokepoint (3, 1)"),
+	var expected: Array[String] = [
+		"(1, 1)->## island_buffer (3, 1)",
+		"(1, 2)->. island_chokepoint (3, 1)",
+		"(2, 2)->. island_chokepoint (3, 1)",
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_dead_end() -> void:
@@ -82,10 +82,10 @@ func test_enqueue_island_chokepoints_dead_end() -> void:
 		"          ",
 		"          ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 0), CELL_ISLAND, "pool_chokepoint (0, 0)"),
+	var expected: Array[String] = [
+		"(1, 0)->. pool_chokepoint (0, 0)",
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_false_positive() -> void:
@@ -100,9 +100,9 @@ func test_enqueue_island_chokepoints_false_positive() -> void:
 		"        ",
 		"    ##  ",
 	]
-	var expected: Array[FastDeduction] = [
+	var expected: Array[String] = [
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_snug() -> void:
@@ -113,13 +113,13 @@ func test_enqueue_island_chokepoints_snug() -> void:
 		"    ##",
 		"   . 5",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(0, 2), CELL_WALL, "island_buffer (1, 4)"),
-		FastDeduction.new(Vector2i(0, 3), CELL_ISLAND, "island_snug (1, 4)"),
-		FastDeduction.new(Vector2i(0, 4), CELL_ISLAND, "island_snug (1, 4)"),
-		FastDeduction.new(Vector2i(1, 3), CELL_ISLAND, "island_snug (1, 4)"),
+	var expected: Array[String] = [
+		"(0, 2)->## island_buffer (1, 4)",
+		"(0, 3)->. island_snug (1, 4)",
+		"(0, 4)->. island_snug (1, 4)",
+		"(1, 3)->. island_snug (1, 4)",
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_long() -> void:
@@ -131,11 +131,11 @@ func test_enqueue_island_chokepoints_long() -> void:
 		" 6      ",
 		"       5",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(3, 3), CELL_ISLAND, "long_island (3, 5)"),
-		FastDeduction.new(Vector2i(3, 4), CELL_ISLAND, "long_island (3, 5)"),
+	var expected: Array[String] = [
+		"(3, 3)->. long_island (3, 5)",
+		"(3, 4)->. long_island (3, 5)",
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_long_2() -> void:
@@ -148,11 +148,11 @@ func test_enqueue_island_chokepoints_long_2() -> void:
 		"       .",
 		"     7 .",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(3, 3), CELL_ISLAND, "long_island (3, 5)"),
-		FastDeduction.new(Vector2i(3, 4), CELL_ISLAND, "long_island (3, 5)"),
+	var expected: Array[String] = [
+		"(3, 3)->. long_island (3, 5)",
+		"(3, 4)->. long_island (3, 5)",
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_long_3() -> void:
@@ -166,14 +166,14 @@ func test_enqueue_island_chokepoints_long_3() -> void:
 		"      ",
 		"   7  ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 2), CELL_ISLAND, "long_island (1, 7)"),
-		FastDeduction.new(Vector2i(1, 3), CELL_ISLAND, "long_island (1, 7)"),
-		FastDeduction.new(Vector2i(1, 4), CELL_ISLAND, "long_island (1, 7)"),
-		FastDeduction.new(Vector2i(1, 5), CELL_ISLAND, "long_island (1, 7)"),
-		FastDeduction.new(Vector2i(1, 6), CELL_ISLAND, "long_island (1, 7)"),
+	var expected: Array[String] = [
+		"(1, 2)->. long_island (1, 7)",
+		"(1, 3)->. long_island (1, 7)",
+		"(1, 4)->. long_island (1, 7)",
+		"(1, 5)->. long_island (1, 7)",
+		"(1, 6)->. long_island (1, 7)",
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_long_4() -> void:
@@ -187,14 +187,14 @@ func test_enqueue_island_chokepoints_long_4() -> void:
 		"      ",
 		"   8  ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 2), CELL_ISLAND, "long_island (1, 7)"),
-		FastDeduction.new(Vector2i(1, 3), CELL_ISLAND, "long_island (1, 7)"),
-		FastDeduction.new(Vector2i(1, 4), CELL_ISLAND, "long_island (1, 7)"),
-		FastDeduction.new(Vector2i(1, 5), CELL_ISLAND, "long_island (1, 7)"),
-		FastDeduction.new(Vector2i(1, 6), CELL_ISLAND, "long_island (1, 7)"),
+	var expected: Array[String] = [
+		"(1, 2)->. long_island (1, 7)",
+		"(1, 3)->. long_island (1, 7)",
+		"(1, 4)->. long_island (1, 7)",
+		"(1, 5)->. long_island (1, 7)",
+		"(1, 6)->. long_island (1, 7)",
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_long_invalid_too_short() -> void:
@@ -209,9 +209,9 @@ func test_enqueue_island_chokepoints_long_invalid_too_short() -> void:
 		"      ",
 		"   9  ",
 	]
-	var expected: Array[FastDeduction] = [
+	var expected: Array[String] = [
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_chokepoints_long_invalid_bendy() -> void:
@@ -225,9 +225,9 @@ func test_enqueue_island_chokepoints_long_invalid_bendy() -> void:
 		"       .",
 		"     5 .",
 	]
-	var expected: Array[FastDeduction] = [
+	var expected: Array[String] = [
 	]
-	assert_deduction(solver.enqueue_island_chokepoints, expected)
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
 func test_enqueue_island_dividers() -> void:
@@ -236,10 +236,10 @@ func test_enqueue_island_dividers() -> void:
 		" 3    ",
 		"      ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 0), CELL_WALL, "island_divider (0, 0) (2, 0)"),
+	var expected: Array[String] = [
+		"(1, 0)->## island_divider (0, 0) (2, 0)",
 	]
-	assert_deduction(solver.enqueue_island_dividers, expected)
+	assert_deductions(solver.enqueue_island_dividers, expected)
 
 
 func test_enqueue_islands_corner_island() -> void:
@@ -248,10 +248,10 @@ func test_enqueue_islands_corner_island() -> void:
 		" 2  ####",
 		"    ## 1",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "corner_island (0, 0)"),
+	var expected: Array[String] = [
+		"(1, 1)->## corner_island (0, 0)",
 	]
-	assert_deduction(solver.enqueue_islands, expected)
+	assert_deductions(solver.enqueue_islands, expected)
 
 
 func test_enqueue_islands_island_expansion_1() -> void:
@@ -260,10 +260,10 @@ func test_enqueue_islands_island_expansion_1() -> void:
 		"####  ",
 		"      ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 0), CELL_ISLAND, "island_expansion (0, 0)"),
+	var expected: Array[String] = [
+		"(1, 0)->. island_expansion (0, 0)",
 	]
-	assert_deduction(solver.enqueue_islands, expected)
+	assert_deductions(solver.enqueue_islands, expected)
 
 
 func test_enqueue_islands_island_expansion_and_moat() -> void:
@@ -272,12 +272,12 @@ func test_enqueue_islands_island_expansion_and_moat() -> void:
 		"##    ",
 		"      ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 0), CELL_ISLAND, "island_expansion (0, 0)"),
-		FastDeduction.new(Vector2i(2, 0), CELL_WALL, "island_moat (0, 0)"),
-		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "island_moat (0, 0)"),
+	var expected: Array[String] = [
+		"(1, 0)->. island_expansion (0, 0)",
+		"(1, 1)->## island_moat (0, 0)",
+		"(2, 0)->## island_moat (0, 0)",
 	]
-	assert_deduction(solver.enqueue_islands, expected)
+	assert_deductions(solver.enqueue_islands, expected)
 
 
 func test_enqueue_islands_island_connector() -> void:
@@ -286,10 +286,10 @@ func test_enqueue_islands_island_connector() -> void:
 		"##    ",
 		" .    ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 2), CELL_ISLAND, "island_connector (0, 2)"),
+	var expected: Array[String] = [
+		"(1, 2)->. island_connector (0, 2)",
 	]
-	assert_deduction(solver.enqueue_islands, expected)
+	assert_deductions(solver.enqueue_islands, expected)
 
 
 func test_enqueue_islands_island_moat() -> void:
@@ -298,12 +298,12 @@ func test_enqueue_islands_island_moat() -> void:
 		" .    ",
 		"      ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 0), CELL_WALL, "island_moat (0, 0)"),
-		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "island_moat (0, 0)"),
-		FastDeduction.new(Vector2i(0, 2), CELL_WALL, "island_moat (0, 0)"),
+	var expected: Array[String] = [
+		"(0, 2)->## island_moat (0, 0)",
+		"(1, 0)->## island_moat (0, 0)",
+		"(1, 1)->## island_moat (0, 0)",
 	]
-	assert_deduction(solver.enqueue_islands, expected)
+	assert_deductions(solver.enqueue_islands, expected)
 
 
 func test_enqueue_islands_island_snug() -> void:
@@ -311,12 +311,12 @@ func test_enqueue_islands_island_snug() -> void:
 		"   4  ",
 		"####  ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(0, 0), CELL_ISLAND, "island_snug (1, 0)"),
-		FastDeduction.new(Vector2i(2, 0), CELL_ISLAND, "island_snug (1, 0)"),
-		FastDeduction.new(Vector2i(2, 1), CELL_ISLAND, "island_snug (1, 0)"),
+	var expected: Array[String] = [
+		"(0, 0)->. island_snug (1, 0)",
+		"(2, 0)->. island_snug (1, 0)",
+		"(2, 1)->. island_snug (1, 0)",
 	]
-	assert_deduction(solver.enqueue_islands, expected)
+	assert_deductions(solver.enqueue_islands, expected)
 
 
 func test_enqueue_unreachable_squares_1() -> void:
@@ -325,10 +325,10 @@ func test_enqueue_unreachable_squares_1() -> void:
 		"      ",
 		"      ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2(2, 2), CELL_WALL, "unreachable_square (0, 0)"),
+	var expected: Array[String] = [
+		"(2, 2)->## unreachable_cell (0, 0)",
 	]
-	assert_deduction(solver.enqueue_unreachable_squares, expected)
+	assert_deductions(solver.enqueue_unreachable_squares, expected)
 
 
 func test_enqueue_unreachable_squares_2() -> void:
@@ -337,11 +337,11 @@ func test_enqueue_unreachable_squares_2() -> void:
 		" .    ",
 		"      ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2(2, 0), CELL_WALL, "unreachable_square (0, 0)"),
-		FastDeduction.new(Vector2(2, 2), CELL_WALL, "unreachable_square (0, 0)"),
+	var expected: Array[String] = [
+		"(2, 0)->## unreachable_cell (0, 0)",
+		"(2, 2)->## unreachable_cell (0, 0)",
 	]
-	assert_deduction(solver.enqueue_unreachable_squares, expected)
+	assert_deductions(solver.enqueue_unreachable_squares, expected)
 
 
 func test_enqueue_unreachable_squares_3() -> void:
@@ -350,11 +350,11 @@ func test_enqueue_unreachable_squares_3() -> void:
 		"    ## 2",
 		" . 7   .",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2(2, 2), CELL_WALL, "island_divider (0, 2) (3, 1)"),
-		FastDeduction.new(Vector2(3, 0), CELL_WALL, "unreachable_square (3, 1)"),
+	var expected: Array[String] = [
+		"(2, 2)->## island_divider (0, 2) (3, 1)",
+		"(3, 0)->## unreachable_cell (3, 1)",
 	]
-	assert_deduction(solver.enqueue_unreachable_squares, expected)
+	assert_deductions(solver.enqueue_unreachable_squares, expected)
 
 
 func test_enqueue_unreachable_squares_blocked() -> void:
@@ -364,10 +364,10 @@ func test_enqueue_unreachable_squares_blocked() -> void:
 		"     3    ",
 		"         2",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2(4, 0), CELL_WALL, "unreachable_square (4, 2)"),
+	var expected: Array[String] = [
+		"(4, 0)->## unreachable_cell (4, 2)",
 	]
-	assert_deduction(solver.enqueue_unreachable_squares, expected)
+	assert_deductions(solver.enqueue_unreachable_squares, expected)
 
 
 func test_enqueue_unreachable_squares_wall_bubble() -> void:
@@ -377,11 +377,11 @@ func test_enqueue_unreachable_squares_wall_bubble() -> void:
 		"## 1## 2##  ",
 		"  ##  ## 5  ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(0, 3), CELL_WALL, "wall_bubble"),
-		FastDeduction.new(Vector2i(2, 3), CELL_WALL, "wall_bubble"),
+	var expected: Array[String] = [
+		"(0, 3)->## wall_bubble",
+		"(2, 3)->## wall_bubble",
 	]
-	assert_deduction(solver.enqueue_unreachable_squares, expected)
+	assert_deductions(solver.enqueue_unreachable_squares, expected)
 
 
 func test_enqueue_wall_chokepoints() -> void:
@@ -390,10 +390,10 @@ func test_enqueue_wall_chokepoints() -> void:
 		"     3",
 		"####  ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "wall_connector (1, 0)"),
+	var expected: Array[String] = [
+		"(1, 1)->## wall_connector (1, 0)",
 	]
-	assert_deduction(solver.enqueue_wall_chokepoints, expected)
+	assert_deductions(solver.enqueue_wall_chokepoints, expected)
 
 
 func test_enqueue_walls_pool_triplet_1() -> void:
@@ -402,10 +402,10 @@ func test_enqueue_walls_pool_triplet_1() -> void:
 		"    ##",
 		"  ####",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 1), CELL_ISLAND, "pool_triplet (1, 2) (2, 1) (2, 2)"),
+	var expected: Array[String] = [
+		"(1, 1)->. pool_triplet (1, 2) (2, 1) (2, 2)",
 	]
-	assert_deduction(solver.enqueue_walls, expected)
+	assert_deductions(solver.enqueue_walls, expected)
 
 
 func test_pool_triplets_2() -> void:
@@ -414,10 +414,10 @@ func test_pool_triplets_2() -> void:
 		"##  ##",
 		"######",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 1), CELL_ISLAND, "pool_triplet (0, 1) (0, 2) (1, 2)"),
+	var expected: Array[String] = [
+		"(1, 1)->. pool_triplet (0, 1) (0, 2) (1, 2)",
 	]
-	assert_deduction(solver.enqueue_walls, expected)
+	assert_deductions(solver.enqueue_walls, expected)
 
 
 func test_enqueue_walls_pool_triplets_invalid() -> void:
@@ -426,9 +426,9 @@ func test_enqueue_walls_pool_triplets_invalid() -> void:
 		"        ",
 		"  ####  ",
 	]
-	var expected: Array[FastDeduction] = [
+	var expected: Array[String] = [
 	]
-	assert_deduction(solver.enqueue_walls, expected)
+	assert_deductions(solver.enqueue_walls, expected)
 
 
 func test_enqueue_walls_wall_expansion_1() -> void:
@@ -437,7 +437,7 @@ func test_enqueue_walls_wall_expansion_1() -> void:
 		"      ",
 		"    ##",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(0, 1), CELL_WALL, "wall_expansion (0, 0)"),
+	var expected: Array[String] = [
+		"(0, 1)->## wall_expansion (0, 0)",
 	]
-	assert_deduction(solver.enqueue_walls, expected)
+	assert_deductions(solver.enqueue_walls, expected)

--- a/project/src/test/nurikabe/fast/test_fast_solver_starting_techniques.gd
+++ b/project/src/test/nurikabe/fast/test_fast_solver_starting_techniques.gd
@@ -6,13 +6,13 @@ func test_islands_of_one() -> void:
 		"   1  ",
 		"      ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(0, 1), CELL_WALL, "island_of_one (1, 1)"),
-		FastDeduction.new(Vector2i(1, 0), CELL_WALL, "island_of_one (1, 1)"),
-		FastDeduction.new(Vector2i(1, 2), CELL_WALL, "island_of_one (1, 1)"),
-		FastDeduction.new(Vector2i(2, 1), CELL_WALL, "island_of_one (1, 1)"),
+	var expected: Array[String] = [
+		"(0, 1)->## island_of_one (1, 1)",
+		"(1, 0)->## island_of_one (1, 1)",
+		"(1, 2)->## island_of_one (1, 1)",
+		"(2, 1)->## island_of_one (1, 1)",
 	]
-	assert_deduction(solver.enqueue_islands_of_one, expected)
+	assert_deductions(solver.enqueue_islands_of_one, expected)
 
 
 func test_deduce_island_of_one_corners() -> void:
@@ -21,13 +21,13 @@ func test_deduce_island_of_one_corners() -> void:
 		"    ",
 		"   1",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(0, 1), CELL_WALL, "island_of_one (0, 0)"),
-		FastDeduction.new(Vector2i(0, 2), CELL_WALL, "island_of_one (1, 2)"),
-		FastDeduction.new(Vector2i(1, 0), CELL_WALL, "island_of_one (0, 0)"),
-		FastDeduction.new(Vector2i(1, 1), CELL_WALL, "island_of_one (1, 2)"),
+	var expected: Array[String] = [
+		"(0, 1)->## island_of_one (0, 0)",
+		"(0, 2)->## island_of_one (1, 2)",
+		"(1, 0)->## island_of_one (0, 0)",
+		"(1, 1)->## island_of_one (1, 2)",
 	]
-	assert_deduction(solver.enqueue_islands_of_one, expected)
+	assert_deductions(solver.enqueue_islands_of_one, expected)
 
 
 func test_deduce_adjacent_clues_1() -> void:
@@ -36,10 +36,10 @@ func test_deduce_adjacent_clues_1() -> void:
 		"      ",
 		" 2    ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(0, 1), CELL_WALL, "adjacent_clues (0, 0) (0, 2)"),
+	var expected: Array[String] = [
+		"(0, 1)->## adjacent_clues (0, 0) (0, 2)",
 	]
-	assert_deduction(solver.enqueue_adjacent_clues, expected)
+	assert_deductions(solver.enqueue_adjacent_clues, expected)
 
 
 func test_deduce_adjacent_clues_2() -> void:
@@ -48,10 +48,10 @@ func test_deduce_adjacent_clues_2() -> void:
 		"      ",
 		"      ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 0), CELL_WALL, "adjacent_clues (0, 0) (2, 0)"),
+	var expected: Array[String] = [
+		"(1, 0)->## adjacent_clues (0, 0) (2, 0)",
 	]
-	assert_deduction(solver.enqueue_adjacent_clues, expected)
+	assert_deductions(solver.enqueue_adjacent_clues, expected)
 
 
 func test_deduce_diagonal_clues_1() -> void:
@@ -61,11 +61,11 @@ func test_deduce_diagonal_clues_1() -> void:
 		"     2    ",
 		"          ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 2), CELL_WALL, "adjacent_clues (1, 1) (2, 2)"),
-		FastDeduction.new(Vector2i(2, 1), CELL_WALL, "adjacent_clues (2, 2) (1, 1)"),
+	var expected: Array[String] = [
+		"(1, 2)->## adjacent_clues (1, 1) (2, 2)",
+		"(2, 1)->## adjacent_clues (2, 2) (1, 1)",
 	]
-	assert_deduction(solver.enqueue_adjacent_clues, expected)
+	assert_deductions(solver.enqueue_adjacent_clues, expected)
 
 
 func test_deduce_diagonal_clues_2() -> void:
@@ -75,11 +75,11 @@ func test_deduce_diagonal_clues_2() -> void:
 		"     2    ",
 		"          ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(2, 1), CELL_WALL, "adjacent_clues (2, 2) (3, 1)"),
-		FastDeduction.new(Vector2i(3, 2), CELL_WALL, "adjacent_clues (3, 1) (2, 2)"),
+	var expected: Array[String] = [
+		"(2, 1)->## adjacent_clues (2, 2) (3, 1)",
+		"(3, 2)->## adjacent_clues (3, 1) (2, 2)",
 	]
-	assert_deduction(solver.enqueue_adjacent_clues, expected)
+	assert_deductions(solver.enqueue_adjacent_clues, expected)
 
 
 func test_deduce_diagonal_clues_3() -> void:
@@ -89,9 +89,9 @@ func test_deduce_diagonal_clues_3() -> void:
 		"     1     ",
 		"           ",
 	]
-	var expected: Array[FastDeduction] = [
-		FastDeduction.new(Vector2i(1, 2), CELL_WALL, "adjacent_clues (1, 1) (2, 2)"),
-		FastDeduction.new(Vector2i(2, 1), CELL_WALL, "adjacent_clues (2, 2) (1, 1)"),
-		FastDeduction.new(Vector2i(3, 2), CELL_WALL, "adjacent_clues (3, 1) (2, 2)"),
+	var expected: Array[String] = [
+		"(1, 2)->## adjacent_clues (1, 1) (2, 2)",
+		"(2, 1)->## adjacent_clues (2, 2) (1, 1)",
+		"(3, 2)->## adjacent_clues (3, 1) (2, 2)",
 	]
-	assert_deduction(solver.enqueue_adjacent_clues, expected)
+	assert_deductions(solver.enqueue_adjacent_clues, expected)

--- a/project/src/test/nurikabe/slow/test_nurikabe_solver.gd
+++ b/project/src/test/nurikabe/slow/test_nurikabe_solver.gd
@@ -7,7 +7,7 @@ const CELL_INVALID: String = NurikabeUtils.CELL_INVALID
 const CELL_ISLAND: String = NurikabeUtils.CELL_ISLAND
 const CELL_WALL: String = NurikabeUtils.CELL_WALL
 
-const UNKNOWN_REASON: NurikabeSolver.Reason = NurikabeSolver.UNKNOWN_REASON
+const UNKNOWN: NurikabeSolver.Reason = NurikabeSolver.UNKNOWN
 
 ## Starting techniques
 const ISLAND_OF_ONE: NurikabeSolver.Reason = NurikabeSolver.ISLAND_OF_ONE


### PR DESCRIPTION
Added enum for FastDeduction reason, and Vector2i for reasoned cells. Some deductions like the island_chokepoint result in changes which are very far from the reasoned island. However, we still want to be able to follow up with those islands. Having the deductions point to the cells which caused the deduction is helpful for this.

Tests now pass in strings. Constructing them with enums was going to be too verbose, but constructing them in tests with strings is easier anyways.