### PR TITLE
Simple 'generate_initial_open_island' logic works

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -264,7 +264,7 @@ fi
 # arrays missing type hint
 RESULT=$(grep -R -n "\(^[^#]*Array[^\[]\|:= \[\]\)" --include="*.gd" project/src \
   | grep -v "\(Array\]\|\[Array\)" \
-  | grep -v "PackedVector2Array\|PackedStringArray\|PackedInt32Array" \
+  | grep -v "PackedFloat32Array\|PackedVector2Array\|PackedStringArray\|PackedInt32Array" \
   )
 if [ -n "$RESULT" ]; then
   echo ""
@@ -288,7 +288,7 @@ RESULT=$(grep -R -n " := " --include="*.gd" project/src \
   | grep -v " := \(true\|false\)" \
   | grep -v " := \(\"\|'\|r\"\|&\"\|^\"\)" \
   | grep -v " := \(\[\|\{\)" \
-  | grep -v " := \(Color\|Vector\|Vector2i\|PackedStringArray\)" \
+  | grep -v " := \(Color\|Vector\|Vector2i\|PackedFloat32Array\|PackedStringArray\)" \
   | grep -v " := [A-Z][A-Za-z0-9]*\.new()" \
   )
 if [ -n "$RESULT" ]; then

--- a/project/src/demo/nurikabe/generator/demo_generator.gd
+++ b/project/src/demo/nurikabe/generator/demo_generator.gd
@@ -4,6 +4,7 @@ extends Node
 ## 	[kbd]Q[/kbd]: Solve one step.
 ## 	[kbd]Shift + Q[/kbd]: Solve five steps.
 ## 	[kbd]W[/kbd]: Test a full solution.
