### PR TITLE
Expand repeatedly with SqueezeFill.

### DIFF
--- a/project/src/main/nurikabe/solver/squeeze_fill.gd
+++ b/project/src/main/nurikabe/solver/squeeze_fill.gd
@@ -1,0 +1,69 @@
+class_name SqueezeFill
+## Fills an empty corridor with walls (or islands) until it hits another wall (or island).
+
+const CELL_EMPTY: String = NurikabeUtils.CELL_EMPTY
+const CELL_INVALID: String = NurikabeUtils.CELL_INVALID
+const CELL_ISLAND: String = NurikabeUtils.CELL_ISLAND
+const CELL_WALL: String = NurikabeUtils.CELL_WALL
+
+var changes: Dictionary[Vector2i, String] = {}
+
+var _board: SolverBoard
+var _queue: Array[Vector2i] = []
+var _visited: Dictionary[Vector2i, bool] = {}
+var _step_count: int = 0
+
+func _init(init_board: SolverBoard) -> void:
+	_board = init_board
+
+
+func skip_cells(cells: Array[Vector2i]) -> void:
+	for cell in cells:
+		_visited[cell] = true
+
+
+func push_change(cell: Vector2i, value: String) -> void:
+	changes[cell] = value
+	_visited[cell] = true
+	_queue.push_back(cell)
+
+
+func step() -> void:
+	var next_cell: Vector2i = _queue.pop_front()
+	var next_cell_value: String = get_cell_string(next_cell)
+	
+	var neighbor_match_cells: Array[Vector2i] = []
+	var neighbor_empty_cells: Array[Vector2i] = []
+	for neighbor: Vector2i in _board.get_neighbors(next_cell):
+		var neighbor_value: String = get_cell_string(neighbor)
+		if neighbor_value == CELL_EMPTY:
+			neighbor_empty_cells.append(neighbor)
+		elif neighbor_value == CELL_INVALID:
+			pass
+		elif ((neighbor_value == CELL_WALL) == (next_cell_value == CELL_WALL)):
+			neighbor_match_cells.append(neighbor)
+	
+	var unvisited_neighbor_match: bool = false
+	for neighbor_match_cell: Vector2i in neighbor_match_cells:
+		if not _visited.has(neighbor_match_cell):
+			unvisited_neighbor_match = true
+			break
+	
+	if not unvisited_neighbor_match and neighbor_empty_cells.size() == 1:
+		push_change(neighbor_empty_cells[0], next_cell_value)
+	
+	_step_count += 1
+
+
+func fill(max_steps: int = 999999) -> void:
+	while not _queue.is_empty() and _step_count < max_steps:
+		step()
+
+
+func get_cell_string(cell: Vector2i) -> String:
+	var cell_string: String
+	if changes.has(cell):
+		cell_string = changes[cell]
+	else:
+		cell_string = _board.get_cell_string(cell)
+	return cell_string

--- a/project/src/main/nurikabe/solver/squeeze_fill.gd.uid
+++ b/project/src/main/nurikabe/solver/squeeze_fill.gd.uid
@@ -1,0 +1,1 @@
+uid://bg0wsievs8dv8

--- a/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
@@ -335,6 +335,9 @@ func test_enqueue_islands_island_expansion_1() -> void:
 	]
 	var expected: Array[String] = [
 		"(1, 0)->. island_expansion (0, 0)",
+		"(2, 0)->. island_expansion (0, 0)",
+		"(2, 1)->. island_expansion (0, 0)",
+		"(2, 2)->## island_moat (0, 0)",
 	]
 	assert_deductions(solver.enqueue_islands, expected)
 


### PR DESCRIPTION
The solver had some times where it repeatedly expanded the same clue or wall. For example, it might push a clue out close to a corner, and then expand the wall toward the corner, and then expand the wall into the corner, and then expand the wall out of the corner.

I've repurposed Border Hug's "repeatedly flood fill as long as there's only one option and no matching cells" logic as SqueezeFill. This lets us batch these changes and rebuild the board fewer times.