### PR TITLE
Array microoptimizations: neighbors, ==

### DIFF
--- a/project/src/main/nurikabe/nurikabe_game_board.gd
+++ b/project/src/main/nurikabe/nurikabe_game_board.gd
@@ -319,7 +319,8 @@ func _on_validate_timer_timeout() -> void:
 	# update lowlight cells if the player isn't finished
 	var new_lowlight_cells: Dictionary[Vector2i, bool] = {}
 	for cell: Vector2i in model.cells:
-		if NurikabeUtils.is_clue(model.get_cell(cell)) or model.get_cell(cell) in [CELL_EMPTY, CELL_ISLAND]:
+		var cell_value: int = model.get_cell(cell)
+		if NurikabeUtils.is_clue(cell_value) or cell_value == CELL_EMPTY or cell_value == CELL_ISLAND:
 			new_lowlight_cells[cell] = true
 	for joined_island_cell: Vector2i in result_strict.joined_islands:
 		new_lowlight_cells.erase(joined_island_cell)

--- a/project/src/main/nurikabe/nurikabe_utils.gd
+++ b/project/src/main/nurikabe/nurikabe_utils.gd
@@ -31,7 +31,8 @@ const CLUE_COLOR: Color = Color("666666")
 const POS_NOT_FOUND: Vector2i = Vector2i(-1, -1)
 
 const NEIGHBOR_DIRS: Array[Vector2i] = [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]
-
+const NEIGHBOR_DIRS_WITH_SELF: Array[Vector2i] = [Vector2i.ZERO,
+		Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]
 
 static func pool_triplet(cell: Vector2i, dir: Vector2i) -> Array[Vector2i]:
 	return [cell + dir, cell + Vector2i(dir.x, 0), cell + Vector2i(0, dir.y)]

--- a/project/src/main/nurikabe/solver/chokepoint_map.gd
+++ b/project/src/main/nurikabe/solver/chokepoint_map.gd
@@ -159,9 +159,8 @@ func _build() -> void:
 	for cell: Vector2i in cells:
 		_neighbors_by_cell[cell] = [] as Array[Vector2i]
 	for cell: Vector2i in cells:
-		for neighbor: Vector2i in [
-				cell + Vector2i.UP, cell + Vector2i.DOWN,
-				cell + Vector2i.LEFT, cell + Vector2i.RIGHT]:
+		for neighbor_dir: Vector2i in NurikabeUtils.NEIGHBOR_DIRS:
+			var neighbor: Vector2i = cell + neighbor_dir
 			if _neighbors_by_cell.has(neighbor):
 				_neighbors_by_cell[cell].append(neighbor)
 	

--- a/project/src/main/nurikabe/solver/global_reachability_map.gd
+++ b/project/src/main/nurikabe/solver/global_reachability_map.gd
@@ -50,7 +50,8 @@ func _build() -> void:
 	var visitable: Dictionary[Vector2i, bool] = {}
 	var island_clues: Dictionary[Vector2i, int] = _board.get_island_clues()
 	for cell: Vector2i in _board.cells:
-		if _board.get_cell(cell) in [CELL_ISLAND, CELL_EMPTY] \
+		var cell_value: int = _board.get_cell(cell)
+		if cell_value == CELL_ISLAND or cell_value == CELL_EMPTY \
 				and island_clues.get(cell, 0) == 0:
 			visitable[cell] = true
 	
@@ -77,7 +78,8 @@ func _build() -> void:
 	while not queue.is_empty():
 		var cell: Vector2i = queue.pop_front()
 		
-		for neighbor: Vector2i in _board.get_neighbors(cell):
+		for neighbor_dir: Vector2i in NurikabeUtils.NEIGHBOR_DIRS:
+			var neighbor: Vector2i = cell + neighbor_dir
 			if not visitable.has(neighbor):
 				continue
 			if _reach_score_by_cell.has(neighbor):

--- a/project/src/main/nurikabe/solver/group_map.gd
+++ b/project/src/main/nurikabe/solver/group_map.gd
@@ -36,9 +36,8 @@ func _build() -> void:
 			groups_by_cell[cell] = group
 			roots_by_cell[cell] = group.front()
 			
