### PR TITLE
Bug: 'island release' deduction applied to complete islands

### DIFF
--- a/project/src/main/nurikabe/solver/solver.gd
+++ b/project/src/main/nurikabe/solver/solver.gd
@@ -961,6 +961,8 @@ func enqueue_island_release() -> void:
 		if board.get_liberties(island).size() != 2:
 			continue
 		var clue_value: int = board.get_clue_for_island(island)
+		if island.size() >= clue_value:
+			continue
 		var liberties: Array[Vector2i] = board.get_liberties(island)
 		for liberty: Vector2i in liberties:
 			if not _should_deduce(board, liberty):

--- a/project/src/main/player/player_puzzle_handler.gd
+++ b/project/src/main/player/player_puzzle_handler.gd
@@ -102,7 +102,8 @@ func _handle_lmb_press() -> void:
 func _handle_mb_drag() -> void:
 	var cell: Vector2i = _mouse_cell()
 	var old_cell_value: int = game_board.get_cell(cell)
-	if old_cell_value == _last_set_cell or (old_cell_value != CELL_EMPTY and old_cell_value != CELL_WALL and old_cell_value != CELL_ISLAND):
+	if old_cell_value == _last_set_cell \
+			or (old_cell_value != CELL_EMPTY and old_cell_value != CELL_WALL and old_cell_value != CELL_ISLAND):
 		return
 	
 	match _last_set_cell:

--- a/project/src/test/nurikabe/solver/test_solver_advanced_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_advanced_techniques.gd
@@ -73,6 +73,21 @@ func test_enqueue_wall_strangle_one_wall() -> void:
 	assert_deductions(solver.enqueue_wall_strangle, expected)
 
 
+func test_enqueue_wall_chokepoints_border_hug() -> void:
+	grid = [
+		"########",
+		"     .##",
+		"     . 7",
+		"      ##",
+		"####    ",
+		" 1##    ",
+	]
+	var expected: Array[String] = [
+		"(0, 1)->## border_hug (0, 0)",
+	]
+	assert_deductions(solver.enqueue_wall_strangle, expected)
+
+
 func test_enqueue_island_strangle() -> void:
 	grid = [
 		"           7",
@@ -97,4 +112,14 @@ func test_enqueue_island_release() -> void:
 	var expected: Array[String] = [
 		"(1, 4)->. island_release (0, 4)",
 	]
+	assert_deductions(solver.enqueue_island_release, expected)
+
+
+func test_enqueue_island_release_probes_complete() -> void:
+	grid = [
+		"##    ",
+		" . . .",
+		" 6 . .",
+	]
+	var expected: Array[String] = []
 	assert_deductions(solver.enqueue_island_release, expected)

--- a/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
@@ -500,21 +500,6 @@ func test_enqueue_wall_chokepoints() -> void:
 	assert_deductions(solver.enqueue_wall_chokepoints, expected)
 
 
-func test_enqueue_wall_chokepoints_border_hug() -> void:
-	grid = [
-		"########",
-		"     .##",
-		"     . 7",
-		"      ##",
-		"####    ",
-		" 1##    ",
-	]
-	var expected: Array[String] = [
-		"(0, 1)->## border_hug (0, 0)",
-	]
-	assert_deductions(solver.enqueue_wall_strangle, expected)
-
-
 func test_enqueue_wall_chokepoints_border_hug_invalid_1() -> void:
 	grid = [
 		"   6    ## 1",


### PR DESCRIPTION
Moved border hug tests from basic_techniques to advanced_techniques. This deduction requires bifurcation now.