### PR TITLE
Added island chain logic.

### DIFF
--- a/project/src/demo/nurikabe/solver/demo_solver.gd
+++ b/project/src/demo/nurikabe/solver/demo_solver.gd
@@ -44,11 +44,13 @@ var solver: Solver = Solver.new()
 var performance_suite_queue: Array[String] = []
 
 var _puzzle_paths: Array[String] = []
+var _performance_test_start_index: int = -1
 
 func _ready() -> void:
 	_load_puzzle_paths()
 	_refresh_puzzle_path()
 	solver.board = %GameBoard.to_solver_board()
+	_performance_test_start_index = _puzzle_paths.find(puzzle_path)
 
 
 func _load_puzzle_paths() -> void:
@@ -80,13 +82,13 @@ func _input(event: InputEvent) -> void:
 		KEY_W:
 			performance_data.clear()
 			if Input.is_key_pressed(KEY_SHIFT):
-				var start_index: int = _puzzle_paths.find(puzzle_path)
-				if start_index == -1:
+				if _performance_test_start_index == -1:
 					push_error("Puzzle not found: %s" % [puzzle_path])
 					return
 				performance_suite_queue.clear()
 				for i in 10:
-					performance_suite_queue.append(_puzzle_paths[(start_index + i) % _puzzle_paths.size()])
+					var performance_text_index: int = (_performance_test_start_index + i) % _puzzle_paths.size()
+					performance_suite_queue.append(_puzzle_paths[performance_text_index])
 				if not %MessageLabel.text.is_empty():
 					_show_message("--------")
 				_show_message("performance suite start (%s)" % [performance_suite_queue.size()])
@@ -303,7 +305,7 @@ func _on_command_palette_command_entered(command: String) -> void:
 			var puzzle_path_pattern: String
 			match command.substr(0, 1):
 				"j": puzzle_path_pattern = "res://assets/demo/nurikabe/puzzles/janko/%s.janko"
-				"n": puzzle_path_pattern = "res://assets/demo/nurikabe/puzzles/nurikabe/%s.txt"
+				"n": puzzle_path_pattern = "res://assets/demo/nurikabe/puzzles/nikoli/%s.txt"
 				"p": puzzle_path_pattern = "res://assets/demo/nurikabe/puzzles/poobslag/%s.txt"
 				_: puzzle_path_pattern = "res://assets/demo/nurikabe/puzzles/%s.txt"
 			var new_puzzle_path: String = puzzle_path_pattern % [command.substr(1)]
@@ -311,5 +313,6 @@ func _on_command_palette_command_entered(command: String) -> void:
 				_show_message("File not found: %s" % [new_puzzle_path])
 				return
 			load_puzzle(new_puzzle_path)
+			_performance_test_start_index = _puzzle_paths.find(puzzle_path)
 		_:
 			_show_message("Invalid command: %s" % [command.substr(1)])