-			for neighbor: Vector2i in [
-				cell + Vector2i.UP, cell + Vector2i.DOWN,
-				cell + Vector2i.LEFT, cell + Vector2i.RIGHT]:
+			for neighbor_dir: Vector2i in NurikabeUtils.NEIGHBOR_DIRS:
+				var neighbor: Vector2i = cell + neighbor_dir
 				if neighbor in unvisited:
 					queue.push_back(neighbor)
 					unvisited.erase(neighbor)

--- a/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
+++ b/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
@@ -23,7 +23,8 @@ func _init(init_board: SolverBoard) -> void:
 	# collect visitable cells (empty cells, or clueless islands)
 	var island_clues: Dictionary[Vector2i, int] = _board.get_island_clues()
 	for cell: Vector2i in _board.cells:
-		if _board.get_cell(cell) in [CELL_ISLAND, CELL_EMPTY] \
+		var cell_value: int = _board.get_cell(cell)
+		if cell_value == CELL_ISLAND or cell_value == CELL_EMPTY \
 				and island_clues.get(cell, 0) == 0:
 			_visitable[cell] = true
 	
@@ -80,7 +81,8 @@ func find_chokepoint_cells(island_cell: Vector2i) -> Dictionary[Vector2i, int]:
 			# the chokepoint itself must be an island
 			result[chokepoint] = CELL_ISLAND
 		
-		for neighbor: Vector2i in _board.get_neighbors(chokepoint):
+		for neighbor_dir: Vector2i in NurikabeUtils.NEIGHBOR_DIRS:
+			var neighbor: Vector2i = chokepoint + neighbor_dir
 			# buffer wall between this and other clued islands
 			if needs_buffer(island_root, neighbor):
 				result[neighbor] = CELL_WALL
@@ -148,7 +150,8 @@ func _init_chokepoint_map(island_cell: Vector2i) -> void:
 	while not queue.is_empty():
 		var cell: Vector2i = queue.pop_front()
 		
-		for neighbor: Vector2i in _board.get_neighbors(cell):
+		for neighbor_dir: Vector2i in NurikabeUtils.NEIGHBOR_DIRS:
+			var neighbor: Vector2i = cell + neighbor_dir
 			if not _visitable.has(neighbor):
 				continue
 			if _claimed_by_clue.has(neighbor) \

--- a/project/src/main/nurikabe/solver/solver_board.gd
+++ b/project/src/main/nurikabe/solver/solver_board.gd
@@ -37,7 +37,8 @@ func perform_bfs(start_cell: Vector2i, filter: Callable) -> void:
 		var next_cell: Vector2i = queue.pop_front()
 		if not filter.call(next_cell):
 			continue
-		for neighbor: Vector2i in get_neighbors(next_cell):
+		for neighbor_dir: Vector2i in NurikabeUtils.NEIGHBOR_DIRS:
+			var neighbor: Vector2i = next_cell + neighbor_dir
 			if visited.has(neighbor):
 				continue
 			visited[neighbor] = true
@@ -114,10 +115,6 @@ func get_group_neighbors(group: Array[Vector2i]) -> Array[Vector2i]:
 	return _get_cached(
 		"group_neighbors %s" % ["-" if group.is_empty() else str(group[0])],
 		_build_group_neighbors.bind(group))
-
-
-func get_neighbors(cell_pos: Vector2i) -> Array[Vector2i]:
-	return [cell_pos + Vector2i.UP, cell_pos + Vector2i.DOWN, cell_pos + Vector2i.LEFT, cell_pos + Vector2i.RIGHT]
 
 
 func get_global_reachability_map() -> GlobalReachabilityMap:
@@ -297,9 +294,8 @@ func validate_local(local_cells: Array[Vector2i]) -> String:
 	var local_wall_roots: Dictionary[Vector2i, bool] = {}
 	var local_island_roots: Dictionary[Vector2i, bool] = {}
 	for local_cell: Vector2i in local_cells:
-		for cell: Vector2i in [local_cell,
-				local_cell + Vector2i.UP, local_cell + Vector2i.DOWN,
-				local_cell + Vector2i.LEFT, local_cell + Vector2i.RIGHT]:
+		for cell_dir in NurikabeUtils.NEIGHBOR_DIRS_WITH_SELF:
+			var cell: Vector2i = local_cell + cell_dir
 			if not cells.has(cell):
 				continue
 			match cells[cell]:
