### PR TITLE
Replaced SolverBoard.get_liberties() with CellGroup

### DIFF
--- a/project/src/main/nurikabe/nurikabe_game_board.gd
+++ b/project/src/main/nurikabe/nurikabe_game_board.gd
@@ -320,7 +320,7 @@ func _on_validate_timer_timeout() -> void:
 	var new_lowlight_cells: Dictionary[Vector2i, bool] = {}
 	for cell: Vector2i in model.cells:
 		var cell_value: int = model.get_cell(cell)
-		if NurikabeUtils.is_clue(cell_value) or cell_value == CELL_EMPTY or cell_value == CELL_ISLAND:
+		if NurikabeUtils.is_island_or_empty(cell_value):
 			new_lowlight_cells[cell] = true
 	for joined_island_cell: Vector2i in result_strict.joined_islands:
 		new_lowlight_cells.erase(joined_island_cell)

--- a/project/src/main/nurikabe/nurikabe_utils.gd
+++ b/project/src/main/nurikabe/nurikabe_utils.gd
@@ -42,6 +42,14 @@ static func is_clue(value: int) -> int:
 	return value >= 1 and value <= 255
 
 
+static func is_island(value: int) -> int:
+	return value >= 1 and value <= 256
+
+
+static func is_island_or_empty(value: int) -> int:
+	return value >= 1 and value <= 257
+
+
 static func to_cell_string(value: int) -> String:
 	match value:
 		CELL_INVALID: return CELL_STRING_INVALID

--- a/project/src/main/nurikabe/solver/cell_group.gd
+++ b/project/src/main/nurikabe/solver/cell_group.gd
@@ -1,0 +1,39 @@
+class_name CellGroup
+
+var cells: Array[Vector2i]
+
+## Clue value for this group: 0=none, N=single clue, -1=multiple clues.
+var clue: int = 0
+
+var liberties: Array[Vector2i]
+
+func _to_string() -> String:
+	return JSON.stringify({
+		"cells": cells,
+		"clue": clue,
+		"liberties": liberties,
+	})
+
+
+func duplicate() -> CellGroup:
+	var copy: CellGroup = CellGroup.new()
+	copy.cells = cells.duplicate()
+	copy.clue = clue
+	copy.liberties = liberties.duplicate()
+	return copy
+
+
+## Merges two non-overlapping, non-adjacent groups.
+func merge(other_group: CellGroup) -> void:
+	cells.append_array(other_group.cells)
+	clue = max(clue, other_group.clue) if clue == 0 or other_group.clue == 0 else -1
+	var liberties_set: Dictionary[Vector2i, bool] = {}
+	for liberty: Vector2i in liberties:
+		liberties_set[liberty] = true
+	for other_liberty: Vector2i in other_group.liberties:
+		if not liberties_set.has(other_liberty):
+			liberties.append(other_liberty)
+
+
+func size() -> int:
+	return cells.size()

--- a/project/src/main/nurikabe/solver/cell_group.gd.uid
+++ b/project/src/main/nurikabe/solver/cell_group.gd.uid
@@ -1,0 +1,1 @@
+uid://vi36c6ru4m6h

--- a/project/src/main/nurikabe/solver/probe.gd
+++ b/project/src/main/nurikabe/solver/probe.gd
@@ -33,9 +33,13 @@ static func probe_key(target: Callable) -> String:
 	var value: String = target.get_method()
 	var args: Array[Variant] = target.get_bound_arguments()
 	if not args.is_empty():
-		# only the first two arguments; add_bifurcation_scenario takes a lot of length arguments which aren't needed
-		# in the key
-		value += ":" + JSON.stringify(args.slice(0, 2))
+		# truncate the args to remove unnecessary detail in the keys
+		var sanitized_args: Array[Variant] = args.slice(0, 2)
+		for i in sanitized_args.size():
+			if sanitized_args[i] is CellGroup:
+				sanitized_args[i] = sanitized_args[i].cells.front()
+		
+		value += ":" + JSON.stringify(sanitized_args)
 	return value
 
 

--- a/project/src/test/nurikabe/solver/test_per_clue_chokepoint_map.gd
+++ b/project/src/test/nurikabe/solver/test_per_clue_chokepoint_map.gd
@@ -107,13 +107,15 @@ func test_get_reachable_clues_by_cell() -> void:
 
 func assert_chokepoint_cells(island_cell: Vector2i, expected: Dictionary[Vector2i, int]) -> void:
 	var pccm: PerClueChokepointMap = init_per_clue_chokepoint_map()
-	var actual: Dictionary[Vector2i, int] = pccm.find_chokepoint_cells(island_cell)
+	var island: CellGroup = pccm.board.get_island_for_cell(island_cell)
+	var actual: Dictionary[Vector2i, int] = pccm.find_chokepoint_cells(island)
 	assert_eq(actual, expected)
 
 
 func assert_component_cells(island_cell: Vector2i, expected: Array[Vector2i]) -> void:
 	var pccm: PerClueChokepointMap = init_per_clue_chokepoint_map()
-	var actual: Array[Vector2i] = pccm.get_component_cells(island_cell)
+	var island: CellGroup = pccm.board.get_island_for_cell(island_cell)
+	var actual: Array[Vector2i] = pccm.get_component_cells(island)
 	actual.sort()
 	expected.sort()
 	assert_eq(actual, expected)

--- a/project/src/test/nurikabe/solver/test_per_clue_extent_map.gd
+++ b/project/src/test/nurikabe/solver/test_per_clue_extent_map.gd
@@ -53,7 +53,8 @@ func test_extent_cells_neighbors_2() -> void:
 
 func assert_extent_cells(island_cell: Vector2i, expected: Array[Vector2i]) -> void:
 	var pcem: PerClueExtentMap = init_per_clue_extent_map()
-	var actual: Array[Vector2i] = pcem.get_extent_cells(island_cell)
+	var island: CellGroup = pcem.board.get_island_for_cell(island_cell)
+	var actual: Array[Vector2i] = pcem.get_extent_cells(island)
 	actual.sort()
 	expected.sort()
 	assert_eq(actual, expected)
@@ -61,7 +62,8 @@ func assert_extent_cells(island_cell: Vector2i, expected: Array[Vector2i]) -> vo
 
 func assert_extent_size(island_cell: Vector2i, expected: int) -> void:
 	var pcem: PerClueExtentMap = init_per_clue_extent_map()
-	var actual: int = pcem.get_extent_size(island_cell)
+	var island: CellGroup = pcem.board.get_island_for_cell(island_cell)
+	var actual: int = pcem.get_extent_size(island)
 	assert_eq(actual, expected)
 
 

--- a/project/src/test/nurikabe/solver/test_solver_chokepoint_map.gd
+++ b/project/src/test/nurikabe/solver/test_solver_chokepoint_map.gd
@@ -145,7 +145,7 @@ func _build_island_chokepoint_map() -> SolverChokepointMap:
 	return SolverChokepointMap.new(board,
 		func(cell: Vector2i) -> bool:
 			var value: int = board.get_cell(cell)
-			return NurikabeUtils.is_clue(value) or value == CELL_EMPTY or value == CELL_ISLAND)
+			return NurikabeUtils.is_island(value) or value == CELL_EMPTY)
 
 
 func _build_wall_chokepoint_map() -> SolverChokepointMap:


### PR DESCRIPTION
This CellGroup exposes common fields like cells, clue value and liberties. We maintain these cell groups and build them incrementally, rather than invalidating them and rebuilding them from scratch. This makes the solver about 58% faster (8100 ms -> 5100 ms)