### PR TITLE
Solver metrics, logging.

### DIFF
--- a/project/src/demo/nurikabe/solver/demo_solver.gd
+++ b/project/src/demo/nurikabe/solver/demo_solver.gd
@@ -16,6 +16,12 @@ extends Node
 		puzzle_path = value
 		_refresh_puzzle_path()
 
+@export var log_enabled: bool = false:
+	set(value):
+		log_enabled = value
+		solver.log_enabled = log_enabled
+
+
 const CELL_INVALID: int = NurikabeUtils.CELL_INVALID
 const CELL_ISLAND: int = NurikabeUtils.CELL_ISLAND
 const CELL_WALL: int = NurikabeUtils.CELL_WALL

--- a/project/src/demo/nurikabe/solver/demo_solver.tscn
+++ b/project/src/demo/nurikabe/solver/demo_solver.tscn
@@ -7,6 +7,7 @@
 [node name="Demo" type="Node"]
 script = ExtResource("1_hjsai")
 puzzle_path = "res://assets/demo/nurikabe/puzzles/puzzle_nikoli_1_071.txt"
+log_enabled = true
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 anchors_preset = 15

--- a/project/src/main/nurikabe/solver/bifurcation_engine.gd
+++ b/project/src/main/nurikabe/solver/bifurcation_engine.gd
@@ -6,20 +6,23 @@ func clear() -> void:
 	_scenarios_by_key.clear()
 
 
