### PR TITLE
Bug: Islands with two mystery clues did not report a conflict

### DIFF
--- a/project/src/main/nurikabe/generator/generator.gd
+++ b/project/src/main/nurikabe/generator/generator.gd
@@ -626,7 +626,7 @@ func prepare_board_for_mutation() -> SolverBoard:
 	
 	# renumber islands to match their size
 	for island: CellGroup in prepared_board.islands:
-		if island.clue == 0 or island.clue == -1:
+		if island.clue == 0:
 			continue
 		if island.clue == island.size():
 			continue

--- a/project/src/main/nurikabe/solver/solver_board.gd
+++ b/project/src/main/nurikabe/solver/solver_board.gd
@@ -491,7 +491,7 @@ func _clue_value_for_cells(island: Array[Vector2i]) -> int:
 		if not has_clue(cell):
 			continue
 		var clue_value: int = get_clue(cell)
-		if total_clue_value > 0:
+		if total_clue_value > 0 or total_clue_value == CELL_MYSTERY_CLUE:
 			total_clue_value = -1
 			break
 		total_clue_value = clue_value

--- a/project/src/test/nurikabe/solver/test_solver_board.gd
+++ b/project/src/test/nurikabe/solver/test_solver_board.gd
@@ -36,6 +36,17 @@ func test_islands_mystery_clue_1() -> void:
 	])
 
 
+func test_islands_mystery_clue_joined() -> void:
+	grid = [
+		" ? .",
+		"## ?",
+	]
+	var board: SolverBoard = SolverTestUtils.init_board(grid)
+	assert_groups(board.islands, [
+		{"cells": [Vector2i(0, 0), Vector2i(1, 0), Vector2i(1, 1)], "clue": -1, "liberties": []},
+	])
+
+
 func test_islands_mystery_clue_2() -> void:
 	grid = [
 		"    ",


### PR DESCRIPTION
I noticed this when investigating the generator's "prepare board for mutation" logic. It was treating a big island with multiple '?' clues as though it only had one clue. I've modified the generator to continue handling big islands this way, because it generated good puzzles.