### PR TITLE
Fixed Nurikabe #71. Restored complex validation for fallback.

### DIFF
--- a/project/src/demo/nurikabe/solver/demo_solver.gd
+++ b/project/src/demo/nurikabe/solver/demo_solver.gd
@@ -237,7 +237,7 @@ func _on_performance_suite_timer_timeout() -> void:
 	copy_board_from_solver()
 	var duration: int = Time.get_ticks_usec() - start_time
 	var filled: bool = solver.board.is_filled()
-	var validation_errors: SolverBoard.ValidationResult = solver.board.validate()
+	var validation_errors: SolverBoard.ValidationResult = solver.board.validate(SolverBoard.VALIDATE_SIMPLE)
 	var puzzle_name: String = StringUtils.substring_after_last(next_path, "/").trim_suffix(".txt")
 	var result: String = "err" if validation_errors.error_count > 0 else "dnf" if not filled else "ok"
 	_show_message("| %s | %s %s | %s | %s |" % [

--- a/project/src/main/nurikabe/nurikabe_game_board.gd
+++ b/project/src/main/nurikabe/nurikabe_game_board.gd
@@ -310,10 +310,10 @@ func _push_undo_action(player_id: int, cell_positions: Array[Vector2i], values: 
 
 func _on_validate_timer_timeout() -> void:
 	var model: SolverBoard = to_solver_board()
-	var validation_result: SolverBoard.ValidationResult = model.validate()
-	var strict_validation_result: SolverBoard.ValidationResult = model.validate_strict()
+	var result_simple: SolverBoard.ValidationResult = model.validate(SolverBoard.VALIDATE_SIMPLE)
+	var result_strict: SolverBoard.ValidationResult = model.validate(SolverBoard.VALIDATE_STRICT)
 	
-	if strict_validation_result.error_count == 0:
+	if result_strict.error_count == 0:
 		puzzle_finished.emit()
 	
 	# update lowlight cells if the player isn't finished
@@ -321,24 +321,24 @@ func _on_validate_timer_timeout() -> void:
 	for cell: Vector2i in model.cells:
 		if NurikabeUtils.is_clue(model.get_cell(cell)) or model.get_cell(cell) in [CELL_EMPTY, CELL_ISLAND]:
 			new_lowlight_cells[cell] = true
-	for joined_island_cell: Vector2i in strict_validation_result.joined_islands:
+	for joined_island_cell: Vector2i in result_strict.joined_islands:
 		new_lowlight_cells.erase(joined_island_cell)
-	for wrong_size_cell: Vector2i in strict_validation_result.wrong_size:
+	for wrong_size_cell: Vector2i in result_strict.wrong_size:
 		new_lowlight_cells.erase(wrong_size_cell)
 	lowlight_cells = new_lowlight_cells
 	
 	# update error cells if the player made a mistake
 	var old_error_cells: Dictionary[Vector2i, bool] = error_cells
 	var new_error_cells: Dictionary[Vector2i, bool] = {}
-	for pool_cell: Vector2i in validation_result.pools:
+	for pool_cell: Vector2i in result_simple.pools:
 		new_error_cells[pool_cell] = true
-	for joined_island_cell: Vector2i in validation_result.joined_islands:
+	for joined_island_cell: Vector2i in result_simple.joined_islands:
 		new_error_cells[joined_island_cell] = true
-	for unclued_island_cell: Vector2i in validation_result.unclued_islands:
+	for unclued_island_cell: Vector2i in result_simple.unclued_islands:
 		new_error_cells[unclued_island_cell] = true
-	for wrong_size_cell: Vector2i in validation_result.wrong_size:
+	for wrong_size_cell: Vector2i in result_simple.wrong_size:
 		new_error_cells[wrong_size_cell] = true
-	for split_wall_cell in validation_result.split_walls:
+	for split_wall_cell in result_simple.split_walls:
 		new_error_cells[split_wall_cell] = true
 	error_cells = new_error_cells
 	

--- a/project/src/main/nurikabe/solver/bifurcation_engine.gd
+++ b/project/src/main/nurikabe/solver/bifurcation_engine.gd
@@ -21,8 +21,6 @@ func add_scenario(board: SolverBoard, key: String, cells: Array[Vector2i],
 func step(scenario_key: String) -> void:
 	var scenario: BifurcationScenario = _scenarios_by_key[scenario_key]
 	scenario.step()
-	if scenario.is_queue_empty() and not _scenarios_by_key[scenario_key].has_new_contradictions():
-		_scenarios_by_key.erase(scenario_key)
 
 
 func is_queue_empty() -> bool:
@@ -34,13 +32,14 @@ func get_scenario_count() -> int:
 	return _scenarios_by_key.size()
 
 
-func has_new_contradictions() -> bool:
+func has_new_contradictions(mode: SolverBoard.ValidationMode = SolverBoard.VALIDATE_SIMPLE) -> bool:
 	return _scenarios_by_key.values().any(func(scenario: BifurcationScenario) -> bool:
-		return scenario.has_new_contradictions())
+		return scenario.has_new_contradictions(mode))
 
 
-func scenario_has_new_contradictions(key: String) -> bool:
-	return _scenarios_by_key[key].has_new_contradictions()
+func scenario_has_new_contradictions(key: String,
+		mode: SolverBoard.ValidationMode = SolverBoard.VALIDATE_SIMPLE) -> bool:
+	return _scenarios_by_key[key].has_new_contradictions(mode)
 
 
 func get_scenario_deductions(key: String) -> Array[Deduction]:

--- a/project/src/main/nurikabe/solver/bifurcation_scenario.gd
+++ b/project/src/main/nurikabe/solver/bifurcation_scenario.gd
@@ -4,8 +4,6 @@ var solver: Solver = Solver.new()
 var board: SolverBoard
 var assumptions: Dictionary[Vector2i, int]
 var deductions: Array[Deduction]
-var _last_validation_result: SolverBoard.ValidationResult
-var _initial_validation_result: SolverBoard.ValidationResult
 
 func _init(init_board: SolverBoard,
 		init_assumptions: Dictionary[Vector2i, int],
@@ -17,12 +15,10 @@ func _init(init_board: SolverBoard,
 
 
 func _build() -> void:
-	_initial_validation_result = board.validate()
 	solver.board = board.duplicate()
 	for assumption_cell in assumptions:
 		solver.add_deduction(assumption_cell, assumptions[assumption_cell], Deduction.Reason.ASSUMPTION)
 	solver.apply_changes()
-	_last_validation_result = solver.board.validate()
 
 
 func is_queue_empty() -> bool:
@@ -30,13 +26,16 @@ func is_queue_empty() -> bool:
 
 
 func step() -> void:
-	if _last_validation_result.error_count > _initial_validation_result.error_count or solver.is_queue_empty():
+	var initial_validation_result: SolverBoard.ValidationResult = board.validate(SolverBoard.VALIDATE_SIMPLE)
+	var last_validation_result: SolverBoard.ValidationResult  = solver.board.validate(SolverBoard.VALIDATE_SIMPLE)
+	if last_validation_result.error_count > initial_validation_result.error_count or solver.is_queue_empty():
 		return
 	
 	solver.step()
 	solver.apply_changes()
 
 
-func has_new_contradictions() -> bool:
-	_last_validation_result = solver.board.validate()
-	return _last_validation_result.error_count > _initial_validation_result.error_count
+func has_new_contradictions(mode: SolverBoard.ValidationMode = SolverBoard.VALIDATE_SIMPLE) -> bool:
+	var initial_validation_result: SolverBoard.ValidationResult = board.validate(mode)
+	var last_validation_result: SolverBoard.ValidationResult  = solver.board.validate(mode)
+	return last_validation_result.error_count > initial_validation_result.error_count

--- a/project/src/test/nurikabe/solver/test_solver_board.gd
+++ b/project/src/test/nurikabe/solver/test_solver_board.gd
@@ -1,7 +1,10 @@
 extends GutTest
 
-var grid: Array[String]
+const VALIDATE_STRICT: SolverBoard.ValidationMode = SolverBoard.VALIDATE_STRICT
+const VALIDATE_COMPLEX: SolverBoard.ValidationMode = SolverBoard.VALIDATE_COMPLEX
+const VALIDATE_SIMPLE: SolverBoard.ValidationMode = SolverBoard.VALIDATE_SIMPLE
 
+var grid: Array[String]
 
 func test_joined_islands_two() -> void:
 	grid = [
@@ -9,36 +12,36 @@ func test_joined_islands_two() -> void:
 		"  ##  ",
 		"  ##  ",
 	]
-	assert_valid_strict()
+	assert_valid(VALIDATE_STRICT)
 	
 	grid = [
 		" 3## 3",
 		"  ##  ",
 		"      ",
 	]
-	assert_invalid_strict({"joined_islands": [
+	assert_invalid(VALIDATE_STRICT, {"joined_islands": [
 		Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2),
 		Vector2i(1, 2),
 		Vector2i(2, 0), Vector2i(2, 1), Vector2i(2, 2)]})
-	assert_valid()
+	assert_valid(VALIDATE_SIMPLE)
 	
 	grid = [
 		" 3## 3",
 		" .## .",
 		" .   .",
 	]
-	assert_invalid_strict({"joined_islands": [
+	assert_invalid(VALIDATE_STRICT, {"joined_islands": [
 		Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2),
 		Vector2i(1, 2),
 		Vector2i(2, 0), Vector2i(2, 1), Vector2i(2, 2)]})
-	assert_valid()
+	assert_valid(VALIDATE_COMPLEX)
 	
 	grid = [
 		" 3## 3",
 		" .## .",
 		" . . .",
 	]
-	assert_invalid({"joined_islands": [
+	assert_invalid(VALIDATE_COMPLEX, {"joined_islands": [
 		Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2),
 		Vector2i(1, 2),
 		Vector2i(2, 0), Vector2i(2, 1), Vector2i(2, 2)]})
@@ -50,26 +53,25 @@ func test_joined_islands_three() -> void:
 		"     3    ",
 		"         3",
 	]
-	assert_invalid_strict({
-		"joined_islands": [
+	assert_invalid(VALIDATE_STRICT, {"joined_islands": [
 			Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2),
 			Vector2i(1, 0), Vector2i(1, 1), Vector2i(1, 2),
 			Vector2i(2, 0), Vector2i(2, 1), Vector2i(2, 2),
 			Vector2i(3, 0), Vector2i(3, 1), Vector2i(3, 2),
 			Vector2i(4, 0), Vector2i(4, 1), Vector2i(4, 2),
-			]})
-	assert_valid()
+		]})
+	assert_valid(VALIDATE_COMPLEX)
 	
 	grid = [
 		" 3        ",
 		" . . 3    ",
 		"         3",
 	]
-	assert_invalid({
-		"joined_islands": [
+	assert_invalid(VALIDATE_COMPLEX, {"joined_islands": [
 			Vector2i(0, 0), Vector2i(0, 1),
 			Vector2i(1, 1),
-			Vector2i(2, 1)]})
+			Vector2i(2, 1),
+		]})
 
 
 func test_pools_ok() -> void:
@@ -78,7 +80,7 @@ func test_pools_ok() -> void:
 		"##    ",
 		"######",
 	]
-	assert_valid_strict()
+	assert_valid(VALIDATE_STRICT)
 
 
 func test_pools_one() -> void:
@@ -87,7 +89,8 @@ func test_pools_one() -> void:
 		"####  ",
 		"####  ",
 	]
-	assert_invalid_strict({"pools": [Vector2i(0, 1), Vector2i(0, 2), Vector2i(1, 1), Vector2i(1, 2)]})
+	assert_invalid(VALIDATE_STRICT, {"pools": [
+			Vector2i(0, 1), Vector2i(0, 2), Vector2i(1, 1), Vector2i(1, 2)]})
 
 
 func test_pools_two() -> void:
@@ -96,10 +99,11 @@ func test_pools_two() -> void:
 		"######",
 		"######",
 	]
-	assert_invalid_strict({"pools": [
-		Vector2i(0, 1), Vector2i(0, 2),
-		Vector2i(1, 1), Vector2i(1, 2),
-		Vector2i(2, 1), Vector2i(2, 2)]})
+	assert_invalid(VALIDATE_STRICT, {"pools": [
+			Vector2i(0, 1), Vector2i(0, 2),
+			Vector2i(1, 1), Vector2i(1, 2),
+			Vector2i(2, 1), Vector2i(2, 2),
+		]})
 
 
 func test_split_walls_ok() -> void:
@@ -108,14 +112,14 @@ func test_split_walls_ok() -> void:
 		"  ##  ",
 		"   5  ",
 	]
-	assert_valid_strict()
+	assert_valid(VALIDATE_STRICT)
 	
 	grid = [
 		" 8    ",
 		" .    ",
 		"## .  ",
 	]
-	assert_valid_strict()
+	assert_valid(VALIDATE_STRICT)
 
 
 func test_split_walls_two() -> void:
@@ -124,22 +128,22 @@ func test_split_walls_two() -> void:
 		" 6    ",
 		"    ##",
 	]
-	assert_invalid_strict({"split_walls": [Vector2i(2, 2)]})
-	assert_valid()
+	assert_invalid(VALIDATE_STRICT, {"split_walls": [Vector2i(2, 2)]})
+	assert_valid(VALIDATE_COMPLEX)
 	
 	grid = [
 		"  ####",
 		" 6   .",
 		"    ##",
 	]
-	assert_valid()
+	assert_valid(VALIDATE_COMPLEX)
 	
 	grid = [
 		"  ####",
 		" 6 . .",
 		"    ##",
 	]
-	assert_invalid({"split_walls": [Vector2i(2, 2)]})
+	assert_invalid(VALIDATE_COMPLEX, {"split_walls": [Vector2i(2, 2)]})
 
 
 func test_split_walls_three() -> void:
@@ -148,22 +152,22 @@ func test_split_walls_three() -> void:
 		"  ##  ",
 		" 3  ##",
 	]
-	assert_invalid_strict({"split_walls": [Vector2i(1, 1), Vector2i(2, 2)]})
-	assert_valid()
+	assert_invalid(VALIDATE_STRICT, {"split_walls": [Vector2i(1, 1), Vector2i(2, 2)]})
+	assert_valid(VALIDATE_COMPLEX)
 	
 	grid = [
 		"## . 3",
 		" .## .",
 		" 3 .##",
 	]
-	assert_invalid({"split_walls": [Vector2i(1, 1), Vector2i(2, 2)]})
+	assert_invalid(VALIDATE_COMPLEX, {"split_walls": [Vector2i(1, 1), Vector2i(2, 2)]})
 	
 	grid = [
 		"##   3",
 		"  ## .",
 		" 3 .##",
 	]
-	assert_invalid({"split_walls": [Vector2i(2, 2)]})
+	assert_invalid(VALIDATE_COMPLEX, {"split_walls": [Vector2i(2, 2)]})
 
 
 func test_unclued_islands() -> void:
@@ -172,22 +176,22 @@ func test_unclued_islands() -> void:
 		"#### 3",
 		"  ####",
 	]
-	assert_invalid_strict({"unclued_islands": [Vector2i(0, 2)]})
-	assert_valid()
+	assert_invalid(VALIDATE_STRICT, {"unclued_islands": [Vector2i(0, 2)]})
+	assert_valid(VALIDATE_COMPLEX)
 	
 	grid = [
 		"## .  ",
 		"#### 3",
 		"  ####",
 	]
-	assert_valid()
+	assert_valid(VALIDATE_COMPLEX)
 	
 	grid = [
 		"##    ",
 		"#### 3",
 		" .####",
 	]
-	assert_invalid({"unclued_islands": [Vector2i(0, 2)]})
+	assert_invalid(VALIDATE_COMPLEX, {"unclued_islands": [Vector2i(0, 2)]})
 
 
 func test_wrong_size() -> void:
@@ -196,27 +200,27 @@ func test_wrong_size() -> void:
 		"##    ",
 		"######",
 	]
-	assert_valid_strict()
-	assert_valid()
+	assert_valid(VALIDATE_STRICT)
+	assert_valid(VALIDATE_SIMPLE)
 	
 	grid = [
 		"#### 4",
 		"##    ",
 		"######",
 	]
-	assert_invalid_strict({"wrong_size": [Vector2i(1, 1), Vector2i(2, 0), Vector2i(2, 1)]})
-	assert_invalid({"wrong_size": [Vector2i(2, 0)]})
+	assert_invalid(VALIDATE_STRICT, {"wrong_size": [Vector2i(1, 1), Vector2i(2, 0), Vector2i(2, 1)]})
+	assert_invalid(VALIDATE_SIMPLE, {"wrong_size": [Vector2i(2, 0)]})
 	
 	grid = [
 		" . . 4",
 		"## . .",
 		"######",
 	]
-	assert_invalid_strict({"wrong_size": [
+	assert_invalid(VALIDATE_STRICT, {"wrong_size": [
 			Vector2i(0, 0),
 			Vector2i(1, 0), Vector2i(1, 1),
 			Vector2i(2, 0), Vector2i(2, 1)]})
-	assert_invalid({"wrong_size": [
+	assert_invalid(VALIDATE_SIMPLE, {"wrong_size": [
 			Vector2i(0, 0),
 			Vector2i(1, 0), Vector2i(1, 1),
 			Vector2i(2, 0), Vector2i(2, 1)]})
@@ -228,44 +232,49 @@ func test_wrong_size_neighbors() -> void:
 		"      ",
 		" 1  ##",
 	]
-	assert_valid()
+	assert_valid(VALIDATE_COMPLEX)
+	assert_valid(VALIDATE_SIMPLE)
 	
-	# these clues can't grow to their full size, but our validator is too simple to catch that
 	grid = [
 		"##   5",
 		"      ",
 		" 1  ##",
 	]
-	assert_valid()
+	assert_invalid(VALIDATE_COMPLEX, {"wrong_size": [Vector2i(2, 0)]})
+	assert_valid(VALIDATE_SIMPLE)
 	
-	# these clues can't grow to their full size, but our validator is too simple to catch that
 	grid = [
 		"## . 5",
 		"   . .",
 		" 1  ##",
 	]
-	assert_invalid({"split_walls": [Vector2i(2, 2)]})
+	assert_invalid(VALIDATE_COMPLEX, {
+			"wrong_size": [Vector2i(1, 0), Vector2i(1, 1), Vector2i(2, 0), Vector2i(2, 1)],
+			"split_walls": [Vector2i(2, 2)]})
+	assert_invalid(VALIDATE_SIMPLE, {"split_walls": [Vector2i(2, 2)]})
 
 
-func assert_valid() -> void:
-	_assert_validate("validate", {})
+func test_complex_bug() -> void:
+	grid = [
+		"##########",
+		" 3## . 4##",
+		" .   .####",
+		"       2  ",
+	]
+	assert_invalid(VALIDATE_COMPLEX, {"wrong_size": [Vector2i(2, 1), Vector2i(2, 2), Vector2i(3, 1)]})
 
 
-func assert_invalid(expected_result_dict: Dictionary) -> void:
-	_assert_validate("validate", expected_result_dict)
+func assert_valid(mode: SolverBoard.ValidationMode) -> void:
+	_assert_validate(mode, {})
 
 
-func assert_valid_strict() -> void:
-	_assert_validate("validate_strict", {})
+func assert_invalid(mode: SolverBoard.ValidationMode, expected_result_dict: Dictionary) -> void:
+	_assert_validate(mode, expected_result_dict)
 
 
-func assert_invalid_strict(expected_result_dict: Dictionary) -> void:
-	_assert_validate("validate_strict", expected_result_dict)
-
-
-func _assert_validate(method: String, expected_result_dict: Dictionary) -> void:
+func _assert_validate(mode: SolverBoard.ValidationMode, expected_result_dict: Dictionary) -> void:
 	var board: SolverBoard = SolverTestUtils.init_board(grid)
-	var validation_result: SolverBoard.ValidationResult = board.call(method)
+	var validation_result: SolverBoard.ValidationResult = board.validate(mode)
 	for key: String in ["joined_islands", "pools", "split_walls", "unclued_islands", "wrong_size"]:
 		var validation_result_value: Array[Vector2i] = validation_result.get(key)
 		validation_result_value.sort()


### PR DESCRIPTION
I recently swapped the solver over from complex validation (using Tarjan's articulation point algorithm) to a simple flood fill, because it's faster and will be easier to cache incrementally. However this introduced a regression where a particularly difficult puzzle (puzzle_nikoli_1_071.txt) could not be solved.

I implemented a hybrid approach in this commit.

The hybrid approach uses the simple validation approach until the solver "gets stuck". If it gets stuck during bifurcation, it checks all of its scenarios with the slower articulation point validation rules, which finds a contradiction and lets it solve the harder puzzle. But for all of the other puzzles, it gets away with the faster logic.