+## 	[kbd]R[/kbd]: Clear the board.
 ## 	[kbd]G[/kbd]: Generate a puzzle.
 
 const PUZZLE_SIZES: Array[Vector2i] = [
@@ -45,6 +46,10 @@ func _input(event: InputEvent) -> void:
 		KEY_G:
 			generator.board = %GameBoard.to_generator_board()
 			generator.generate()
+			copy_board_from_generator()
+		KEY_R:
+			generator.clear()
+			%GameBoard.reset()
 			copy_board_from_generator()
 
 

--- a/project/src/main/nurikabe/generator/generator.gd
+++ b/project/src/main/nurikabe/generator/generator.gd
@@ -1,6 +1,180 @@
 class_name Generator
 
+const CELL_INVALID: int = NurikabeUtils.CELL_INVALID
+const CELL_ISLAND: int = NurikabeUtils.CELL_ISLAND
+const CELL_WALL: int = NurikabeUtils.CELL_WALL
+const CELL_EMPTY: int = NurikabeUtils.CELL_EMPTY
+const CELL_MYSTERY_CLUE: int = NurikabeUtils.CELL_MYSTERY_CLUE
+
+const NEIGHBOR_DIRS: Array[Vector2i] = NurikabeUtils.NEIGHBOR_DIRS
+const NEIGHBOR_DIRS_WITH_SELF: Array[Vector2i] = NurikabeUtils.NEIGHBOR_DIRS_WITH_SELF
+
+const INITIAL_OPEN_ISLAND_EDGE_WEIGHT: float = 1.5
+const INITIAL_OPEN_ISLAND_CORNER_WEIGHT: float = 0.25
+const INITIAL_OPEN_ISLAND_INTERIOR_WEIGHT: float = 0.5
+
+var rng: RandomNumberGenerator = RandomNumberGenerator.new()
 var board: GeneratorBoard
 
+func clear() -> void:
+	board.clear()
+
+
 func generate() -> void:
-	board.solver_board.set_clue(Vector2i(0, 0), 1)
+	generate_initial_open_island()
+
+
+func generate_initial_open_island() -> void:
+	for _mercy in 10:
+		# island_plan keys:
+		# - seed_cell: Vector2i
+		# - open_liberty: Vector2i
+		# - supporting_clues: Dictionary[Vector2i, bool]
+		var island_plan: Dictionary[String, Variant] = {}
+		_select_initial_open_island_candidate(island_plan)
+		_plan_initial_open_island_walls(island_plan)
+		
+		if island_plan.has("seed_cell") and island_plan.has("supporting_clues"):
+			board.set_clue(island_plan["seed_cell"], NurikabeUtils.CELL_MYSTERY_CLUE)
+			for other_clue: Vector2i in island_plan["supporting_clues"]:
+				board.set_clue(other_clue, NurikabeUtils.CELL_MYSTERY_CLUE)
+			break
+
+
+## Selects an initial open-island candidate: a new clue cell constrained to expand through a single open liberty. Most
+## Nurikabe puzzles begin with at least one such forced expansion.
+## [br]
+## island_plan keys: [br]
+## - seed_cell: Vector2i [br]
+## - open_liberty: Vector2i [br]
+## - supporting_clues: Dictionary[Vector2i, bool] [br]
+func _select_initial_open_island_candidate(island_plan: Dictionary[String, Variant]) -> void:
+	var corner_cells: Array[Vector2i] = []
+	var edge_cells: Array[Vector2i] = []
+	var interior_cells: Array[Vector2i] = []
+	for cell: Vector2i in board.cells:
+		var empty_neighbor_cell_count: int = _empty_neighbor_cell_count(cell)
+		match empty_neighbor_cell_count:
+			2: corner_cells.append(cell)
+			3: edge_cells.append(cell)
+			4: interior_cells.append(cell)
+	
+	var potential_cells: Array[Vector2i]
+	var weights := PackedFloat32Array([
+		INITIAL_OPEN_ISLAND_CORNER_WEIGHT,
+		INITIAL_OPEN_ISLAND_EDGE_WEIGHT,
+		INITIAL_OPEN_ISLAND_INTERIOR_WEIGHT,
+	])
+	match rng.rand_weighted(weights):
+		0: potential_cells = corner_cells
+		1: potential_cells = edge_cells
+		2: potential_cells = interior_cells
+	if potential_cells.is_empty():
+		potential_cells = board.cells.keys()
+	if potential_cells.is_empty():
+		return
+	var seed_cell: Vector2i = potential_cells.pick_random()
+	
+	var potential_preserved_liberties: Array[Vector2i] = []
+	for neighbor_dir: Vector2i in NEIGHBOR_DIRS:
+		var neighbor: Vector2i = seed_cell + neighbor_dir
+		var neighbor_value: int = board.get_cell(neighbor)
+		if neighbor_value == CELL_EMPTY:
+			potential_preserved_liberties.append(neighbor)
+	
+	if potential_preserved_liberties.is_empty():
+		return
+	var open_liberty: Vector2i = potential_preserved_liberties.pick_random()
+	
+	island_plan["seed_cell"] = seed_cell
+	island_plan["open_liberty"] = open_liberty
+
+
+## Augments the open-island candidate with supporting clues. These additional clues constrain the surrounding walls so
+## that the island may expand only through its designated open liberty.
+## [br]
+## island_plan keys: [br]
+## - seed_cell: Vector2i [br]
+## - open_liberty: Vector2i [br]
+## - supporting_clues: Dictionary[Vector2i, bool] [br]
+func _plan_initial_open_island_walls(island_plan: Dictionary[String, Variant]) -> void:
+	if not island_plan.has("seed_cell") or not island_plan.has("open_liberty"):
+		return
+	
+	var seed_cell: Vector2i = island_plan["seed_cell"]
+	var open_liberty: Vector2i = island_plan["open_liberty"]
+	var initial_wall_cells: Dictionary[Vector2i, bool] = {}
+	for neighbor_dir: Vector2i in NEIGHBOR_DIRS:
+		var neighbor: Vector2i = seed_cell + neighbor_dir
+		if neighbor == open_liberty:
+			continue
+		if board.get_cell(neighbor) != CELL_EMPTY:
+			continue
+		initial_wall_cells[neighbor] = true
+	
+	# If the island's surrounding wall is in a corner, it inevitably results in a split wall.
+	if initial_wall_cells.keys().any(func(cell: Vector2i) -> bool:
+			var empty_neighbor_cell_count: int = _empty_neighbor_cell_count(cell)
+			return empty_neighbor_cell_count <= 2):
+		return
+	
+	var supporting_clues: Dictionary[Vector2i, bool] = {}
+	var mercy: int = 0
+	var remaining_wall_cells: Dictionary[Vector2i, bool] = initial_wall_cells.duplicate()
+	while not remaining_wall_cells.is_empty() and mercy < 10:
+		mercy += 1
+		var other_wall: Vector2i = remaining_wall_cells.keys().pick_random()
+		var other_clue: Vector2i = NurikabeUtils.POS_NOT_FOUND
+		for potential_other_clue_dir: Vector2i in NEIGHBOR_DIRS.duplicate():
+			var potential_other_clue: Vector2i = other_wall + potential_other_clue_dir
+			if potential_other_clue == seed_cell:
+				continue
+			if potential_other_clue.distance_to(open_liberty) <= 1:
+				continue
+			if board.get_cell(potential_other_clue) != CELL_EMPTY:
+				continue
+			var adjacent_other_wall_count: int = 0
+			for adjacent_other_wall_dir: Vector2i in NEIGHBOR_DIRS:
+				var adjacent_other_wall: Vector2i = potential_other_clue + adjacent_other_wall_dir
+				if remaining_wall_cells.has(adjacent_other_wall):
+					adjacent_other_wall_count += 1
+			if adjacent_other_wall_count >= 2:
+				other_clue = potential_other_clue
+				break
+			elif other_clue == NurikabeUtils.POS_NOT_FOUND:
+				other_clue = potential_other_clue
+		
+		if other_clue == NurikabeUtils.POS_NOT_FOUND:
+			continue
+		supporting_clues[other_clue] = true
+		for removed_other_wall_dir: Vector2i in NEIGHBOR_DIRS:
+			var removed_other_wall: Vector2i = other_clue + removed_other_wall_dir
+			if remaining_wall_cells.has(removed_other_wall):
+				remaining_wall_cells.erase(removed_other_wall)
+	
+	if not remaining_wall_cells.is_empty():
+		return
+	
+	var new_clues: Array[Vector2i] = []
+	new_clues.append_array(supporting_clues.keys())
+	new_clues.append(seed_cell)
+	var bfs_walls: Array[Vector2i] = board.solver_board.perform_bfs([initial_wall_cells.keys().front()],
+		func(c: Vector2i) -> bool:
+			var cell_value: int = board.solver_board.get_cell(c)
+			return cell_value == CELL_WALL or (cell_value == CELL_EMPTY and not new_clues.has(c)))
+	if not initial_wall_cells.keys().all(
+		func(c: Vector2i) -> bool:
+			return bfs_walls.has(c)):
+		return
+	
+	island_plan["supporting_clues"] = supporting_clues
+
+
+func _empty_neighbor_cell_count(cell: Vector2i) -> int:
+	var count: int = 0
+	for neighbor_dir: Vector2i in NEIGHBOR_DIRS:
+		var neighbor: Vector2i = cell + neighbor_dir
+		var neighbor_value: int = board.get_cell(neighbor)
+		if neighbor_value == CELL_EMPTY:
+			count += 1
+	return count

--- a/project/src/main/nurikabe/generator/generator_board.gd
+++ b/project/src/main/nurikabe/generator/generator_board.gd
@@ -1,6 +1,26 @@
 class_name GeneratorBoard
 
+var cells: Dictionary[Vector2i, int]:
+	get():
+		return solver_board.cells
+
 var solver_board: SolverBoard = SolverBoard.new()
+
+func clear() -> void:
+	solver_board.clear()
+
 
 func from_game_board(game_board: NurikabeGameBoard) -> void:
 	solver_board.from_game_board(game_board)
+
+
+func set_cell(cell_pos: Vector2i, value: int) -> void:
+	solver_board.set_cell(cell_pos, value)
+
+
+func set_clue(cell_pos: Vector2i, value: int) -> void:
+	solver_board.set_clue(cell_pos, value)
+
+
+func get_cell(cell_pos: Vector2i) -> int:
+	return solver_board.get_cell(cell_pos)


### PR DESCRIPTION
This 'initial open island' logic can generate an island in the middle, corner or edge of the playfield. The island is guided to expand in a particular direction by other islands.