### PR TITLE
Solver API improvements: subtree_root_under_chokepoint, filter

### DIFF
--- a/project/src/main/nurikabe/solver/chokepoint_map.gd
+++ b/project/src/main/nurikabe/solver/chokepoint_map.gd
@@ -92,6 +92,19 @@ func get_distance_map(start_cells: Array[Vector2i]) -> Dictionary[Vector2i, int]
 	return distance_by_cell
 
 
+## Returns the topmost ancestor of [param cell] whose parent is [param chokepoint].[br]
+## [br]
+## If cell is not a descendant of chokepoint, returns the DFS root of its component.
+func get_subtree_root_under_chokepoint(chokepoint: Vector2i, cell: Vector2i) -> Vector2i:
+	var curr: Vector2i = cell
+	while _parent_by_cell.has(curr):
+		var next: Vector2i = _parent_by_cell[curr]
+		if next == chokepoint:
+			break
+		curr = next
+	return curr
+
+
 func _internal_get_unchoked_cell_count(
 		chokepoint: Vector2i, cell: Vector2i, count_by_cell: Dictionary[Vector2i, int],
 		subtract_chokepoint: bool = true) -> int:
@@ -111,7 +124,7 @@ func _internal_get_unchoked_cell_count(
 			# Return the size of the cell component.
 			result = count_by_cell[cell_root]
 	else:
-		var branch_root: Vector2i = _find_subtree_root_under_chokepoint(chokepoint, cell)
+		var branch_root: Vector2i = get_subtree_root_under_chokepoint(chokepoint, cell)
 		if _parent_by_cell.get(branch_root) == chokepoint:
 			# Cell is a descendant of the chokepoint.
 			if _lowest_index_by_cell[branch_root] >= _discovery_time_by_cell[chokepoint]:
@@ -191,16 +204,3 @@ func _perform_dfs(cell: Vector2i) -> void:
 	
 	_subtree_size_by_cell[cell] = subtree_size
 	_subtree_special_count_by_cell[cell] = subtree_special_count
-
-
-## Returns the topmost ancestor of [param cell] whose parent is [param chokepoint].[br]
-## [br]
-## If cell is not a descendant of chokepoint, returns the DFS root of its component.
-func _find_subtree_root_under_chokepoint(chokepoint: Vector2i, cell: Vector2i) -> Vector2i:
-	var curr: Vector2i = cell
-	while _parent_by_cell.has(curr):
-		var next: Vector2i = _parent_by_cell[curr]
-		if next == chokepoint:
-			break
-		curr = next
-	return curr

--- a/project/src/main/nurikabe/solver/solver_board.gd
+++ b/project/src/main/nurikabe/solver/solver_board.gd
@@ -255,8 +255,12 @@ func _build_island_group_map() -> SolverGroupMap:
 
 
 func _build_island_chokepoint_map() -> SolverChokepointMap:
-	return SolverChokepointMap.new(self, func(value: String) -> bool:
-		return value.is_valid_int() or value in [CELL_EMPTY, CELL_ISLAND])
+	return SolverChokepointMap.new(self,
+		func(cell: Vector2i) -> bool:
+			var value: String = get_cell_string(cell)
+			return value.is_valid_int() or value in [CELL_EMPTY, CELL_ISLAND],
+		func(cell: Vector2i) -> bool:
+			return get_cell_string(cell).is_valid_int())
 
 
 func _build_strict_validation_result() -> ValidationResult:
@@ -339,7 +343,8 @@ func _build_validation_result() -> ValidationResult:
 
 func _build_wall_chokepoint_map() -> SolverChokepointMap:
 	return SolverChokepointMap.new(self,
-		func(value: String) -> bool:
+		func(cell: Vector2i) -> bool:
+			var value: String = get_cell_string(cell)
 			return value in [CELL_EMPTY, CELL_WALL],
 		func(cell: Vector2i) -> bool:
 			return get_cell_string(cell) == CELL_WALL)

--- a/project/src/main/nurikabe/solver/solver_chokepoint_map.gd
+++ b/project/src/main/nurikabe/solver/solver_chokepoint_map.gd
@@ -51,6 +51,12 @@ func get_subtree_root(cell: Vector2i) -> Vector2i:
 	return _chokepoint_map.get_subtree_root(cell)
 
 
+func get_subtree_root_under_chokepoint(chokepoint: Vector2i, cell: Vector2i) -> Vector2i:
+	if _chokepoint_map == null:
+		_build_chokepoint_map()
+	return _chokepoint_map.get_subtree_root_under_chokepoint(chokepoint, cell)
+
+
 func get_unchoked_cell_count(chokepoint: Vector2i, cell: Vector2i) -> int:
 	if _chokepoint_map == null:
 		_build_chokepoint_map()
@@ -66,6 +72,6 @@ func get_unchoked_special_count(chokepoint: Vector2i, cell: Vector2i) -> int:
 func _build_chokepoint_map() -> void:
 	var cells: Array[Vector2i] = []
 	for cell: Vector2i in _board.cells:
-		if _cell_filter.call(_board.get_cell_string(cell)):
+		if _cell_filter.call(cell):
 			cells.append(cell)
 	_chokepoint_map = ChokepointMap.new(cells, _special_cell_filter)

--- a/project/src/test/nurikabe/solver/test_solver_chokepoint_map.gd
+++ b/project/src/test/nurikabe/solver/test_solver_chokepoint_map.gd
@@ -142,14 +142,17 @@ func test_special_cell_count_1() -> void:
 
 func _build_island_chokepoint_map() -> SolverChokepointMap:
 	var board: SolverBoard = SolverTestUtils.init_board(grid)
-	return SolverChokepointMap.new(board, func(value: String) -> bool:
-		return value.is_valid_int() or value in [CELL_EMPTY, CELL_ISLAND])
+	return SolverChokepointMap.new(board,
+		func(cell: Vector2i) -> bool:
+			var value: String = board.get_cell_string(cell)
+			return value.is_valid_int() or value in [CELL_EMPTY, CELL_ISLAND])
 
 
 func _build_wall_chokepoint_map() -> SolverChokepointMap:
 	var board: SolverBoard = SolverTestUtils.init_board(grid)
 	return SolverChokepointMap.new(board,
-		func(value: String) -> bool:
+		func(cell: Vector2i) -> bool:
+			var value: String = board.get_cell_string(cell)
 			return value in [CELL_EMPTY, CELL_WALL],
 		func(cell: Vector2i) -> bool:
 			return board.get_cell_string(cell) == CELL_WALL)


### PR DESCRIPTION
Exposed get_subtree_root_under_chokepoint(). Some algorithms might want to determine whether different cells belong to the same choked component.

Changed SolverChokepointMap to use a cell-based filter, not a value-based filter. Some algorithms might want to exclude or include cells based on their position, not their value.