### PR TITLE
Added support for 'mystery clues'

### DIFF
--- a/project/src/main/nurikabe/nurikabe_utils.gd
+++ b/project/src/main/nurikabe/nurikabe_utils.gd
@@ -7,10 +7,12 @@ extends Node
 ## 	256: Island
 ## 	257: Empty (unknown, either island or wall)
 ## 	258: Wall
+## 	259: Clue (unknown size)
 const CELL_INVALID := 0
 const CELL_ISLAND := 256
 const CELL_EMPTY := 257
 const CELL_WALL := 258
+const CELL_MYSTERY_CLUE := 259
 
 ## Nurikabe cell strings:
 ## 	['0'-'99']: Clue
@@ -22,6 +24,7 @@ const CELL_STRING_EMPTY := ""
 const CELL_STRING_INVALID := "!"
 const CELL_STRING_ISLAND := "."
 const CELL_STRING_WALL := "##"
+const CELL_STRING_MYSTERY_CLUE := "?"
 
 const ERROR_FG_COLOR: Color = Color.WHITE
 const ERROR_BG_COLOR: Color = Color("ff5a5a")
@@ -39,7 +42,7 @@ static func pool_triplet(cell: Vector2i, dir: Vector2i) -> Array[Vector2i]:
 
 
 static func is_clue(value: int) -> int:
-	return value >= 1 and value <= 255
+	return value >= 1 and value <= 255 or value == CELL_MYSTERY_CLUE
 
 
 static func to_cell_string(value: int) -> String:
@@ -48,6 +51,7 @@ static func to_cell_string(value: int) -> String:
 		CELL_ISLAND: return CELL_STRING_ISLAND
 		CELL_WALL: return CELL_STRING_WALL
 		CELL_EMPTY: return CELL_STRING_EMPTY
+		CELL_MYSTERY_CLUE: return CELL_STRING_MYSTERY_CLUE
 		_: return str(value)
 
 
@@ -57,4 +61,5 @@ static func from_cell_string(value: String) -> int:
 		CELL_STRING_ISLAND: return CELL_ISLAND
 		CELL_STRING_WALL: return CELL_WALL
 		CELL_STRING_EMPTY: return CELL_EMPTY
+		CELL_STRING_MYSTERY_CLUE: return CELL_MYSTERY_CLUE
 		_: return value.to_int()

--- a/project/src/main/nurikabe/solver/global_reachability_map.gd
+++ b/project/src/main/nurikabe/solver/global_reachability_map.gd
@@ -16,6 +16,7 @@ const CELL_INVALID: int = NurikabeUtils.CELL_INVALID
 const CELL_ISLAND: int = NurikabeUtils.CELL_ISLAND
 const CELL_WALL: int = NurikabeUtils.CELL_WALL
 const CELL_EMPTY: int = NurikabeUtils.CELL_EMPTY
+const CELL_MYSTERY_CLUE: int = NurikabeUtils.CELL_MYSTERY_CLUE
 
 const POS_NOT_FOUND: Vector2i = NurikabeUtils.POS_NOT_FOUND
 
@@ -59,7 +60,7 @@ func _build() -> void:
 	for island: CellGroup in board.islands:
 		if island.clue == 0:
 			continue
-		var reachability: int = island.clue - island.size()
+		var reachability: int = island.clue - island.size() if island.clue != CELL_MYSTERY_CLUE else 999999
 		for liberty: Vector2i in island.liberties:
 			if _reach_score_by_cell.has(liberty):
 				# cell is adjacent to two or more islands, so no islands can reach it

--- a/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
+++ b/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
@@ -8,6 +8,7 @@ const CELL_INVALID: int = NurikabeUtils.CELL_INVALID
 const CELL_ISLAND: int = NurikabeUtils.CELL_ISLAND
 const CELL_WALL: int = NurikabeUtils.CELL_WALL
 const CELL_EMPTY: int = NurikabeUtils.CELL_EMPTY
+const CELL_MYSTERY_CLUE: int = NurikabeUtils.CELL_MYSTERY_CLUE
 
 var board: SolverBoard
 
@@ -73,7 +74,7 @@ func find_chokepoint_cells(island: CellGroup) -> Dictionary[Vector2i, int]:
 	
 	for chokepoint: Vector2i in chokepoint_map.chokepoints_by_cell:
 		var unchoked_cell_count: int = chokepoint_map.get_unchoked_cell_count(chokepoint, island.cells.front())
