### PR TITLE
Added local validation logic which runs on a part of the grid.

### DIFF
--- a/project/src/main/nurikabe/solver/bifurcation_engine.gd
+++ b/project/src/main/nurikabe/solver/bifurcation_engine.gd
@@ -32,9 +32,18 @@ func get_scenario_count() -> int:
 	return _scenarios_by_key.size()
 
 
+func has_new_local_contradictions() -> bool:
+	return _scenarios_by_key.values().any(func(scenario: BifurcationScenario) -> bool:
+		return scenario.has_new_local_contradictions())
+
+
 func has_new_contradictions(mode: SolverBoard.ValidationMode = SolverBoard.VALIDATE_SIMPLE) -> bool:
 	return _scenarios_by_key.values().any(func(scenario: BifurcationScenario) -> bool:
 		return scenario.has_new_contradictions(mode))
+
+
+func scenario_has_new_local_contradictions(key: String) -> bool:
+	return _scenarios_by_key[key].has_new_local_contradictions()
 
 
 func scenario_has_new_contradictions(key: String,

--- a/project/src/main/nurikabe/solver/bifurcation_scenario.gd
+++ b/project/src/main/nurikabe/solver/bifurcation_scenario.gd
@@ -5,6 +5,11 @@ var board: SolverBoard
 var assumptions: Dictionary[Vector2i, int]
 var deductions: Array[Deduction]
 
+var _change_cells: Array[Vector2i] = []
+
+var _local_validation_result: String = ""
+var _local_validation_result_dirty: bool = false
+
 func _init(init_board: SolverBoard,
 		init_assumptions: Dictionary[Vector2i, int],
 		init_deductions: Array[Deduction]) -> void:
@@ -18,6 +23,7 @@ func _build() -> void:
 	solver.board = board.duplicate()
 	for assumption_cell in assumptions:
 		solver.add_deduction(assumption_cell, assumptions[assumption_cell], Deduction.Reason.ASSUMPTION)
+	_change_cells.append_array(solver.deductions.cells.keys())
 	solver.apply_changes()
 
 
@@ -26,16 +32,24 @@ func is_queue_empty() -> bool:
 
 
 func step() -> void:
-	var initial_validation_result: SolverBoard.ValidationResult = board.validate(SolverBoard.VALIDATE_SIMPLE)
-	var last_validation_result: SolverBoard.ValidationResult  = solver.board.validate(SolverBoard.VALIDATE_SIMPLE)
-	if last_validation_result.error_count > initial_validation_result.error_count or solver.is_queue_empty():
+	if has_new_local_contradictions():
 		return
 	
 	solver.step()
-	solver.apply_changes()
+	if solver.deductions.has_changes():
+		_change_cells.append_array(solver.deductions.cells.keys())
+		solver.apply_changes()
+		_local_validation_result_dirty = true
+
+
+func has_new_local_contradictions() -> bool:
+	if _local_validation_result_dirty:
+		_local_validation_result = solver.board.validate_local(_change_cells)
+		_local_validation_result_dirty = false
+	return _local_validation_result != ""
 
 
 func has_new_contradictions(mode: SolverBoard.ValidationMode = SolverBoard.VALIDATE_SIMPLE) -> bool:
 	var initial_validation_result: SolverBoard.ValidationResult = board.validate(mode)
-	var last_validation_result: SolverBoard.ValidationResult  = solver.board.validate(mode)
+	var last_validation_result: SolverBoard.ValidationResult = solver.board.validate(mode)
 	return last_validation_result.error_count > initial_validation_result.error_count

--- a/project/src/test/nurikabe/solver/test_solver_advanced_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_advanced_techniques.gd
@@ -81,8 +81,6 @@ func test_enqueue_island_strangle() -> void:
 	]
 	var expected: Array[String] = [
 		"(1, 2)->## island_strangle (2, 2)",
-		"(2, 1)->## island_strangle (2, 2)",
-		"(3, 1)->## island_strangle (2, 2)",
 		"(4, 1)->## island_strangle (2, 2)",
 	]
 	assert_deductions(solver.enqueue_island_strangle, expected)
@@ -97,6 +95,6 @@ func test_enqueue_island_release() -> void:
 		" 6    ",
 	]
 	var expected: Array[String] = [
-		"(1, 1)->. island_release (0, 1)",
+		"(1, 4)->. island_release (0, 4)",
 	]
 	assert_deductions(solver.enqueue_island_release, expected)

--- a/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
@@ -511,7 +511,6 @@ func test_enqueue_wall_chokepoints_border_hug() -> void:
 	]
 	var expected: Array[String] = [
 		"(0, 1)->## border_hug (0, 0)",
-		"(3, 4)->## border_hug (3, 3)",
 	]
 	assert_deductions(solver.enqueue_wall_strangle, expected)
 

--- a/project/src/test/nurikabe/solver/test_solver_board.gd
+++ b/project/src/test/nurikabe/solver/test_solver_board.gd
@@ -47,6 +47,22 @@ func test_joined_islands_two() -> void:
 		Vector2i(2, 0), Vector2i(2, 1), Vector2i(2, 2)]})
 
 