--- a/project/src/main/nurikabe/solver/deduction.gd
+++ b/project/src/main/nurikabe/solver/deduction.gd
@@ -20,6 +20,7 @@ enum Reason {
 	CORNER_ISLAND, # add a wall diagonally from an island with only two liberties
 	ISLAND_BUBBLE, # fill in an empty cell surrounded by islands
 	ISLAND_BUFFER, # add a wall to preserve space for an island to grow
+	ISLAND_CHAIN, # add a wall to avoid connecting an island chain
 	ISLAND_CHOKEPOINT, # expand an island through a narrow passage
 	ISLAND_CONNECTOR, # connect a clueless island to a clued island
 	ISLAND_DIVIDER, # add a wall to keep two islands apart
@@ -34,10 +35,10 @@ enum Reason {
 	WALL_CONNECTOR, # connect two walls through a chokepoint
 	WALL_EXPANSION, # expand a wall in the only possible direction
 	WALL_WEAVER, # finish an island in a way which preserves wall connectivity
-	BORDER_HUG,
 	
 	# advanced techniques
 	ASSUMPTION, # unproven assumption made when bifurcating
+	BORDER_HUG, # bifurcate options where extending an island along the border would create a split wall
 	ISLAND_BATTLEGROUND, # bifurcate two clues with adjacent liberties
 	ISLAND_RELEASE, # bifurcate options for walling in an island
 	ISLAND_STRANGLE, # bifurcate options for completing an island, walling off impossible ones

--- a/project/src/main/nurikabe/solver/island_chain_map.gd
+++ b/project/src/main/nurikabe/solver/island_chain_map.gd
@@ -1,0 +1,154 @@
+class_name IslandChainMap
+
+const CELL_INVALID: int = NurikabeUtils.CELL_INVALID
+const CELL_ISLAND: int = NurikabeUtils.CELL_ISLAND
+const CELL_WALL: int = NurikabeUtils.CELL_WALL
+const CELL_EMPTY: int = NurikabeUtils.CELL_EMPTY
+
+## Virtual root node for islands touching the puzzle border.
+var _border_island: CellGroup = CellGroup.new()
+
+var _board: SolverBoard
+var _parent_by_island: Dictionary[CellGroup, CellGroup] = {}
+var _chain_id_by_island: Dictionary[CellGroup, int] = {}
+var _depth_by_island: Dictionary[CellGroup, int] = {}
+var _diagonal_island_neighbors: Dictionary[CellGroup, Array] = {}
+
+func _init(init_board: SolverBoard) -> void:
+	_board = init_board
+	_build_diagonal_island_neighbors()
+	_build_chains()
+
+
+func has_chain_conflict(cell: Vector2i) -> bool:
+	return not find_chain_conflicts(cell).is_empty()
+
+
+func find_chain_conflicts(cell: Vector2i) -> Array[Vector2i]:
+	var result: Array[Vector2i] = []
+	var connected_islands: Array[CellGroup] = []
+	for neighbor_dir: Vector2i in [
+				Vector2(-1, -1), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1),
+				Vector2( 0,  1), Vector2( 1, -1), Vector2( 1,  0), Vector2( 1,  1),
+			]:
+		var neighbor: Vector2i = cell + neighbor_dir
+		if _board.get_cell(neighbor) != CELL_ISLAND:
+			continue
+		var connected_island: CellGroup = _board.get_island_for_cell(neighbor)
+		if not connected_islands.has(connected_island):
+			connected_islands.append(connected_island)
+	
+	for i: int in connected_islands.size():
+		for j: int in range(i + 1, connected_islands.size()):
+			var island_1: CellGroup = connected_islands[i]
+			var island_2: CellGroup = connected_islands[j]
+			if _chain_id_by_island[island_1] != _chain_id_by_island[island_2]:
+				continue
+			if _illegal_endpoint_connection(island_1, island_2):
+				result = [island_1.root, island_2.root]
+				break
+		if result:
+			break
+	
+	return result
+
+
+func _build_diagonal_island_neighbors() -> void:
+	for island: CellGroup in _board.islands:
+		_diagonal_island_neighbors[island] = []
+	for island: CellGroup in _board.islands:
+		for cell: Vector2i in island.cells:
+			for neighbor_dir: Vector2i in [Vector2i(1, -1), Vector2i(1, 1)]:
+				var neighbor: Vector2i = cell + neighbor_dir
+				if _board.get_cell(neighbor) != CELL_ISLAND:
+					continue
+				var neighbor_island: CellGroup = _board.get_island_for_cell(neighbor)
+				if neighbor_island == island:
+					continue
+				if _diagonal_island_neighbors[island].has(neighbor_island):
+					continue
+				_diagonal_island_neighbors[island].append(neighbor_island)
+				_diagonal_island_neighbors[neighbor_island].append(island)
+
+
+func _build_chains() -> void:
+	_parent_by_island[_border_island] = null
+	_chain_id_by_island[_border_island] = 0
+	_depth_by_island[_border_island] = 0
+	
+	var central_islands: Array[CellGroup] = []
+	var next_chain_id: int = 1
+	for island: CellGroup in _board.islands:
+		if _chain_id_by_island.has(island):
+			continue
+		var is_border_island: bool = false
+		for cell: Vector2i in island.cells:
+			if _board.is_border_cell(cell):
+				is_border_island = true
+				break
+		if is_border_island:
+			_parent_by_island[island] = _border_island
+			_chain_id_by_island[island] = 0
+			_depth_by_island[island] = _depth_by_island[_border_island] + 1
+			_expand_chain(island)
+		else:
+			central_islands.append(island)
+	
+	for island: CellGroup in central_islands:
+		if _chain_id_by_island.has(island):
+			continue
+		_chain_id_by_island[island] = next_chain_id
+		_depth_by_island[island] = 0
+		_expand_chain(island)
+		next_chain_id += 1
+
+
+func _expand_chain(start_island: CellGroup) -> void:
+	var queue: Array[CellGroup] = [start_island]
+	var queue_index: int = 0
+	while queue_index < queue.size():
+		var island: CellGroup = queue[queue_index]
+		queue_index += 1
+		
+		for neighbor_island: CellGroup in _diagonal_island_neighbors[island]:
+			if _chain_id_by_island.has(neighbor_island):
+				continue
+			_parent_by_island[neighbor_island] = island
+			_chain_id_by_island[neighbor_island] = _chain_id_by_island[island]
+			_depth_by_island[neighbor_island] = _depth_by_island[island] + 1
+			queue.append(neighbor_island)
+
+
+func _illegal_endpoint_connection(island_1: CellGroup, island_2: CellGroup) -> bool:
+	if island_1.clue >= 1 and island_2.clue >= 1:
+		return true
+	
+	var numbered_island_count: int = 0
+	var lca: CellGroup = _find_lca(island_1, island_2)
+	numbered_island_count += 1 if lca.clue >= 1 else 0
+	for start: CellGroup in [island_1, island_2]:
+		var a: CellGroup = start
+		while a != lca:
+			numbered_island_count += 1 if a.clue >= 1 else 0
+			a = _parent_by_island[a]
+			if numbered_island_count >= 2:
+				break
+		if numbered_island_count >= 2:
+			break
+	
+	return numbered_island_count >= 2
+
+
+func _find_lca(island_1: CellGroup, island_2: CellGroup) -> CellGroup:
+	var a: CellGroup = island_1
+	var b: CellGroup = island_2
+	if _depth_by_island[b] < _depth_by_island[a]:
+		var c: CellGroup = a
+		a = b
+		b = c
+	for _i in _depth_by_island[b] - _depth_by_island[a]:
+		b = _parent_by_island[b]
+	while a != b:
+		a = _parent_by_island[a]
+		b = _parent_by_island[b]
+	return a

--- a/project/src/main/nurikabe/solver/island_chain_map.gd.uid
+++ b/project/src/main/nurikabe/solver/island_chain_map.gd.uid
@@ -1,0 +1,1 @@
+uid://bg1dtpg6ytljo

--- a/project/src/main/nurikabe/solver/solver_board.gd
+++ b/project/src/main/nurikabe/solver/solver_board.gd
@@ -153,12 +153,19 @@ func get_global_reachability_map() -> GlobalReachabilityMap:
 		_build_global_reachability_map)
 
 
