### PR TITLE
Replaced long_island deduction with broader unclued_lifeline

### DIFF
--- a/project/src/main/nurikabe/solver/chokepoint_map.gd
+++ b/project/src/main/nurikabe/solver/chokepoint_map.gd
@@ -77,6 +77,21 @@ func get_unchoked_cell_count(chokepoint: Vector2i, cell: Vector2i) -> int:
 	return _internal_get_unchoked_cell_count(chokepoint, cell, _subtree_size_by_cell)
 
 
+func get_distance_map(start_cells: Array[Vector2i]) -> Dictionary[Vector2i, int]:
+	var distance_by_cell: Dictionary[Vector2i, int] = {}
+	var queue: Array[Vector2i] = start_cells.duplicate()
+	for cell: Vector2i in start_cells:
+		distance_by_cell[cell] = 0
+	while not queue.is_empty():
+		var next_cell: Vector2i = queue.pop_front()
+		for neighbor: Vector2i in _neighbors_by_cell.get(next_cell):
+			if distance_by_cell.has(neighbor):
+				continue
+			distance_by_cell[neighbor] = distance_by_cell[next_cell] + 1
+			queue.append(neighbor)
+	return distance_by_cell
+
+
 func _internal_get_unchoked_cell_count(
 		chokepoint: Vector2i, cell: Vector2i, count_by_cell: Dictionary[Vector2i, int],
 		subtract_chokepoint: bool = true) -> int:

--- a/project/src/main/nurikabe/solver/deduction.gd
+++ b/project/src/main/nurikabe/solver/deduction.gd
@@ -16,9 +16,9 @@ enum Reason {
 	ISLAND_EXPANSION, # expand an island to a cell needed to fulfill its clue
 	ISLAND_MOAT, # seal a completed island with walls
 	ISLAND_SNUG, # fill an island when its reachable space matches its clue
-	LONG_ISLAND, # extend a stretched island along its only viable axis
 	POOL_CHOKEPOINT, # add an island to avoid isolating or trapping a small wall region
 	POOL_TRIPLET, # add an island to avoid a 2x2 wall area
+	UNCLUED_LIFELINE, # extend an unclued island towards the only connectable clue
 	UNREACHABLE_CELL, # add a wall where no clue can reach
 	WALL_BUBBLE, # wall in a cell surrounded by walls
 	WALL_CONNECTOR, # connect two walls through a chokepoint

--- a/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
+++ b/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
@@ -42,6 +42,10 @@ func _init(init_board: SolverBoard) -> void:
 				_visitable.erase(liberty)
 
 
+func get_distance_map(island_cell: Vector2i, start_cells: Array[Vector2i]) -> Dictionary[Vector2i, int]:
+	return get_chokepoint_map(island_cell).get_distance_map(start_cells)
+
+
 func get_chokepoint_map(island_cell: Vector2i) -> ChokepointMap:
 	if not _has_chokepoint_map(island_cell):
 		_init_chokepoint_map(island_cell)

--- a/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
@@ -122,7 +122,7 @@ func test_enqueue_island_chokepoints_snug() -> void:
 	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
-func test_enqueue_island_chokepoints_long() -> void:
+func test_enqueue_island_chokepoints_lifeline() -> void:
 	grid = [
 		"    ####",
 		" 2  ## .",
@@ -132,13 +132,13 @@ func test_enqueue_island_chokepoints_long() -> void:
 		"       5",
 	]
 	var expected: Array[String] = [
-		"(3, 3)->. long_island (3, 5)",
-		"(3, 4)->. long_island (3, 5)",
+		"(3, 3)->. unclued_lifeline (3, 5)",
+		"(3, 4)->. unclued_lifeline (3, 5)",
 	]
 	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
-func test_enqueue_island_chokepoints_long_2() -> void:
+func test_enqueue_island_chokepoints_lifeline_2() -> void:
 	grid = [
 		"    ####",
 		" 2  ## .",
@@ -149,13 +149,13 @@ func test_enqueue_island_chokepoints_long_2() -> void:
 		"     7 .",
 	]
 	var expected: Array[String] = [
-		"(3, 3)->. long_island (3, 5)",
-		"(3, 4)->. long_island (3, 5)",
+		"(3, 3)->. unclued_lifeline (3, 5)",
+		"(3, 4)->. unclued_lifeline (3, 5)",
 	]
 	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
-func test_enqueue_island_chokepoints_long_3() -> void:
+func test_enqueue_island_chokepoints_lifeline_3() -> void:
 	grid = [
 		"  ##  ",
 		"   .  ",
@@ -167,16 +167,16 @@ func test_enqueue_island_chokepoints_long_3() -> void:
 		"   7  ",
 	]
 	var expected: Array[String] = [
-		"(1, 2)->. long_island (1, 7)",
-		"(1, 3)->. long_island (1, 7)",
-		"(1, 4)->. long_island (1, 7)",
-		"(1, 5)->. long_island (1, 7)",
-		"(1, 6)->. long_island (1, 7)",
+		"(1, 2)->. unclued_lifeline (1, 7)",
+		"(1, 3)->. unclued_lifeline (1, 7)",
+		"(1, 4)->. unclued_lifeline (1, 7)",
+		"(1, 5)->. unclued_lifeline (1, 7)",
+		"(1, 6)->. unclued_lifeline (1, 7)",
 	]
 	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
-func test_enqueue_island_chokepoints_long_4() -> void:
+func test_enqueue_island_chokepoints_lifeline_4() -> void:
 	grid = [
 		"  ##  ",
 		"   .  ",
@@ -188,17 +188,50 @@ func test_enqueue_island_chokepoints_long_4() -> void:
 		"   8  ",
 	]
 	var expected: Array[String] = [
-		"(1, 2)->. long_island (1, 7)",
-		"(1, 3)->. long_island (1, 7)",
-		"(1, 4)->. long_island (1, 7)",
-		"(1, 5)->. long_island (1, 7)",
-		"(1, 6)->. long_island (1, 7)",
+		"(1, 2)->. unclued_lifeline (1, 7)",
+		"(1, 3)->. unclued_lifeline (1, 7)",
+		"(1, 4)->. unclued_lifeline (1, 7)",
+		"(1, 5)->. unclued_lifeline (1, 7)",
+		"(1, 6)->. unclued_lifeline (1, 7)",
 	]
 	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
-func test_enqueue_island_chokepoints_long_invalid_too_short() -> void:
-	# the long island deduction can't apply to clues which are too close; they could swerve
+func test_enqueue_island_chokepoints_lifeline_5() -> void:
+	grid = [
+		"############",
+		"## .## 6    ",
+		"## 2##      ",
+		"####        ",
+		" .## 6     .",
+		" .######## .",
+		" . 6 . .## .",
+	]
+	var expected: Array[String] = [
+		"(3, 4)->. unclued_lifeline (2, 4)",
+		"(4, 4)->. unclued_lifeline (2, 4)",
+	]
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
+
+
+func test_enqueue_island_chokepoints_lifeline_6() -> void:
+	grid = [
+		"####     4",
+		"## .      ",
+		"## .      ",
+		"## 8     .",
+		"######## .",
+		" 2 .  ## .",
+	]
+	var expected: Array[String] = [
+		"(2, 3)->. unclued_lifeline (1, 1)",
+		"(3, 3)->. unclued_lifeline (1, 1)",
+	]
+	assert_deductions(solver.enqueue_island_chokepoints, expected)
+
+
+func test_enqueue_island_chokepoints_lifeline_invalid_too_short() -> void:
+	# the unclued lifeline deduction can't apply to clues which are too close; they could swerve
 	grid = [
 		"  ##  ",
 		"   .  ",
@@ -214,8 +247,8 @@ func test_enqueue_island_chokepoints_long_invalid_too_short() -> void:
 	assert_deductions(solver.enqueue_island_chokepoints, expected)
 
 
-func test_enqueue_island_chokepoints_long_invalid_bendy() -> void:
-	# the long island deduction can't apply to diagonal clues
+func test_enqueue_island_chokepoints_lifeline_invalid_bendy() -> void:
+	# the unclued lifeline deduction can't apply to diagonal clues
 	grid = [
 		"    ####",
 		" 2  ## .",


### PR DESCRIPTION
The new unclued_lifeline connects unclued islands to clued islands in more cases, including around corners.