### PR TITLE
Eliminate non-simple validation

### DIFF
--- a/project/src/main/nurikabe/nurikabe_game_board.gd
+++ b/project/src/main/nurikabe/nurikabe_game_board.gd
@@ -310,10 +310,10 @@ func _push_undo_action(player_id: int, cell_positions: Array[Vector2i], values: 
 
 func _on_validate_timer_timeout() -> void:
 	var model: SolverBoard = to_solver_board()
-	var result_simple: SolverBoard.ValidationResult = model.validate_simple()
-	var result_strict: SolverBoard.ValidationResult = model.validate_strict()
+	var validation_result: SolverBoard.ValidationResult = model.validate()
+	var strict_validation_result: SolverBoard.ValidationResult = model.validate_strict()
 	
-	if result_strict.error_count == 0:
+	if strict_validation_result.error_count == 0:
 		puzzle_finished.emit()
 	
 	# update lowlight cells if the player isn't finished
@@ -321,24 +321,24 @@ func _on_validate_timer_timeout() -> void:
 	for cell: Vector2i in model.cells:
 		if NurikabeUtils.is_clue(model.get_cell(cell)) or model.get_cell(cell) in [CELL_EMPTY, CELL_ISLAND]:
 			new_lowlight_cells[cell] = true
-	for joined_island_cell: Vector2i in result_strict.joined_islands:
+	for joined_island_cell: Vector2i in strict_validation_result.joined_islands:
 		new_lowlight_cells.erase(joined_island_cell)
-	for wrong_size_cell: Vector2i in result_strict.wrong_size:
+	for wrong_size_cell: Vector2i in strict_validation_result.wrong_size:
 		new_lowlight_cells.erase(wrong_size_cell)
 	lowlight_cells = new_lowlight_cells
 	
 	# update error cells if the player made a mistake
 	var old_error_cells: Dictionary[Vector2i, bool] = error_cells
 	var new_error_cells: Dictionary[Vector2i, bool] = {}
-	for pool_cell: Vector2i in result_simple.pools:
+	for pool_cell: Vector2i in validation_result.pools:
 		new_error_cells[pool_cell] = true
-	for joined_island_cell: Vector2i in result_simple.joined_islands:
+	for joined_island_cell: Vector2i in validation_result.joined_islands:
 		new_error_cells[joined_island_cell] = true
-	for unclued_island_cell: Vector2i in result_simple.unclued_islands:
+	for unclued_island_cell: Vector2i in validation_result.unclued_islands:
 		new_error_cells[unclued_island_cell] = true
-	for wrong_size_cell: Vector2i in result_simple.wrong_size:
+	for wrong_size_cell: Vector2i in validation_result.wrong_size:
 		new_error_cells[wrong_size_cell] = true
-	for split_wall_cell in result_simple.split_walls:
+	for split_wall_cell in validation_result.split_walls:
 		new_error_cells[split_wall_cell] = true
 	error_cells = new_error_cells
 	

--- a/project/src/main/nurikabe/solver/bifurcation_scenario.gd
+++ b/project/src/main/nurikabe/solver/bifurcation_scenario.gd
@@ -17,12 +17,12 @@ func _init(init_board: SolverBoard,
 
 
 func _build() -> void:
-	_initial_validation_result = board.validate_simple()
+	_initial_validation_result = board.validate()
 	solver.board = board.duplicate()
 	for assumption_cell in assumptions:
 		solver.add_deduction(assumption_cell, assumptions[assumption_cell], Deduction.Reason.ASSUMPTION)
 	solver.apply_changes()
-	_last_validation_result = solver.board.validate_simple()
+	_last_validation_result = solver.board.validate()
 
 
 func is_queue_empty() -> bool:
@@ -38,5 +38,5 @@ func step() -> void:
 
 
 func has_new_contradictions() -> bool:
-	_last_validation_result = solver.board.validate_simple()
+	_last_validation_result = solver.board.validate()
 	return _last_validation_result.error_count > _initial_validation_result.error_count

--- a/project/src/main/nurikabe/solver/solver.gd
+++ b/project/src/main/nurikabe/solver/solver.gd
@@ -1274,7 +1274,7 @@ class BorderScenario:
 		var new_board: SolverBoard = _board.duplicate()
 		for change_cell: Vector2i in _squeeze_fill.changes:
 			new_board.set_cell(change_cell, _squeeze_fill.changes[change_cell])
-		var init_validation_result: SolverBoard.ValidationResult = _board.validate_simple()
-		var validation_result: SolverBoard.ValidationResult = new_board.validate_simple()
+		var init_validation_result: SolverBoard.ValidationResult = _board.validate()
+		var validation_result: SolverBoard.ValidationResult = new_board.validate()
 		
 		return validation_result.error_count > init_validation_result.error_count

--- a/project/src/main/nurikabe/solver/solver_board.gd
+++ b/project/src/main/nurikabe/solver/solver_board.gd
@@ -222,16 +222,11 @@ func surround_island(cell: Vector2i) -> Array[Dictionary]:
 	
 	return changes
 
+
 func validate() -> ValidationResult:
 	return _get_cached(
 		"validation_result",
 		_build_validation_result)
-
-
-func validate_simple() -> ValidationResult:
-	return _get_cached(
-		"simple_validation_result",
-		_build_simple_validation_result)
 
 
 func validate_strict() -> ValidationResult:
@@ -306,15 +301,11 @@ func _build_island_chokepoint_map() -> SolverChokepointMap:
 			return NurikabeUtils.is_clue(get_cell(cell)))
 
 
-func _build_simple_validation_result() -> ValidationResult:
-	return _build_validation_result(true)
-
-
 func _build_strict_validation_result() -> ValidationResult:
 	return get_flooded_board().validate()
 
 
-func _build_validation_result(simple_reach_checks: bool = false) -> ValidationResult:
+func _build_validation_result() -> ValidationResult:
 	var result: ValidationResult = ValidationResult.new()
 	
 	# joined islands
@@ -378,21 +369,13 @@ func _build_validation_result(simple_reach_checks: bool = false) -> ValidationRe
 			result.wrong_size.append_array(island)
 			continue
 		
-		if simple_reach_checks:
-			var group_map: SolverGroupMap = get_flooded_island_group_map()
-			var flooded_island_group: Array[Vector2i] \
-					= group_map.groups_by_cell.get(island_cell, [] as Array[Vector2i])
-			if clue_value > flooded_island_group.size():
-				# island is too small and can't grow
-				result.wrong_size.append_array(island)
-				continue
-		else:
-			var chokepoint_map: ChokepointMap = get_per_clue_chokepoint_map().get_chokepoint_map(island_cell)
-			var island_max_size: int = chokepoint_map.get_component_cells(island_cell).size()
-			if clue_value > island_max_size:
-				# island is too small and can't grow
-				result.wrong_size.append_array(island)
-				continue
+		var group_map: SolverGroupMap = get_flooded_island_group_map()
+		var flooded_island_group: Array[Vector2i] \
+				= group_map.groups_by_cell.get(island_cell, [] as Array[Vector2i])
+		if clue_value > flooded_island_group.size():
+			# island is too small and can't grow
+			result.wrong_size.append_array(island)
+			continue
 	
 	return result
 

--- a/project/src/test/nurikabe/solver/test_solver_board.gd
+++ b/project/src/test/nurikabe/solver/test_solver_board.gd
@@ -197,7 +197,7 @@ func test_wrong_size() -> void:
 		"######",
 	]
 	assert_valid_strict()
