### PR TITLE
Improve effiency of 'get_clue_for_island'

### DIFF
--- a/project/src/main/nurikabe/solver/global_reachability_map.gd
+++ b/project/src/main/nurikabe/solver/global_reachability_map.gd
@@ -48,15 +48,16 @@ func _build() -> void:
 	
 	# collect visitable cells (empty cells, or clueless islands)
 	var visitable: Dictionary[Vector2i, bool] = {}
+	var island_clues: Dictionary[Vector2i, int] = _board.get_island_clues()
 	for cell: Vector2i in _board.cells:
 		if _board.get_cell(cell) in [CELL_ISLAND, CELL_EMPTY] \
-				and _board.get_clue_for_island_cell(cell) == 0:
+				and island_clues.get(cell, 0) == 0:
 			visitable[cell] = true
 	
 	# seed queue from islands
 	var queue: Array[Vector2i] = []
 	for island: Array[Vector2i] in islands:
-		var clue_value: int = _board.get_clue_for_island(island)
+		var clue_value: int = island_clues.get(island.front(), 0)
 		if clue_value == 0:
 			continue
 		var reachability: int = clue_value - island.size()

--- a/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
+++ b/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
@@ -21,14 +21,15 @@ func _init(init_board: SolverBoard) -> void:
 	var islands: Array[Array] = _board.get_islands()
 	
 	# collect visitable cells (empty cells, or clueless islands)
+	var island_clues: Dictionary[Vector2i, int] = _board.get_island_clues()
 	for cell: Vector2i in _board.cells:
 		if _board.get_cell(cell) in [CELL_ISLAND, CELL_EMPTY] \
-				and _board.get_clue_for_island_cell(cell) == 0:
+				and island_clues.get(cell, 0) == 0:
 			_visitable[cell] = true
 	
 	# seed queue from islands
 	for island: Array[Vector2i] in islands:
-		var clue_value: int = _board.get_clue_for_island(island)
+		var clue_value: int = island_clues.get(island.front(), 0)
 		if clue_value == 0:
 			continue
 		for liberty: Vector2i in _board.get_liberties(island):

--- a/project/src/main/nurikabe/solver/solver.gd
+++ b/project/src/main/nurikabe/solver/solver.gd
@@ -490,7 +490,7 @@ func deduce_unclued_lifeline() -> void:
 		
 		var clue_root: Vector2i = exclusive_clues_by_unclued[unclued_root]
 		var clue: Array[Vector2i] = board.get_island_for_cell(clue_root)
-		var clue_value: int = board.get_clue_for_island(clue)
+		var clue_value: int = board.get_clue_for_island_cell(clue_root)
 		
 		# calculate the minimum distance to the clued and unclued cells
 		var unclued_distance_map: Dictionary[Vector2i, int] \
@@ -532,7 +532,7 @@ func deduce_island_of_one(clue_cell: Vector2i) -> void:
 
 func deduce_clued_island(island_cell: Vector2i) -> void:
 	var island: Array[Vector2i] = board.get_island_for_cell(island_cell)
-	var clue_value: int = board.get_clue_for_island(island)
+	var clue_value: int = board.get_clue_for_island_cell(island_cell)
 	if clue_value < 1:
 		# unclued/invalid group
 		return
@@ -619,7 +619,7 @@ func deduce_corner_buffer(island_cell: Vector2i) -> void:
 
 func deduce_unclued_island(island_cell: Vector2i) -> void:
 	var island: Array[Vector2i] = board.get_island_for_cell(island_cell)
-	var clue_value: int = board.get_clue_for_island(island)
+	var clue_value: int = board.get_clue_for_island_cell(island_cell)
 	if clue_value != 0:
 		# clued/invalid group
 		return
@@ -965,7 +965,7 @@ func get_merged_island_info(island_cells: Array[Vector2i]) -> Dictionary[String,
 		if island.is_empty() or visited_island_roots.has(island.front()):
 			continue
 		result["neighbor_island_cells"].append(island_cell)
-		var neighbor_clue_value: int = board.get_clue_for_island(island)
+		var neighbor_clue_value: int = board.get_clue_for_island_cell(island_cell)
 		result["total_joined_size"] += island.size()
 		if neighbor_clue_value >= 1:
 			result["clue_value"] = max(result["clue_value"], neighbor_clue_value)
@@ -1055,9 +1055,10 @@ func _react_to_changes(changes: Array[Dictionary]) -> void:
 		var island: Array[Vector2i] = board.get_island_for_cell(island_root)
 		if board.get_liberties(island).is_empty():
 			continue
-		if board.get_clue_for_island(island) >= 1:
+		var clue_value: int = board.get_clue_for_island_cell(island_root)
+		if clue_value >= 1:
 			schedule_task(deduce_clued_island.bind(island_root), 350)
-		if board.get_clue_for_island(island) == 0:
+		elif clue_value == 0:
 			schedule_task(deduce_unclued_island.bind(island_root), 350)
 
 


### PR DESCRIPTION
Almost every deduction wanted to get the clue for a cell, so now we cache them all once in 'build_island_clues' instead of caching them for each group like before.