### PR TITLE
Bifurcation tweaks: border walls, squeeze fill

### DIFF
--- a/project/src/demo/nurikabe/solver/demo_solver.gd
+++ b/project/src/demo/nurikabe/solver/demo_solver.gd
@@ -10,6 +10,7 @@ extends Node
 ## 	[kbd]R[/kbd]: Reset the board.
 ## 	[kbd]P[/kbd]: Print partially solved puzzle to console.
 ## 	[kbd]Shift + P[/kbd]: Print task queue to console.
+## 	[kbd]B[/kbd]: Print benchmark results for AggregateTimer/SplitTimer.
 
 @export_file("*.txt") var puzzle_path: String:
 	set(value):
@@ -83,6 +84,9 @@ func _input(event: InputEvent) -> void:
 			%GameBoard.reset()
 			solver.board = %GameBoard.to_solver_board()
 			solver.clear()
+		KEY_B:
+			AggregateTimer.print_results()
+			SplitTimer.print_results()
 
 
 func _ready() -> void:

--- a/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
@@ -512,7 +512,7 @@ func test_enqueue_wall_chokepoints_border_hug() -> void:
 	var expected: Array[String] = [
 		"(0, 1)->## border_hug (0, 0)",
 	]
-	assert_deductions(solver.enqueue_border_walls_simple, expected)
+	assert_deductions(solver.enqueue_wall_strangle, expected)
 
 
 func test_enqueue_wall_chokepoints_border_hug_invalid_1() -> void:


### PR DESCRIPTION
The border wall logic used to be an unusual 'semi bifurcation' which just ran a squeeze fill and didn't really bifurcate. This is an interesting idea, but it should also apply to other bifurcations.

I've rewritten the existing 'wall strangle' bifurcation to encompass the border wall bifurcation. I've also rewritten it and other bifurcations to leverage the squeeze fill logic.