-	assert_valid_simple()
+	assert_valid()
 	
 	grid = [
 		"#### 4",
@@ -205,7 +205,7 @@ func test_wrong_size() -> void:
 		"######",
 	]
 	assert_invalid_strict({"wrong_size": [Vector2i(1, 1), Vector2i(2, 0), Vector2i(2, 1)]})
-	assert_invalid_simple({"wrong_size": [Vector2i(2, 0)]})
+	assert_invalid({"wrong_size": [Vector2i(2, 0)]})
 	
 	grid = [
 		" . . 4",
@@ -216,7 +216,7 @@ func test_wrong_size() -> void:
 			Vector2i(0, 0),
 			Vector2i(1, 0), Vector2i(1, 1),
 			Vector2i(2, 0), Vector2i(2, 1)]})
-	assert_invalid_simple({"wrong_size": [
+	assert_invalid({"wrong_size": [
 			Vector2i(0, 0),
 			Vector2i(1, 0), Vector2i(1, 1),
 			Vector2i(2, 0), Vector2i(2, 1)]})
@@ -229,35 +229,22 @@ func test_wrong_size_neighbors() -> void:
 		" 1  ##",
 	]
 	assert_valid()
-	assert_valid_simple()
 	
+	# these clues can't grow to their full size, but our validator is too simple to catch that
 	grid = [
 		"##   5",
 		"      ",
 		" 1  ##",
 	]
-	assert_invalid({"wrong_size": [Vector2i(2, 0)]})
-	assert_valid_simple()
+	assert_valid()
 	
+	# these clues can't grow to their full size, but our validator is too simple to catch that
 	grid = [
 		"## . 5",
 		"   . .",
 		" 1  ##",
 	]
-	assert_invalid({
-			"wrong_size": [Vector2i(1, 0), Vector2i(1, 1), Vector2i(2, 0), Vector2i(2, 1)],
-			"split_walls": [Vector2i(2, 2)]})
-	assert_invalid_simple({"split_walls": [Vector2i(2, 2)]})
-
-
-func test_asdf_bug_2() -> void:
-	grid = [
-		"##########",
-		" 3## . 4##",
-		" .   .####",
-		"       2  ",
-	]
-	assert_invalid({"wrong_size": [Vector2i(2, 1), Vector2i(2, 2), Vector2i(3, 1)]})
+	assert_invalid({"split_walls": [Vector2i(2, 2)]})
 
 
 func assert_valid() -> void:
@@ -266,14 +253,6 @@ func assert_valid() -> void:
 
 func assert_invalid(expected_result_dict: Dictionary) -> void:
 	_assert_validate("validate", expected_result_dict)
-
-
-func assert_valid_simple() -> void:
-	_assert_validate("validate_simple", {})
-
-
-func assert_invalid_simple(expected_result_dict: Dictionary) -> void:
-	_assert_validate("validate_simple", expected_result_dict)
 
 
 func assert_valid_strict() -> void:


### PR DESCRIPTION
SolverBoard used to have a "complex validation" which used the ChokepointMap to determine the largest size each clue could grow to. ChokepointMaps are slow to build, and this validation didn't accomplish anything we couldn't do with a simpler type of validation.