+func test_joined_islands_local() -> void:
+	grid = [
+		" 3   3",
+		" .   .",
+		" .## .",
+	]
+	assert_valid_local([Vector2i(0, 2)])
+	
+	grid = [
+		" 3 . 3",
+		" .   .",
+		" .## .",
+	]
+	assert_invalid_local([Vector2i(1, 1)], "j")
+
+
 func test_joined_islands_three() -> void:
 	grid = [
 		" 3        ",
@@ -91,6 +107,22 @@ func test_pools_one() -> void:
 	]
 	assert_invalid(VALIDATE_STRICT, {"pools": [
 			Vector2i(0, 1), Vector2i(0, 2), Vector2i(1, 1), Vector2i(1, 2)]})
+
+
+func test_pools_local() -> void:
+	grid = [
+		"      ",
+		"##    ",
+		"####  ",
+	]
+	assert_valid_local([Vector2i(1, 1)])
+	
+	grid = [
+		"      ",
+		"####  ",
+		"####  ",
+	]
+	assert_invalid_local([Vector2i(1, 1)], "p")
 
 
 func test_pools_two() -> void:
@@ -146,6 +178,22 @@ func test_split_walls_two() -> void:
 	assert_invalid(VALIDATE_COMPLEX, {"split_walls": [Vector2i(2, 2)]})
 
 
+func test_split_walls_local() -> void:
+	grid = [
+		"  ####",
+		"     .",
+		" 6  ##",
+	]
+	assert_valid_local([Vector2i(2, 1)])
+	
+	grid = [
+		"  ####",
+		"     .",
+		" 6 .##",
+	]
+	assert_invalid_local([Vector2i(1, 2)], "s")
+
+
 func test_split_walls_three() -> void:
 	grid = [
 		"##   3",
@@ -199,6 +247,22 @@ func test_unclued_islands() -> void:
 		" .####",
 	]
 	assert_invalid(VALIDATE_COMPLEX, {"unclued_islands": [Vector2i(0, 2)]})
+
+
+func test_unclued_islands_local() -> void:
+	grid = [
+		"  ####",
+		"     .",
+		" 6  ##",
+	]
+	assert_valid_local([Vector2i(2, 1)])
+	
+	grid = [
+		"  ####",
+		"  ## .",
+		" 6  ##",
+	]
+	assert_invalid_local([Vector2i(2, 1)], "u")
 
 
 func test_wrong_size() -> void:
@@ -259,6 +323,22 @@ func test_wrong_size_neighbors() -> void:
 			"wrong_size": [Vector2i(1, 0), Vector2i(1, 1), Vector2i(2, 0), Vector2i(2, 1)],
 			"split_walls": [Vector2i(2, 2)]})
 	assert_invalid(VALIDATE_SIMPLE, {"split_walls": [Vector2i(2, 2)]})
+
+
+func test_wrong_size_local() -> void:
+	grid = [
+		" 2    ",
+		"     .",
+		"     2",
+	]
+	assert_valid_local([Vector2i(2, 1)])
+	
+	grid = [
+		" 2   .",
+		"     .",
+		"     2",
+	]
+	assert_invalid_local([Vector2i(2, 1)], "c")
 
 
 func test_complex_bug() -> void:
@@ -323,6 +403,14 @@ func assert_valid(mode: SolverBoard.ValidationMode) -> void:
 	_assert_validate(mode, {})
 
 
+func assert_valid_local(local_cells: Array[Vector2i]) -> void:
+	_assert_validate_local(local_cells, "")
+
+
+func assert_invalid_local(local_cells: Array[Vector2i], expected_result: String) -> void:
+	_assert_validate_local(local_cells, expected_result)
+
+
 func assert_invalid(mode: SolverBoard.ValidationMode, expected_result_dict: Dictionary) -> void:
 	_assert_validate(mode, expected_result_dict)
 
@@ -334,3 +422,9 @@ func _assert_validate(mode: SolverBoard.ValidationMode, expected_result_dict: Di
 		var validation_result_value: Array[Vector2i] = validation_result.get(key)
 		validation_result_value.sort()
 		assert_eq(expected_result_dict.get(key, []), validation_result_value, "Incorrect %s." % [key])
+
+
+func _assert_validate_local(local_cells: Array[Vector2i], expected_result: String) -> void:
+	var board: SolverBoard = SolverTestUtils.init_board(grid)
+	var validation_result: String = board.validate_local(local_cells)
+	assert_eq(validation_result, expected_result)


### PR DESCRIPTION
This local validation logic runs a simplified subset of rules. For example, it doesn't check whether all of the board's walls can connect into a single wall -- it just checks whether any nearby walls are fully sealed in.

This is about 8x as fast (3.617 -> 0.452). For the 16 bifurcations performed in puzzles 61-71, 14 of them could detect contradictions with this faster approach. 1 required the full board "simple" logic, and 1 required the full board "complex" logic.