### PR TITLE
Fixed PerClueChokepointMap liberty bugs

### DIFF
--- a/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
+++ b/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
@@ -39,7 +39,6 @@ func _init(init_board: SolverBoard) -> void:
 			else:
 				_adjacent_clues_by_cell[liberty] = 1
 				_claimed_by_clue[liberty] = island.front()
-				_visitable.erase(liberty)
 
 
 func get_distance_map(island_cell: Vector2i, start_cells: Array[Vector2i]) -> Dictionary[Vector2i, int]:
@@ -136,11 +135,11 @@ func _init_chokepoint_map(island_cell: Vector2i) -> void:
 	for other_island_cell: Vector2i in island:
 		reach_score_by_cell[other_island_cell] = reachability + 1
 	for liberty: Vector2i in _board.get_liberties(island):
-		if reach_score_by_cell.has(liberty):
-			# cell is adjacent to two or more islands, so no islands can reach it
-			reach_score_by_cell[liberty] = 0
-			_adjacent_clues_by_cell[liberty] += 1
+		if not _visitable.has(liberty):
 			continue
+		if _claimed_by_clue.has(liberty) \
+			and _claimed_by_clue[liberty] != island.front():
+				continue
 		reach_score_by_cell[liberty] = reachability
 		queue.append(liberty)
 	
@@ -151,6 +150,9 @@ func _init_chokepoint_map(island_cell: Vector2i) -> void:
 		for neighbor: Vector2i in _board.get_neighbors(cell):
 			if not _visitable.has(neighbor):
 				continue
+			if _claimed_by_clue.has(neighbor) \
+				and _claimed_by_clue[neighbor] != island.front():
+					continue
 			if reach_score_by_cell.has(neighbor):
 				# already visited
 				continue

--- a/project/src/test/nurikabe/solver/test_per_clue_chokepoint_map.gd
+++ b/project/src/test/nurikabe/solver/test_per_clue_chokepoint_map.gd
@@ -63,6 +63,34 @@ func test_component_cells() -> void:
 	])
 
 
+func test_component_cells_neighbors() -> void:
+	grid = [
+		" . .  ",
+		" 5##  ",
+		"  ####",
+		" 5 .##",
+		" .    ",
+	]
+	assert_component_cells(Vector2i(0, 3), [
+		Vector2i(0, 3), Vector2i(0, 4),
+		Vector2i(1, 3), Vector2i(1, 4),
+		Vector2i(2, 4),
+	])
+
+
+func test_component_cells_neighbors_2() -> void:
+	grid = [
+		"##########",
+		" 3## . 4##",
+		" .   .####",
+		"       2  ",
+	]
+	assert_component_cells(Vector2i(2, 1), [
+		Vector2i(2, 1), Vector2i(2, 2),
+		Vector2i(3, 1),
+	])
+
+
 func test_get_reachable_clues_by_cell() -> void:
 	grid = [
 		"    ####",


### PR DESCRIPTION
PerClueChokePointMap was traversing to shared liberties. It would not traverse from clue A to clue B's liberties, but if clue A and clue B shared a liberty, it would initialize its BFS traversal with a shared liberty.