### PR TITLE
Generator: Undo, logging, checkpoints

### DIFF
--- a/project/src/main/nurikabe/generator/generator_board.gd
+++ b/project/src/main/nurikabe/generator/generator_board.gd
@@ -8,9 +8,16 @@ const CELL_MYSTERY_CLUE: int = NurikabeUtils.CELL_MYSTERY_CLUE
 
 var solver_board: SolverBoard = SolverBoard.new()
 
+var version: int:
+	get():
+		return solver_board.version
+
 var cells: Dictionary[Vector2i, int]:
 	get():
 		return solver_board.cells
+var clues: Dictionary[Vector2i, int]:
+	get():
+		return solver_board.clues
 var empty_cells: Dictionary[Vector2i, bool] = {}:
 	get:
 		return solver_board.empty_cells
@@ -59,6 +66,7 @@ func set_clue(cell_pos: Vector2i, value: int) -> void:
 
 func get_cell(cell_pos: Vector2i) -> int:
 	return solver_board.get_cell(cell_pos)
+
 
 func has_clue(cell_pos: Vector2i) -> int:
 	return solver_board.has_clue(cell_pos)


### PR DESCRIPTION
Generator supports undo. Will retry from a checkpoint 5 times, and then load from an earlier checkpoint.

Generator stores checkpoints. Checkpoints are saved every time the generator steps without introducing validation errors.

Generator maintains an event log to support the demo. The demo used to duplicate the logic of 'keep stepping the generator.... but add a few log messages'. This is impractical now that the generator's execution flow is more complex, a log is a better fit. We should eventually roll this out to the solver as well.