### PR TITLE
Tweaks: small island bias, chokepoint crash, step_until_done limit, etc

### DIFF
--- a/project/src/main/nurikabe/generator/generator_board.gd
+++ b/project/src/main/nurikabe/generator/generator_board.gd
@@ -82,5 +82,9 @@ func get_clue(cell_pos: Vector2i) -> int:
 	return clues[cell_pos]
 
 
+func get_island_for_cell(cell: Vector2i) -> CellGroup:
+	return solver_board.get_island_for_cell(cell)
+
+
 func has_clue(cell_pos: Vector2i) -> int:
 	return solver_board.has_clue(cell_pos)

--- a/project/src/main/nurikabe/generator/placement.gd
+++ b/project/src/main/nurikabe/generator/placement.gd
@@ -7,7 +7,7 @@ enum Reason {
 	INITIAL_OPEN_ISLAND, # add a clue cell constrained to expand through a single open liberty
 	
 	# basic techniques
-	ISLAND_GUIDE, # add a clue cell to constrain an open island
+	ISLAND_GUIDE, # add a clue cell to constrain an open island (adjacent or diagonal)
 	ISLAND_EXPANSION, # add an island cell to expand an open island
 	ISLAND_MOAT, # seal an open island with walls
 	SEALED_ISLAND_CLUE, # assign a clue number to a sealed island

--- a/project/src/main/nurikabe/solver/global_reachability_map.gd
+++ b/project/src/main/nurikabe/solver/global_reachability_map.gd
@@ -40,7 +40,7 @@ func get_clue_reachability(cell: Vector2i) -> ClueReachability:
 ## [br]
 ## Reachability accounts for clue distance, clue value, and current island size. A large nearby clue with few existing
 ## island cells ranks high, while a small distant clue with many existing island cells ranks low.
-func get_nearest_clue_cell(cell: Vector2i) -> Vector2i:
+func get_nearest_clued_island_cell(cell: Vector2i) -> Vector2i:
 	return _nearest_clue_root_by_cell.get(cell, POS_NOT_FOUND)
 
 

--- a/project/src/main/nurikabe/solver/solver.gd
+++ b/project/src/main/nurikabe/solver/solver.gd
@@ -545,7 +545,7 @@ func deduce_all_unreachable_squares() -> void:
 				continue
 			GlobalReachabilityMap.ClueReachability.UNREACHABLE:
 				add_deduction(cell, CELL_WALL, UNREACHABLE_CELL,
-						[board.get_global_reachability_map().get_nearest_clue_cell(cell)])
+						[board.get_global_reachability_map().get_nearest_clued_island_cell(cell)])
 				add_fun(FUN_THINK, 1.0)
 			GlobalReachabilityMap.ClueReachability.IMPOSSIBLE:
 				add_deduction(cell, CELL_WALL, WALL_BUBBLE)
@@ -576,14 +576,13 @@ func deduce_island_chokepoint_cramped(chokepoint: Vector2i) -> void:
 	if not board.get_island_chokepoint_map().chokepoints_by_cell.has(chokepoint):
 		return
 	
-	var clue_cell: Vector2i = board.get_global_reachability_map().get_nearest_clue_cell(chokepoint)
+	var clue_cell: Vector2i = board.get_global_reachability_map().get_nearest_clued_island_cell(chokepoint)
 	if clue_cell == POS_NOT_FOUND:
 		return
-	var clue_value: int = board.get_clue(clue_cell)
 	var unchoked_cell_count: int = \
 			board.get_island_chokepoint_map().get_unchoked_cell_count(chokepoint, clue_cell)
-	if unchoked_cell_count < clue_value and clue_value != CELL_MYSTERY_CLUE:
-		var island: CellGroup = board.get_island_for_cell(clue_cell)
+	var island: CellGroup = board.get_island_for_cell(clue_cell)
+	if unchoked_cell_count < island.clue and island.clue != CELL_MYSTERY_CLUE:
 		if chokepoint in island.liberties:
 			add_deduction(chokepoint, CELL_ISLAND,
 				ISLAND_EXPANSION, [clue_cell])

--- a/project/src/test/nurikabe/generator/test_generator.gd
+++ b/project/src/test/nurikabe/generator/test_generator.gd
@@ -11,6 +11,7 @@ var generator: Generator = Generator.new()
 var grid: Array[String] = []
 
 func before_each() -> void:
+	generator.rng.seed = 0 # avoid randomness
 	generator.clear()
 
 

--- a/project/src/test/nurikabe/generator/test_generator_basic.gd
+++ b/project/src/test/nurikabe/generator/test_generator_basic.gd
@@ -8,7 +8,7 @@ func test_find_island_guide_cell_candidates() -> void:
 		"          ",
 	]
 	generator.board = GeneratorTestUtils.init_board(grid)
-	var island: CellGroup = generator.board.solver_board.get_island_for_cell(Vector2i(1, 0))
+	var island: CellGroup = generator.board.get_island_for_cell(Vector2i(1, 0))
 	var candidates: Array[Vector2i] = generator.find_island_guide_cell_candidates(island)
 	candidates.sort()
 	assert_eq(candidates, [Vector2i(1, 3), Vector2i(3, 1)])

--- a/project/src/test/nurikabe/solver/test_global_reachability_map.gd
+++ b/project/src/test/nurikabe/solver/test_global_reachability_map.gd
@@ -17,16 +17,16 @@ func test_get_clue_reachability() -> void:
 	assert_eq(grm.get_clue_reachability(Vector2(3, 0)), GlobalReachabilityMap.ClueReachability.IMPOSSIBLE)
 
 
-func test_get_nearest_clue_cell() -> void:
+func test_get_nearest_clued_island_cell() -> void:
 	grid = [
 		"      ",
 		" 1    ",
 		"     2",
 	]
 	var grm: GlobalReachabilityMap = init_global_reachability_map()
-	assert_eq(grm.get_nearest_clue_cell(Vector2(1, 1)), Vector2i(0, 1))
-	assert_eq(grm.get_nearest_clue_cell(Vector2(2, 0)), Vector2i(2, 2))
-	assert_eq(grm.get_nearest_clue_cell(Vector2(2, 1)), Vector2i(2, 2))
+	assert_eq(grm.get_nearest_clued_island_cell(Vector2(1, 1)), Vector2i(0, 1))
+	assert_eq(grm.get_nearest_clued_island_cell(Vector2(2, 0)), Vector2i(2, 2))
+	assert_eq(grm.get_nearest_clued_island_cell(Vector2(2, 1)), Vector2i(2, 2))
 
 
 func init_global_reachability_map() -> GlobalReachabilityMap:


### PR DESCRIPTION
Adjusted PRIORITY_EXPANSION_SMALL_ISLAND_BIAS to allow larger islands to expand more frequently.

Bug: Solver.deduce_island_chokepoint_cramped could crash on generated puzzles where the island root did not contain a clue.

Generator.step_until_done exits when the puzzle is finished. Before, it would always run until hitting the 'mercy' limit.

Generator.generate_open_island_expansion is now exclusively a priority technique, and always applies weights. It's simpler this way.

Decreased MAX_GENERATION_FACTOR. Anecdotally, puzzles which finish hit about 25% the puzzle size, so going to 200% the puzzle size is overkill and makes the generator run for a very long time for deadlocked puzzles.

Adjusted 'allow_unclued_islands' to only allow islands adjacent to empty spaces. Unclued islands which are completely walled in are invalid.

Renamed get_nearest_clue_cell to get_nearest_clued_island_cell for clarity.

SolverBoard invalidates its cache appropriately as clues are added/removed.

Fixed seed for generator unit tests.