### PR TITLE
Removed SolverBoard.get_heat(), Probe.related_cells.

### DIFF
--- a/project/src/demo/nurikabe/solver/demo_solver.gd
+++ b/project/src/demo/nurikabe/solver/demo_solver.gd
@@ -152,11 +152,9 @@ func step() -> void:
 		for deduction_index: int in solver.deductions.deductions.size():
 			var shown_index: int = solver.board.version + deduction_index
 			var deduction: Deduction = solver.deductions.deductions[deduction_index]
-			var heat: float = solver.board.get_heat(deduction.pos)
-			_show_message("%s %s heat=%.2f" % \
-					[shown_index, str(deduction), heat])
+			_show_message("%s %s" % \
+					[shown_index, str(deduction)])
 		
-		solver.apply_heat()
 		solver.apply_changes()
 		for change: Dictionary[String, Variant] in changes:
 			%GameBoard.set_cell(change["pos"], change["value"])
@@ -192,7 +190,6 @@ func keep_stepping(idle_step_threshold: int, deduction_threshold: int = 999999, 
 			break
 		solver.run_next_probe(allow_bifurcation)
 		if apply_changes:
-			solver.apply_heat()
 			solver.apply_changes()
 		if old_version == solver.board.version:
 			idle_steps += 1

--- a/project/src/main/nurikabe/solver/probe.gd
+++ b/project/src/main/nurikabe/solver/probe.gd
@@ -4,7 +4,6 @@ var callable: Callable
 var key: String
 var name: String
 var deduction_cells: Array[Vector2i] = []
-var related_cells: Array[Vector2i] = []
 
 var bifurcation: bool = false
 var one_shot: bool = false
@@ -28,17 +27,6 @@ func add_deduction_cells(cells: Array[Vector2i]) -> void:
 func add_deduction_cell(cell: Vector2i) -> void:
 	if not cell in deduction_cells:
 		deduction_cells.append(cell)
-		add_related_cell(cell)
-
-
-func add_related_cells(cells: Array[Vector2i]) -> void:
-	for cell: Vector2i in cells:
-		add_related_cell(cell)
-
-
-func add_related_cell(cell: Vector2i) -> void:
-	if not cell in related_cells:
-		related_cells.append(cell)
 
 
 static func probe_key(target: Callable) -> String:

--- a/project/src/main/nurikabe/solver/probe_library.gd
+++ b/project/src/main/nurikabe/solver/probe_library.gd
@@ -113,13 +113,3 @@ class ProbeBuilder:
 	func deduction_cell(cell: Vector2i) -> ProbeBuilder:
 		probe.add_deduction_cell(cell)
 		return self
-	
-	
-	func related_cells(cells: Array[Vector2i]) -> ProbeBuilder:
-		probe.add_related_cells(cells)
-		return self
-	
-	
-	func related_cell(cell: Vector2i) -> ProbeBuilder:
-		probe.add_related_cell(cell)
-		return self

--- a/project/src/main/nurikabe/solver/solver.gd
+++ b/project/src/main/nurikabe/solver/solver.gd
@@ -85,7 +85,7 @@ func add_bifurcation_scenario(key: String, cells: Array[Vector2i],
 	metrics["bifurcation_scenarios"] += 1
 	bifurcation_engine.add_scenario(board, key, cells, assumptions, bifurcation_deductions)
 	var builder: ProbeLibrary.ProbeBuilder = probe_library.add_probe(run_bifurcation_step) \
-			.set_bifurcation().set_one_shot().related_cells(cells)
+			.set_bifurcation().set_one_shot()
 	for deduction: Deduction in bifurcation_deductions:
 		builder.probe.add_deduction_cell(deduction.pos)
 
@@ -114,11 +114,6 @@ func apply_changes() -> void:
 	bifurcation_engine.clear()
 	
 	_create_change_probes(changes)
-
-
-func apply_heat() -> void:
-	board.decrease_heat()
-	board.increase_heat(deductions.cells.keys())
 
 
 func clear(default_probes: bool = true) -> void:
@@ -185,8 +180,7 @@ func create_wall_probes(wall: Array[Vector2i]) -> void:
 	if liberties.is_empty():
 		return
 	if wall.size() >= 3 and liberties.size() >= 1:
-		probe_library.add_probe(deduce_pool.bind(wall.front())).set_one_shot() \
-				.related_cells(liberties)
+		probe_library.add_probe(deduce_pool.bind(wall.front())).set_one_shot()
 
 
 func create_bifurcation_probes() -> void:
@@ -212,8 +206,7 @@ func create_island_chokepoint_probes() -> void:
 		var liberties: Array[Vector2i] = board.get_liberties(island)
 		if liberties.is_empty():
 			continue
-		probe_library.add_probe(deduce_clue_chokepoint.bind(island.front())).set_one_shot() \
-				.related_cells(liberties)
+		probe_library.add_probe(deduce_clue_chokepoint.bind(island.front())).set_one_shot()
 	_log.end("create_island_chokepoint_probes")
 
 
@@ -238,8 +231,7 @@ func create_island_probes(island: Array[Vector2i]) -> void:
 	
 	if clue_value >= 1:
 		# clued island
-		probe_library.add_probe(deduce_clued_island_snug.bind(island.front())).set_one_shot() \
-				.related_cells(liberties)
+		probe_library.add_probe(deduce_clued_island_snug.bind(island.front())).set_one_shot()
 
 
 ## Executes a bifurcation on two islands which are almost adjacent.
@@ -282,7 +274,7 @@ func create_bifurcation_probe(key: String, cells: Array[Vector2i],
 		bifurcation_deductions: Array[Deduction]) -> void:
 	var builder: ProbeLibrary.ProbeBuilder = probe_library.add_probe(add_bifurcation_scenario.bind(
 			key, cells, assumptions, bifurcation_deductions)) \
-		.set_bifurcation().set_one_shot().related_cells(cells)
+		.set_bifurcation().set_one_shot()
 	for deduction: Deduction in bifurcation_deductions:
 		builder.probe.add_deduction_cell(deduction.pos)
 

--- a/project/src/main/nurikabe/solver/solver_board.gd
+++ b/project/src/main/nurikabe/solver/solver_board.gd
@@ -17,18 +17,9 @@ const CELL_ISLAND: int = NurikabeUtils.CELL_ISLAND
 const CELL_WALL: int = NurikabeUtils.CELL_WALL
 const CELL_EMPTY: int = NurikabeUtils.CELL_EMPTY
 
-const HEAT_RADIUS: int = 2 # how far heat spreads, in cells
-const HEAT_HISTORY: int = 50 # how many heat events are remembered
-const HEAT_SPREAD_FACTOR: float = 0.5 # how effectively heat spreads to neighboring cells; 0.0 = near, 1.0 = far
-const HEAT_FADE_FACTOR: float = 0.9 # how fast heat fades over time; 0.0 = fast, 1.0 = slow
-
 var cells: Dictionary[Vector2i, int]
 var version: int
 
-var _heat_by_cell: Dictionary[Vector2i, float] = {}
-
-## Deferred heat calculations. We defer these until they're needed as they're moderately expensive to calculate.
-var _pending_heat_changes: Array[Callable] = []
 var _cache: Dictionary[String, Variant] = {}
 
 func perform_bfs(start_cells: Array[Vector2i], filter: Callable) -> void:
@@ -51,8 +42,6 @@ func perform_bfs(start_cells: Array[Vector2i], filter: Callable) -> void:
 func duplicate() -> SolverBoard:
 	var copy: SolverBoard = SolverBoard.new()
 	copy.cells = cells.duplicate()
-	copy._heat_by_cell = _heat_by_cell.duplicate()
-	copy._pending_heat_changes = _pending_heat_changes.duplicate()
 	copy._cache = _cache.duplicate()
 	return copy
 
@@ -64,7 +53,6 @@ func from_game_board(game_board: NurikabeGameBoard) -> void:
 		set_cell(cell_pos, game_board.get_cell(cell_pos))
 		if cell_value != CELL_EMPTY:
 			non_empty_cells.append(cell_pos)
-	increase_heat(non_empty_cells)
 
 
 func get_cell(cell_pos: Vector2i) -> int:
@@ -151,24 +139,6 @@ func set_cell(cell_pos: Vector2i, value: int) -> void:
 	_cache.clear()
 	cells[cell_pos] = value
 	version += 1
-
-
-func increase_heat(heated_cells: Array[Vector2i]) -> void:
-	_pending_heat_changes.append(_apply_heat_increase.bind(heated_cells))
-	if _pending_heat_changes.size() > HEAT_HISTORY:
-		_pending_heat_changes.pop_front()
-
-
-func decrease_heat(factor: float = 1.0) -> void:
-	_pending_heat_changes.append(_apply_heat_decrease.bind(factor))
-	if _pending_heat_changes.size() > HEAT_HISTORY:
-		_pending_heat_changes.pop_front()
-
-
-func get_heat(cell: Vector2i) -> float:
-	if _pending_heat_changes:
-		_apply_heat_changes()
-	return _heat_by_cell.get(cell, 0.0)
 
 
 func get_flooded_island_group_map() -> SolverGroupMap:
@@ -569,66 +539,6 @@ func _get_cached(cache_key: String, builder: Callable) -> Variant:
 	if not _cache.has(cache_key):
 		_cache[cache_key] = builder.call()
 	return _cache[cache_key]
-
-
-func _apply_heat_changes() -> void:
-	while not _pending_heat_changes.is_empty():
-		_pending_heat_changes.pop_front().call()
-
-
-func _apply_heat_increase(heated_cells: Array[Vector2i]) -> void:
-	var visited: Dictionary[Vector2i, bool] = {}
-	var queue: Array[Array] = []
-	for cell: Vector2i in heated_cells:
-		visited[cell] = true
-		queue.append([cell, 0])
-	
-	while not queue.is_empty():
-		var queue_item: Array[Variant] = queue.pop_front()
-		var cell: Vector2i = queue_item[0]
-		var heat_distance: int = queue_item[1]
-		
-		_increase_heat_for_cell(cell, heat_distance)
-		
-		var connected_cells: Array[Vector2i]
-		match cells[cell]:
-			CELL_WALL:
-				connected_cells = get_wall_for_cell(cell)
-			CELL_ISLAND:
-				connected_cells = get_island_for_cell(cell)
-			CELL_EMPTY:
-				connected_cells = [cell]
-			_:
-				if NurikabeUtils.is_clue(cells[cell]):
-					connected_cells = get_island_for_cell(cell)
-		var neighbors: Array[Vector2i] = get_group_neighbors(connected_cells)
-		
-		for group_cell: Vector2i in connected_cells:
-			if visited.has(group_cell):
-				continue
-			_increase_heat_for_cell(group_cell, heat_distance)
-			visited[group_cell] = true
-		
-		for neighbor: Vector2i in neighbors:
-			if visited.has(neighbor):
-				continue
-			if heat_distance < HEAT_RADIUS:
-				queue.append([neighbor, heat_distance + 1])
-				visited[neighbor] = true
-			else:
-				_increase_heat_for_cell(neighbor, heat_distance + 1)
-				visited[neighbor] = true
-
-
-func _apply_heat_decrease(factor: float = 1.0) -> void:
-	for cell: Vector2i in _heat_by_cell:
-		_heat_by_cell[cell] *= pow(HEAT_FADE_FACTOR, factor)
-
-
-func _increase_heat_for_cell(cell: Vector2i, distance: int) -> void:
-	if not _heat_by_cell.has(cell):
-		_heat_by_cell[cell] = 0.0
-	_heat_by_cell[cell] += pow(HEAT_SPREAD_FACTOR, distance)
 
 
 class ValidationResult:

--- a/project/src/test/nurikabe/solver/test_solver_board.gd
+++ b/project/src/test/nurikabe/solver/test_solver_board.gd
@@ -351,54 +351,6 @@ func test_complex_bug() -> void:
 	assert_invalid(VALIDATE_COMPLEX, {"wrong_size": [Vector2i(2, 1), Vector2i(2, 2), Vector2i(3, 1)]})
 
 
-func test_increase_heat() -> void:
-	grid = [
-		"######  ##",
-		" 3 .      ",
-		"          ",
-		"   6      ",
-	]
-	var board: SolverBoard = SolverTestUtils.init_board(grid)
-	board.increase_heat([Vector2i(1, 1)])
-	
-	# heat spreads to adjacent walls and their liberties
-	assert_heat(board, Vector2i(0, 0), 0.5)
-	assert_heat(board, Vector2i(1, 0), 0.5)
-	assert_heat(board, Vector2i(2, 0), 0.5)
-	assert_heat(board, Vector2i(3, 0), 0.25)
-	assert_heat(board, Vector2i(4, 0), 0.125)
-	assert_heat(board, Vector2i(4, 1), 0.125)
-	
-	# head spreads to islands and their liberties
-	assert_heat(board, Vector2i(0, 0), 0.5)
-	assert_heat(board, Vector2i(1, 1), 1.0)
-	assert_heat(board, Vector2i(2, 1), 0.5)
-	assert_heat(board, Vector2i(0, 2), 0.5)
-	assert_heat(board, Vector2i(1, 2), 0.5)
-	
-	# heat spreads nearby
-	assert_heat(board, Vector2i(2, 2), 0.25)
-	assert_heat(board, Vector2i(1, 3), 0.25)
-
-
-func test_decrease_heat() -> void:
-	grid = [
-		"######  ##",
-		" 3 .      ",
-		"          ",
-		"   6      ",
-	]
-	var board: SolverBoard = SolverTestUtils.init_board(grid)
-	board.increase_heat([Vector2i(1, 1)])
-	assert_heat(board, Vector2i(1, 1), 1.000)
-	board.decrease_heat(3)
-	assert_heat(board, Vector2i(1, 1), 0.729)
-
-
-func assert_heat(board: SolverBoard, cell: Vector2i, expected_heat: float) -> void:
-	assert_almost_eq(board.get_heat(cell), expected_heat, 0.01)
-
-
 func assert_valid(mode: SolverBoard.ValidationMode) -> void:
 	_assert_validate(mode, {})
 


### PR DESCRIPTION
This was an interesting idea where deductions near busy parts of the board would be prioritized over deductions near idle parts of the board. But the idea of 'near busy parts of the board' requires CPU cycles to track and compare, and in the end it didn't make things faster.