### PR TITLE
Unclued island divider logic.

### DIFF
--- a/project/src/main/nurikabe/solver/solver.gd
+++ b/project/src/main/nurikabe/solver/solver.gd
@@ -482,13 +482,30 @@ func deduce_unclued_island(island_cell: Vector2i) -> void:
 
 func deduce_island_divider(island_cell: Vector2i) -> void:
 	var liberties: Array[Vector2i] = board.get_liberties(board.get_island_for_cell(island_cell))
+	var clue_value: int = board.get_clue_for_island_cell(island_cell)
 	for liberty: Vector2i in liberties:
 		if not _can_deduce(board, liberty):
 			continue
-		var clued_neighbor_roots: Array[Vector2i] = _find_clued_neighbor_roots(liberty)
-		if clued_neighbor_roots.size() >= 2:
-			add_deduction(liberty, CELL_WALL, ISLAND_DIVIDER,
-					[clued_neighbor_roots[0], clued_neighbor_roots[1]])
+		
+		var visited_island_roots: Dictionary[Vector2i, bool] = {}
+		var total_joined_size: int = 1
+		var total_clues: int = 0
+		
+		for neighbor: Vector2i in board.get_neighbors(liberty):
+			var neighbor_island: Array[Vector2i] = board.get_island_for_cell(neighbor)
+			if neighbor_island.is_empty() or visited_island_roots.has(neighbor_island.front()):
+				continue
+			
+			var neighbor_clue_value: int = board.get_clue_for_island(neighbor_island)
+			total_joined_size += neighbor_island.size()
+			if neighbor_clue_value >= 1:
+				total_clues += 1
+			
+			if total_clues > 1 or total_joined_size > clue_value:
+				add_deduction(liberty, CELL_WALL, ISLAND_DIVIDER,
+						[island_cell, neighbor])
+				break
+			visited_island_roots[neighbor_island.front()] = true
 
 
 func deduce_unreachable_square(cell: Vector2i) -> void:

--- a/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
@@ -242,6 +242,29 @@ func test_enqueue_island_dividers() -> void:
 	assert_deductions(solver.enqueue_island_dividers, expected)
 
 
+func test_enqueue_unclued_island_dividers() -> void:
+	grid = [
+		" .   .",
+		" 3    ",
+		"     3",
+	]
+	var expected: Array[String] = [
+		"(1, 0)->## island_divider (0, 0) (2, 0)",
+	]
+	assert_deductions(solver.enqueue_island_dividers, expected)
+
+
+func test_enqueue_unclued_island_dividers_invalid() -> void:
+	grid = [
+		"      ",
+		"     .",
+		"   . 6",
+	]
+	var expected: Array[String] = [
+	]
+	assert_deductions(solver.enqueue_island_dividers, expected)
+
+
 func test_enqueue_islands_corner_island() -> void:
 	# The cell at (1, 1) can't be an island or it would block the 2 island from growing.
 	grid = [


### PR DESCRIPTION
The old island divider logic only worked for clued islands. We now add walls in cases where merging an unclued island with a clued island invalidates the clue.

Improves solver performance by 53% (47000 ms -> 22000 ms)