### PR TITLE
Optimized BFS implementation.

### DIFF
--- a/project/src/main/nurikabe/solver/solver_board.gd
+++ b/project/src/main/nurikabe/solver/solver_board.gd
@@ -47,24 +47,21 @@ var groups_need_rebuild: bool = true
 var _cache: Dictionary[String, Variant] = {}
 
 func perform_bfs(start_cells: Array[Vector2i], filter: Callable) -> Array[Vector2i]:
-	var result: Array[Vector2i] = []
+	var result: Array[Vector2i] = start_cells.filter(filter)
 	var visited: Dictionary[Vector2i, bool] = {}
-	for start_cell: Vector2i in start_cells:
-		visited[start_cell] = true
-	var queue: Array[Vector2i] = start_cells.duplicate()
-	while not queue.is_empty():
-		var next_cell: Vector2i = queue.pop_front()
-		if not filter.call(next_cell):
-			continue
-		result.append(next_cell)
+	for cell: Vector2i in start_cells:
+		visited[cell] = true
+	var current_index: int = 0
+	while current_index < result.size():
+		var next_cell: Vector2i = result[current_index]
 		for neighbor_dir: Vector2i in NEIGHBOR_DIRS:
 			var neighbor: Vector2i = next_cell + neighbor_dir
-			if not cells.has(neighbor):
-				continue
 			if visited.has(neighbor):
 				continue
 			visited[neighbor] = true
-			queue.append(neighbor)
+			if cells.has(neighbor) and filter.call(neighbor):
+				result.append(neighbor)
+		current_index += 1
 	return result
 
 


### PR DESCRIPTION
This new BFS has several improvements:
 - Iteration queue is replaced with an index integer
 - The small visited dict is evaluated before the large cells dict
 - Items not matching our filter are excluded from the queue

It runs about 28% faster than the old BFS (670 ms -> 522)