+func get_island_chain_map() -> IslandChainMap:
+	return _get_cached(
+		"island_chain_map",
+		_build_island_chain_map)
+
+
 func get_island_chokepoint_map() -> SolverChokepointMap:
 	return _get_cached(
 		"island_chokepoint_map",
 		_build_island_chokepoint_map)
 
 
+## This wall chokepoint map is currently unused because island-chain cycle logic is faster.
 func get_wall_chokepoint_map() -> SolverChokepointMap:
 	return _get_cached(
 		"wall_chokepoint_map",
@@ -212,6 +219,15 @@ func set_cell(cell_pos: Vector2i, value: int) -> void:
 	
 	_cache.clear()
 	version += 1
+
+
+func is_border_cell(cell: Vector2i) -> bool:
+	var result: bool = false
+	for neighbor_dir: Vector2i in NEIGHBOR_DIRS:
+		if get_cell(cell + neighbor_dir) == CELL_INVALID:
+			result = true
+			break
+	return result
 
 
 func _expand_groups(groups: Array[CellGroup], cell: Vector2i) -> void:
@@ -487,6 +503,10 @@ func _build_island_chokepoint_map() -> SolverChokepointMap:
 			return has_clue(cell))
 
 
+func _build_island_chain_map() -> IslandChainMap:
+	return IslandChainMap.new(self)
+
+
 func _build_strict_validation_result() -> ValidationResult:
 	return get_flooded_board().validate(VALIDATE_SIMPLE)
 
