### PR TITLE
Avoid iterating over SolverBoard.cells.

### DIFF
--- a/project/src/main/nurikabe/solver/global_reachability_map.gd
+++ b/project/src/main/nurikabe/solver/global_reachability_map.gd
@@ -46,10 +46,8 @@ func get_nearest_clue_cell(cell: Vector2i) -> Vector2i:
 func _build() -> void:
 	# collect visitable cells (empty cells, or clueless islands)
 	var visitable: Dictionary[Vector2i, bool] = {}
-	for cell: Vector2i in board.cells:
-		var cell_value: int = board.get_cell(cell)
-		if cell_value == CELL_EMPTY:
-			visitable[cell] = true
+	for cell: Vector2i in board.empty_cells:
+		visitable[cell] = true
 	for island: CellGroup in board.islands:
 		if island.clue != 0:
 			continue
@@ -96,7 +94,7 @@ func _build() -> void:
 			queue.append(neighbor)
 	
 	# classify each cell into ClueReachability categories
-	for cell: Vector2i in board.cells:
+	for cell: Vector2i in visitable:
 		var reachability: ClueReachability = ClueReachability.UNKNOWN
 		if not _reach_score_by_cell.has(cell):
 			reachability = ClueReachability.IMPOSSIBLE

--- a/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
+++ b/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
@@ -23,10 +23,8 @@ func _init(init_board: SolverBoard) -> void:
 	board = init_board
 	
 	# collect visitable cells (empty cells, or clueless islands)
-	for cell: Vector2i in board.cells:
-		var cell_value: int = board.get_cell(cell)
-		if cell_value == CELL_EMPTY:
-			_visitable[cell] = true
+	for cell: Vector2i in board.empty_cells:
+		_visitable[cell] = true
 	for island: CellGroup in board.islands:
 		if island.clue != 0:
 			continue
@@ -119,9 +117,11 @@ func get_wall_exclusion_map(island: CellGroup) -> GroupMap:
 	for component_cell: Vector2i in get_component_cells(island):
 		component_cell_set[component_cell] = true
 	var cells: Array[Vector2i] = []
-	for cell: Vector2i in board.cells:
-		var value: int = board.get_cell(cell)
-		if value == CELL_WALL or (value == CELL_EMPTY and not cell in component_cell_set):
+	for wall: CellGroup in board.walls:
+		for cell in wall.cells:
+			cells.append(cell)
+	for cell: Vector2i in board.empty_cells:
+		if not cell in component_cell_set:
 			cells.append(cell)
 	return GroupMap.new(cells)
 

--- a/project/src/main/nurikabe/solver/per_clue_extent_map.gd
+++ b/project/src/main/nurikabe/solver/per_clue_extent_map.gd
@@ -22,10 +22,8 @@ func _init(init_board: SolverBoard) -> void:
 	board = init_board
 	
 	# collect visitable cells (empty cells, or clueless islands)
-	for cell: Vector2i in board.cells:
-		var cell_value: int = board.get_cell(cell)
-		if cell_value == CELL_EMPTY:
-			_visitable[cell] = true
+	for cell: Vector2i in board.empty_cells:
+		_visitable[cell] = true
 	for island: CellGroup in board.islands:
 		if island.clue != 0:
 			continue
@@ -74,7 +72,6 @@ func _init_extent_map(island: CellGroup) -> void:
 		extent_map[cell] = true
 	
 	_extent_map_by_clue[island.cells.front()] = extent_map
-	SplitTimer.end()
 
 
 func needs_buffer(island: CellGroup, cell: Vector2i) -> bool:

--- a/project/src/test/nurikabe/solver/test_global_reachability_map.gd
+++ b/project/src/test/nurikabe/solver/test_global_reachability_map.gd
@@ -10,10 +10,10 @@ func test_get_clue_reachability() -> void:
 	]
 	var grm: GlobalReachabilityMap = init_global_reachability_map()
 	assert_eq(grm.get_clue_reachability(Vector2(0, 0)), GlobalReachabilityMap.ClueReachability.UNREACHABLE)
-	assert_eq(grm.get_clue_reachability(Vector2(0, 2)), GlobalReachabilityMap.ClueReachability.IMPOSSIBLE)
+	assert_eq(grm.get_clue_reachability(Vector2(0, 2)), GlobalReachabilityMap.ClueReachability.UNKNOWN)
 	assert_eq(grm.get_clue_reachability(Vector2(0, 1)), GlobalReachabilityMap.ClueReachability.REACHABLE)
 	assert_eq(grm.get_clue_reachability(Vector2(1, 2)), GlobalReachabilityMap.ClueReachability.CONFLICT)
-	assert_eq(grm.get_clue_reachability(Vector2(2, 0)), GlobalReachabilityMap.ClueReachability.IMPOSSIBLE)
+	assert_eq(grm.get_clue_reachability(Vector2(2, 0)), GlobalReachabilityMap.ClueReachability.UNKNOWN)
 	assert_eq(grm.get_clue_reachability(Vector2(3, 0)), GlobalReachabilityMap.ClueReachability.IMPOSSIBLE)
 
 


### PR DESCRIPTION
Boards have a lot of cells; it's better to iterate over empty cells or a subset of cells.