### PR TITLE
Fixed generator crashes with huge islands.

### DIFF
--- a/project/src/main/nurikabe/generator/generator_utils.gd
+++ b/project/src/main/nurikabe/generator/generator_utils.gd
@@ -17,7 +17,7 @@ static func best_clue_cells_for_unclued_island(board: SolverBoard, island: CellG
 	for island_cell: Vector2i in island.cells:
 		var island_cell_wrapped: Dictionary[String, Variant] = {
 			"cell": island_cell,
-			"distance": nearest_clue_distance_map[island_cell]}
+			"distance": nearest_clue_distance_map.get(island_cell, 999999)}
 		island_cells_wrapped.append(island_cell_wrapped)
 	island_cells_wrapped.sort_custom(func(a: Dictionary[String, Variant], b: Dictionary[String, Variant]) -> bool:
 		return a["distance"] < b["distance"])

--- a/project/src/main/nurikabe/generator/mutation_library.gd
+++ b/project/src/main/nurikabe/generator/mutation_library.gd
@@ -281,7 +281,7 @@ func fix_joined_island(board: SolverBoard, island: CellGroup) -> void:
 	for old_clue_cell: Vector2i in old_clue_cells:
 		var clue_cell_wrapped: Dictionary[String, Variant] = {
 			"cell": old_clue_cell,
-			"distance": nearest_clue_distance_map[old_clue_cell]}
+			"distance": nearest_clue_distance_map.get(old_clue_cell, 999999)}
 		clue_cells_wrapped.append(clue_cell_wrapped)
 	_rng_ops.shuffle(clue_cells_wrapped)
 	clue_cells_wrapped.sort_custom(func(a: Dictionary[String, Variant], b: Dictionary[String, Variant]) -> bool:
@@ -376,7 +376,7 @@ func move_clue(board: SolverBoard, island: CellGroup) -> void:
 	var weights: Array[float] = []
 	weights.resize(cell_candidates.size())
 	for i in cell_candidates.size():
-		weights[i] = 1.0 / nearest_clue_distance_map[cell_candidates[i]]
+		weights[i] = 1.0 / nearest_clue_distance_map.get(cell_candidates[i], 999999)
 	var new_clue_cell: Vector2i = cell_candidates[rng.rand_weighted(weights)]
 	
 	# set the new clue

--- a/project/src/test/nurikabe/generator/test_generator_utils.gd
+++ b/project/src/test/nurikabe/generator/test_generator_utils.gd
@@ -14,3 +14,19 @@ func test_best_clue_cells_for_unclued_island() -> void:
 	var clue_cells: Array[Vector2i] = \
 			GeneratorUtils.best_clue_cells_for_unclued_island(board, island)
 	assert_eq(clue_cells, [Vector2i(4, 0)])
+
+
+func test_best_clue_cells_for_unclued_island_single() -> void:
+	var grid: Array[String] = [
+		" . . .",
+		" . . .",
+	]
+	var board: SolverBoard = SolverTestUtils.init_board(grid)
+	var island: CellGroup = board.get_island_for_cell(Vector2i(2, 0))
+	var clue_cells: Array[Vector2i] = \
+			GeneratorUtils.best_clue_cells_for_unclued_island(board, island)
+	assert_eq(clue_cells, [
+			Vector2i(0, 0), Vector2i(0, 1),
+			Vector2i(1, 0), Vector2i(1, 1),
+			Vector2i(2, 0), Vector2i(2, 1),
+		])

--- a/project/src/test/nurikabe/generator/test_mutation_library_basic.gd
+++ b/project/src/test/nurikabe/generator/test_mutation_library_basic.gd
@@ -200,5 +200,18 @@ func test_move_clue() -> void:
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).clue, 5)
 
 
+func test_move_clue_single() -> void:
+	var grid: Array[String] = [
+		"##########",
+		" 4 . . .##",
+	]
+	var board: SolverBoard = SolverBoard.new()
+	board.from_grid_string("\n".join(grid))
+	var island: CellGroup = board.get_island_for_cell(Vector2i(0, 1))
+	mutation_library.move_clue(board, island)
+	assert_eq(board.has_clue(Vector2i(0, 1)), false)
+	assert_eq(board.get_island_for_cell(Vector2i(0, 1)).clue, 4)
+
+
 func assert_board(board: SolverBoard, expected: Array[String]) -> void:
 	assert_eq(board.to_grid_string().split("\n"), PackedStringArray(expected))

--- a/project/src/test/nurikabe/generator/test_mutation_library_fix.gd
+++ b/project/src/test/nurikabe/generator/test_mutation_library_fix.gd
@@ -72,6 +72,20 @@ func test_mutate_fix_joined_islands() -> void:
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).clue, 8)
 
 
+func test_mutate_fix_joined_islands_single() -> void:
+	var grid: Array[String] = [
+		" . 2######",
+		"## .## .##",
+		" 5 . . .##",
+	]
+	var board: SolverBoard = SolverBoard.new()
+	board.from_grid_string("\n".join(grid))
+	mutation_library.mutate_fix_joined_islands(board)
+	
+	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).size(), 8)
+	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).clue, 8)
+
+
 func test_mutate_fix_pools() -> void:
 	var grid: Array[String] = [
 		" . 2######",


### PR DESCRIPTION
Small 5x5 puzzles often generated big "single island" puzzles where a lot of our generation techniques would crash. They'd try to find something like "What's the closest clue to this island" and it would fail, because there were none.