@@ -574,6 +594,7 @@ func _build_validation_result(mode: ValidationMode) -> ValidationResult:
 	return result
 
 
+## This wall chokepoint map is currently unused because island-chain cycle logic is faster.
 func _build_wall_chokepoint_map() -> SolverChokepointMap:
 	return SolverChokepointMap.new(self,
 		func(cell: Vector2i) -> bool:

--- a/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
@@ -614,3 +614,16 @@ func test_deduce_all_walls_wall_expansion_mystery_clue() -> void:
 		"(1, 1)->## wall_expansion (2, 1)",
 	]
 	assert_deductions(solver.deduce_all_walls, expected)
+
+
+func test_deduce_all_island_chains() -> void:
+	grid = [
+		"     3",
+		"      ",
+		"  2   ",
+	]
+	var expected: Array[String] = [
+		"(1, 1)->## island_chain (1, 2) (2, 0)",
+		"(2, 1)->## island_chain (1, 2) (2, 0)",
+	]
+	assert_deductions(solver.deduce_all_island_chains, expected)

--- a/project/src/test/nurikabe/solver/test_solver_board.gd
+++ b/project/src/test/nurikabe/solver/test_solver_board.gd
@@ -550,6 +550,79 @@ func test_complex_bug() -> void:
 	assert_invalid(VALIDATE_COMPLEX, {"wrong_size": [Vector2i(2, 1), Vector2i(2, 2), Vector2i(3, 1)]})
 
 
+func test_island_chain_map_cycle() -> void:
+	grid = [
+		"   3",
+		"    ",
+		" 2  ",
+	]
+	var board: SolverBoard = SolverTestUtils.init_board(grid)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(0, 1)), true)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(1, 1)), true)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(0, 0)), false)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(1, 2)), false)
+
+
+func test_island_chain_map_cycle_clueless() -> void:
+	grid = [
+		"   4",
+		"    ",
+		" .  ",
+	]
+	var board: SolverBoard = SolverTestUtils.init_board(grid)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(0, 1)), false)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(1, 1)), false)
+
+
+func test_island_chain_map_cycle_middle() -> void:
+	grid = [
+		"            ",
+		"     9 .    ",
+		"   8   .    ",
+		"   .   .    ",
+		"       .    ",
+		"            ",
+	]
+	var board: SolverBoard = SolverTestUtils.init_board(grid)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(2, 3)), true)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(2, 4)), true)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(2, 5)), false)
+
+
+func test_island_chain_map_cycle_middle_big() -> void:
+	grid = [
+		"              ",
+		"     5 .      ",
+		"   8   .      ",
+		"   .     5    ",
+		"       . .    ",
+		"              ",
+	]
+	var board: SolverBoard = SolverTestUtils.init_board(grid)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(2, 3)), true)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(2, 4)), true)
+
+
+func test_island_chain_map_cycle_janko_3() -> void:
+	grid = [
+		" 2 .## . . 3######  ",
+		"############ 2 .##  ",
+		"## 2 .## 2 .####    ",
+		"###### 2####        ",
+		"   .## .## .        ",
+		"      ##            ",
+		"                ## 7",
+		"       .   .## 6    ",
+		"    ## 3## .  ##    ",
+		"   . 7####   . . .10",
+	]
+	var board: SolverBoard = SolverTestUtils.init_board(grid)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(4, 6)), true)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(4, 7)), true)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(6, 6)), false)
+	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(8, 2)), false)
+
+
 func assert_groups(actual_groups: Array[CellGroup], expected_props_list: Array[Dictionary]) -> void:
 	var actual_props_list: Array[Dictionary] = []
 	for actual_group: CellGroup in actual_groups:


### PR DESCRIPTION
Chains are groups of diagonally connected islands, including connections to the edge of the board. If a cell would create a cycle within a chain, and the cycle includes two islands belonging two two different clues, that cell must be a wall.

I've disabled the 'wall chokepoint' deduction which is redundant with the chain logic.