-func add_scenario(board: SolverBoard,
+func get_scenario_keys() -> Array[String]:
+	return _scenarios_by_key.keys()
+
+
+func add_scenario(board: SolverBoard, key: String, cells: Array[Vector2i],
 		assumptions: Dictionary[Vector2i, int],
 		deductions: Array[Deduction]) -> void:
-	var key: String = "%s -> %s" % [assumptions, deductions]
-	if not _scenarios_by_key.has(key):
-		_scenarios_by_key[key] = BifurcationScenario.new(board, assumptions, deductions)
+	var combo_key: String = _combo_key(key, cells)
+	if not _scenarios_by_key.has(combo_key):
+		_scenarios_by_key[combo_key] = BifurcationScenario.new(board, assumptions, deductions)
 
 
-func step() -> void:
-	for scenario_key: String in _scenarios_by_key:
-		var scenario: BifurcationScenario = _scenarios_by_key[scenario_key]
-		scenario.step()
-		if scenario.is_queue_empty() and not _scenarios_by_key[scenario_key].has_new_contradictions():
-			_scenarios_by_key.erase(scenario_key)
+func step(scenario_key: String) -> void:
+	var scenario: BifurcationScenario = _scenarios_by_key[scenario_key]
+	scenario.step()
+	if scenario.is_queue_empty() and not _scenarios_by_key[scenario_key].has_new_contradictions():
+		_scenarios_by_key.erase(scenario_key)
 
 
 func is_queue_empty() -> bool:
@@ -31,15 +34,18 @@ func get_scenario_count() -> int:
 	return _scenarios_by_key.size()
 
 
-func has_contradictions() -> bool:
+func has_new_contradictions() -> bool:
 	return _scenarios_by_key.values().any(func(scenario: BifurcationScenario) -> bool:
 		return scenario.has_new_contradictions())
 
 
-func get_confirmed_deductions() -> Array[Deduction]:
-	var result: Array[Deduction] = []
-	for scenario_key: String in _scenarios_by_key:
-		var scenario: BifurcationScenario = _scenarios_by_key[scenario_key]
-		if scenario.has_new_contradictions():
-			result.append_array(scenario.deductions)
-	return result
+func scenario_has_new_contradictions(key: String) -> bool:
+	return _scenarios_by_key[key].has_new_contradictions()
+
+
+func get_scenario_deductions(key: String) -> Array[Deduction]:
+	return _scenarios_by_key[key].deductions
+
+
+func _combo_key(key: String, cells: Array[Vector2i] = []) -> String:
+	return key if cells.is_empty() else key + " ".join(cells)

--- a/project/src/main/nurikabe/solver/deduction_batch.gd
+++ b/project/src/main/nurikabe/solver/deduction_batch.gd
@@ -3,6 +3,10 @@ class_name DeductionBatch
 var deductions: Array[Deduction] = []
 var cells: Dictionary[Vector2i, bool]
 
+## Adds a deduction to the batch.[br]
+## [br]
+## Note: It is possible to add multiple redundant deductions to the batch. Allowing for redundant deductions helps us
+## with metrics. For cells which can be deduced many ways, it's good to know which ways work most often.
 func add_deduction(pos: Vector2i, value: int,
 		reason: Deduction.Reason = Deduction.Reason.UNKNOWN,
 		reason_cells: Array[Vector2i] = []) -> void:

--- a/project/src/main/nurikabe/solver/deduction_logger.gd
+++ b/project/src/main/nurikabe/solver/deduction_logger.gd
@@ -1,0 +1,83 @@
+class_name DeductionLogger
+
+const LOG_PATH: String = "user://solver.log"
+
+var solver: Solver
+var deduction_info_by_key: Dictionary[String, Dictionary] = {}
+
+var _log: FileAccess:
+	get():
+		if _log == null:
+			_log = FileAccess.open(LOG_PATH, FileAccess.WRITE)
+		return _log
+
+func _init(init_solver: Solver) -> void:
+	solver = init_solver
+
+
+func start(key: String, cells: Array[Vector2i] = []) -> void:
+	if not solver.log_enabled:
+		return
+	
+	var combo_key: String = _combo_key(key, cells)
+	_start_deduction_timer(combo_key)
+
+
+func pause(key: String, cells: Array[Vector2i] = []) -> void:
+	if not solver.log_enabled:
+		return
+	
+	var combo_key: String = _combo_key(key, cells)
+	_stop_deduction_timer(combo_key)
+
+
+func end(key: String, cells: Array[Vector2i] = []) -> void:
+	if not solver.log_enabled:
+		return
+	
+	var combo_key: String = _combo_key(key, cells)
+	_stop_deduction_timer(combo_key)
+	var deduction_info: Dictionary[String, Variant] = deduction_info_by_key.get(combo_key)
+	_log.store_string("| %s | %s | %s |\n"
+			% [combo_key, deduction_info["time_delta"], deduction_info["deductions_delta"]])
+	_log.flush()
+	_delete_deduction_timer(combo_key)
+
+
+func _combo_key(key: String, cells: Array[Vector2i] = []) -> String:
+	return key if cells.is_empty() else key + " ".join(cells)
+
+
+func _create_deduction_timer(combo_key: String) -> void:
+	deduction_info_by_key[combo_key] = {
+		"active": false,
+		"deductions_delta": 0,
+		"deductions_start": solver.deductions.size(),
+		"time_delta": 0,
+		"time_start": Time.get_ticks_usec(),
+		} as Dictionary[String, Variant]
+
+
+func _start_deduction_timer(combo_key: String) -> void:
+	if not deduction_info_by_key.has(combo_key):
+		_create_deduction_timer(combo_key)
+	var deduction_info: Dictionary[String, Variant] = deduction_info_by_key[combo_key]
+	deduction_info["active"] = true
+	deduction_info["deductions_start"] = solver.deductions.size()
+	deduction_info["time_start"] = Time.get_ticks_usec()
+
+
+func _stop_deduction_timer(combo_key: String) -> void:
+	if not deduction_info_by_key.has(combo_key):
+		_create_deduction_timer(combo_key)
+	var deduction_info: Dictionary[String, Variant] = deduction_info_by_key[combo_key]
+	if deduction_info["active"]:
+		deduction_info["active"] = false
+		deduction_info["time_delta"] += Time.get_ticks_usec() - deduction_info["time_start"]
+		deduction_info["deductions_delta"] += solver.deductions.size() - deduction_info["deductions_start"]
+
+
+func _delete_deduction_timer(combo_key: String) -> void:
+	if not deduction_info_by_key.has(combo_key):
+		return
+	deduction_info_by_key.erase(combo_key)

--- a/project/src/main/nurikabe/solver/deduction_logger.gd.uid
+++ b/project/src/main/nurikabe/solver/deduction_logger.gd.uid
@@ -1,0 +1,1 @@
+uid://rojsbmwkis1d


### PR DESCRIPTION
Solver records how much time each technique took, and how many squares were touched.

Bifurcation engine now uses differently formatted scenario keys, to match the new logged keys.

Added perform_redundant_deductions flag.

Logging can be enabled/disabled via an export property in the demo.