### PR TITLE
Separated SolverBoard.clues.

### DIFF
--- a/project/src/demo/nurikabe/solver/demo_solver.gd
+++ b/project/src/demo/nurikabe/solver/demo_solver.gd
@@ -135,7 +135,8 @@ func step() -> void:
 
 func copy_board_from_solver() -> void:
 	for cell: Vector2i in solver.board.cells:
-		%GameBoard.set_cell(cell, solver.board.get_cell(cell))
+		if not solver.board.has_clue(cell):
+			%GameBoard.set_cell(cell, solver.board.get_cell(cell))
 
 
 func solve_until_bifurcation() -> void:

--- a/project/src/main/nurikabe/nurikabe_game_board.gd
+++ b/project/src/main/nurikabe/nurikabe_game_board.gd
@@ -320,7 +320,7 @@ func _on_validate_timer_timeout() -> void:
 	var new_lowlight_cells: Dictionary[Vector2i, bool] = {}
 	for cell: Vector2i in model.cells:
 		var cell_value: int = model.get_cell(cell)
-		if NurikabeUtils.is_island_or_empty(cell_value):
+		if cell_value == CELL_ISLAND or cell_value == CELL_EMPTY or model.has_clue(cell):
 			new_lowlight_cells[cell] = true
 	for joined_island_cell: Vector2i in result_strict.joined_islands:
 		new_lowlight_cells.erase(joined_island_cell)

--- a/project/src/main/nurikabe/nurikabe_utils.gd
+++ b/project/src/main/nurikabe/nurikabe_utils.gd
@@ -42,14 +42,6 @@ static func is_clue(value: int) -> int:
 	return value >= 1 and value <= 255
 
 
-static func is_island(value: int) -> int:
-	return value >= 1 and value <= 256
-
-
-static func is_island_or_empty(value: int) -> int:
-	return value >= 1 and value <= 257
-
-
 static func to_cell_string(value: int) -> String:
 	match value:
 		CELL_INVALID: return CELL_STRING_INVALID

--- a/project/src/main/nurikabe/solver/solver.gd
+++ b/project/src/main/nurikabe/solver/solver.gd
@@ -443,7 +443,7 @@ func deduce_all_bubbles() -> void:
 		var bubble: bool = true
 		for neighbor_dir: Vector2i in NEIGHBOR_DIRS:
 			var neighbor_value: int = board.get_cell(cell + neighbor_dir)
-			if neighbor_value != CELL_INVALID and not NurikabeUtils.is_island(neighbor_value):
+			if neighbor_value != CELL_INVALID and neighbor_value != CELL_ISLAND:
 				bubble = false
 				break
 		if bubble:
@@ -509,8 +509,7 @@ func deduce_island_chokepoint_cramped(chokepoint: Vector2i) -> void:
 	var clue_cell: Vector2i = board.get_global_reachability_map().get_nearest_clue_cell(chokepoint)
 	if clue_cell == POS_NOT_FOUND:
 		return
-	var chokepoint_value: int = board.get_cell(chokepoint)
-	var clue_value: int = chokepoint_value if NurikabeUtils.is_clue(chokepoint_value) else 0
+	var clue_value: int = board.get_clue(clue_cell)
 	var unchoked_cell_count: int = \
 			board.get_island_chokepoint_map().get_unchoked_cell_count(chokepoint, clue_cell)
 	if unchoked_cell_count < clue_value:
@@ -867,7 +866,7 @@ func _find_clued_neighbor_roots(cell: Vector2i) -> Array[Vector2i]:
 	for neighbor_dir: Vector2i in NEIGHBOR_DIRS:
 		var neighbor: Vector2i = cell + neighbor_dir
 		var neighbor_value: int = board.get_cell(neighbor)
-		if not NurikabeUtils.is_island(neighbor_value):
+		if neighbor_value != CELL_ISLAND:
 			continue
 		var island: CellGroup = board.get_island_for_cell(neighbor)
 		if island.clue == 0:
@@ -879,7 +878,7 @@ func _find_clued_neighbor_roots(cell: Vector2i) -> Array[Vector2i]:
 func _get_unique_islands(cells: Array[Vector2i]) -> Array[CellGroup]:
 	var islands: Dictionary[CellGroup, bool] = {}
 	for cell: Vector2i in cells:
-		if not NurikabeUtils.is_island(board.get_cell(cell)):
+		if board.get_cell(cell) != CELL_ISLAND:
 			continue
 		var island: CellGroup = board.get_island_for_cell(cell)
 		islands[island] = true

--- a/project/src/test/nurikabe/solver/solver_test_utils.gd
+++ b/project/src/test/nurikabe/solver/solver_test_utils.gd
@@ -6,5 +6,10 @@ static func init_board(grid: Array[String]) -> SolverBoard:
 		var row_string: String = grid[y]
 		@warning_ignore("integer_division")
 		for x in row_string.length() / 2:
-			board.set_cell(Vector2i(x, y), NurikabeUtils.from_cell_string(row_string.substr(x * 2, 2).strip_edges()))
+			var cell: Vector2i = Vector2i(x, y)
+			var cell_value: int = NurikabeUtils.from_cell_string(row_string.substr(x * 2, 2).strip_edges())
+			if NurikabeUtils.is_clue(cell_value):
+				board.set_clue(cell, cell_value)
+			else:
+				board.set_cell(cell, cell_value)
 	return board

--- a/project/src/test/nurikabe/solver/test_solver_chokepoint_map.gd
+++ b/project/src/test/nurikabe/solver/test_solver_chokepoint_map.gd
@@ -145,7 +145,7 @@ func _build_island_chokepoint_map() -> SolverChokepointMap:
 	return SolverChokepointMap.new(board,
 		func(cell: Vector2i) -> bool:
 			var value: int = board.get_cell(cell)
-			return NurikabeUtils.is_island(value) or value == CELL_EMPTY)
+			return value == CELL_ISLAND or value == CELL_EMPTY)
 
 
 func _build_wall_chokepoint_map() -> SolverChokepointMap:


### PR DESCRIPTION
Keeping this separate makes our logic simpler. We don't have to worry about "is this an island cell, or a clue number". It makes our code about 6% faster (3300 ms -> 3100)