@@ -409,7 +405,8 @@ func _build_group_neighbors(group: Array[Vector2i]) -> Array[Vector2i]:
 	for group_cell: Vector2i in group:
 		group_cell_set[group_cell] = true
 	for group_cell: Vector2i in group:
-		for neighbor: Vector2i in get_neighbors(group_cell):
+		for neighbor_dir: Vector2i in NurikabeUtils.NEIGHBOR_DIRS:
+			var neighbor: Vector2i = group_cell + neighbor_dir
 			if not cells.has(neighbor):
 				continue
 			if group_cell_set.has(neighbor):
@@ -426,7 +423,7 @@ func _build_island_group_map() -> SolverGroupMap:
 
 func _build_flooded_island_group_map() -> SolverGroupMap:
 	var group_map: SolverGroupMap = SolverGroupMap.new(self, func(value: int) -> bool:
-		return NurikabeUtils.is_clue(value) or value in [CELL_EMPTY, CELL_ISLAND])
+		return NurikabeUtils.is_clue(value) or value == CELL_EMPTY or value == CELL_ISLAND)
 	for group: Array[Vector2i] in group_map.groups:
 		if group.all(func(cell: Vector2i) -> bool:
 				return cells[cell] == CELL_EMPTY):

--- a/project/src/main/nurikabe/solver/squeeze_fill.gd
+++ b/project/src/main/nurikabe/solver/squeeze_fill.gd
@@ -34,7 +34,8 @@ func step() -> void:
 	
 	var neighbor_match_cells: Array[Vector2i] = []
 	var neighbor_empty_cells: Array[Vector2i] = []
-	for neighbor: Vector2i in _board.get_neighbors(next_cell):
+	for neighbor_dir: Vector2i in NurikabeUtils.NEIGHBOR_DIRS:
+		var neighbor: Vector2i = next_cell + neighbor_dir
 		var neighbor_value: int = get_cell(neighbor)
 		if neighbor_value == CELL_EMPTY:
 			neighbor_empty_cells.append(neighbor)

--- a/project/src/main/player/player_puzzle_handler.gd
+++ b/project/src/main/player/player_puzzle_handler.gd
@@ -102,7 +102,7 @@ func _handle_lmb_press() -> void:
 func _handle_mb_drag() -> void:
 	var cell: Vector2i = _mouse_cell()
 	var old_cell_value: int = game_board.get_cell(cell)
-	if old_cell_value == _last_set_cell or old_cell_value not in [CELL_EMPTY, CELL_WALL, CELL_ISLAND]:
+	if old_cell_value == _last_set_cell or (old_cell_value != CELL_EMPTY and old_cell_value != CELL_WALL and old_cell_value != CELL_ISLAND):
 		return
 	
 	match _last_set_cell:

--- a/project/src/test/nurikabe/solver/test_solver_chokepoint_map.gd
+++ b/project/src/test/nurikabe/solver/test_solver_chokepoint_map.gd
@@ -145,7 +145,7 @@ func _build_island_chokepoint_map() -> SolverChokepointMap:
 	return SolverChokepointMap.new(board,
 		func(cell: Vector2i) -> bool:
 			var value: int = board.get_cell(cell)
-			return NurikabeUtils.is_clue(value) or value in [CELL_EMPTY, CELL_ISLAND])
+			return NurikabeUtils.is_clue(value) or value == CELL_EMPTY or value == CELL_ISLAND)
 
 
 func _build_wall_chokepoint_map() -> SolverChokepointMap:
@@ -153,7 +153,7 @@ func _build_wall_chokepoint_map() -> SolverChokepointMap:
 	return SolverChokepointMap.new(board,
 		func(cell: Vector2i) -> bool:
 			var value: int = board.get_cell(cell)
-			return value in [CELL_EMPTY, CELL_WALL],
+			return value == CELL_EMPTY or value == CELL_WALL,
 		func(cell: Vector2i) -> bool:
 			return board.get_cell(cell) == CELL_WALL)
 


### PR DESCRIPTION
Removed SolverBoard.get_neighbors() method. This allocated an array every time, and we called it a lot.

Replaced 'a in [b, c]' with 'a == b or a == c'.

Together, these improve performance by about 8.6% (3694 -> 3403)