### PR TITLE
Performance tweaks: validate_simple, is_valid_merged_island

### DIFF
--- a/project/src/demo/nurikabe/solver/demo_solver_analysis.tscn
+++ b/project/src/demo/nurikabe/solver/demo_solver_analysis.tscn
@@ -1,6 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://kitiy0xaqb5w"]
+[gd_scene load_steps=2 format=3 uid="uid://dw1fu7e0aqcub"]
 
-[ext_resource type="Script" uid="uid://cw0ysh5ifx1wc" path="res://src/demo/nurikabe/solver/demo_solver_analysis.gd" id="1_ccry3"]
+[ext_resource type="Script" path="res://src/demo/nurikabe/solver/demo_solver_analysis.gd" id="1_ccry3"]
 
 [node name="Demo" type="Node"]
 script = ExtResource("1_ccry3")

--- a/project/src/main/nurikabe/solver/bifurcation_scenario.gd
+++ b/project/src/main/nurikabe/solver/bifurcation_scenario.gd
@@ -17,12 +17,12 @@ func _init(init_board: SolverBoard,
 
 
 func _build() -> void:
-	_initial_validation_result = board.validate()
+	_initial_validation_result = board.validate_simple()
 	solver.board = board.duplicate()
 	for assumption_cell in assumptions:
 		solver.add_deduction(assumption_cell, assumptions[assumption_cell], Deduction.Reason.ASSUMPTION)
 	solver.apply_changes()
-	_last_validation_result = solver.board.validate()
+	_last_validation_result = solver.board.validate_simple()
 
 
 func is_queue_empty() -> bool:
@@ -38,5 +38,5 @@ func step() -> void:
 
 
 func has_new_contradictions() -> bool:
-	_last_validation_result = solver.board.validate()
+	_last_validation_result = solver.board.validate_simple()
 	return _last_validation_result.error_count > _initial_validation_result.error_count


### PR DESCRIPTION
Switched bifurcation from 'validate' to 'validate_simple'. This overlooks a few theoretical contradictions where clues can't grow because they're blocked by other clues, but none of the tests care and the performance tests run fine too.

This 'validate_simple' tweak improves BorderScenario and BifurcationScenario performance by about 46% (4.4s -> 3.1s)

Replaced get_merged_island_info with is_valid_merged_island. This avoids creating and populating a dictionary, and lets the loop exit early if an invalid merge is found.

This 'is_valid_merged_island' tweak improves corner_buffer and island_divider performance by about 16% (200 ms -> 180 ms)