-		if unchoked_cell_count >= island.clue:
+		if unchoked_cell_count >= island.clue or island.clue == CELL_MYSTERY_CLUE:
 			continue
 		
 		if board.get_cell(chokepoint) == CELL_EMPTY:
@@ -134,7 +135,7 @@ func _init_chokepoint_map(island: CellGroup) -> void:
 	var reach_score_by_cell: Dictionary[Vector2i, int] = {}
 	var queue: Array[Vector2i] = [island.cells.front()]
 	
-	var reachability: int = island.clue - island.size()
+	var reachability: int = island.clue - island.size() if island.clue != CELL_MYSTERY_CLUE else 999999
 	for other_island_cell: Vector2i in island.cells:
 		reach_score_by_cell[other_island_cell] = reachability + 1
 	for liberty: Vector2i in island.liberties:

--- a/project/src/main/nurikabe/solver/per_clue_extent_map.gd
+++ b/project/src/main/nurikabe/solver/per_clue_extent_map.gd
@@ -9,6 +9,7 @@ const CELL_INVALID: int = NurikabeUtils.CELL_INVALID
 const CELL_ISLAND: int = NurikabeUtils.CELL_ISLAND
 const CELL_WALL: int = NurikabeUtils.CELL_WALL
 const CELL_EMPTY: int = NurikabeUtils.CELL_EMPTY
+const CELL_MYSTERY_CLUE: int = NurikabeUtils.CELL_MYSTERY_CLUE
 
 var board: SolverBoard
 
@@ -65,7 +66,7 @@ func _init_extent_map(island: CellGroup) -> void:
 	for cell: Vector2i in island.cells:
 		extent_map[cell] = true
 	var extent_list: Array[Vector2i] = board.perform_bfs(island.liberties, func(cell: Vector2i) -> bool:
-		return extent_map.size() <= island.clue \
+		return (extent_map.size() <= island.clue or island.clue == CELL_MYSTERY_CLUE) \
 				and _visitable.has(cell) \
 				and (not _claimed_by_clue.has(cell) or _claimed_by_clue[cell] == island.cells.front()))
 	for cell: Vector2i in extent_list:

--- a/project/src/main/nurikabe/tile_map_clue.gd
+++ b/project/src/main/nurikabe/tile_map_clue.gd
@@ -40,19 +40,20 @@ extends Node2D
 func _draw() -> void:
 	for cell: Vector2i in clues_by_cell:
 		var clue: int = clues_by_cell[cell]
+		var clue_string: String = "?" if clue == NurikabeUtils.CELL_MYSTERY_CLUE else str(clue)
 		var clue_scale := Vector2.ONE if clue <= 9 else Vector2(0.66667, 1)
 		draw_set_transform(Vector2(tile_size) * (Vector2(cell) + Vector2.DOWN) + Vector2.UP * font_padding,
 				0.0, clue_scale)
 		if cell in error_cells:
-			draw_string_outline(font, Vector2.ZERO, str(clue), HORIZONTAL_ALIGNMENT_CENTER,
+			draw_string_outline(font, Vector2.ZERO, clue_string, HORIZONTAL_ALIGNMENT_CENTER,
 					tile_size.x / clue_scale.x, font_size, 36, NurikabeUtils.ERROR_BG_COLOR)
-			draw_string(font, Vector2.ZERO, str(clue), HORIZONTAL_ALIGNMENT_CENTER,
+			draw_string(font, Vector2.ZERO, clue_string, HORIZONTAL_ALIGNMENT_CENTER,
 					tile_size.x / clue_scale.x, font_size, NurikabeUtils.ERROR_FG_COLOR)
 		elif cell in lowlight_cells:
-			draw_string(font, Vector2.ZERO, str(clue), HORIZONTAL_ALIGNMENT_CENTER,
+			draw_string(font, Vector2.ZERO, clue_string, HORIZONTAL_ALIGNMENT_CENTER,
 					tile_size.x / clue_scale.x, font_size, NurikabeUtils.CLUE_LOWLIGHT_COLOR)
 		else:
-			draw_string(font, Vector2.ZERO, str(clue), HORIZONTAL_ALIGNMENT_CENTER,
+			draw_string(font, Vector2.ZERO, clue_string, HORIZONTAL_ALIGNMENT_CENTER,
 					tile_size.x / clue_scale.x, font_size, NurikabeUtils.CLUE_COLOR)
 
 


### PR DESCRIPTION
Mystery clues are useful when constructing a puzzle. They represent islands of an unknown size.

Most deductions such as the island moat deduction and corner deductions are invalidated by mystery clues.