### PR TITLE
Generator: Improved anti-stuck logic. Generates XXL puzzles.

### DIFF
--- a/project/src/main/nurikabe/generator/puzzle_mutator.gd
+++ b/project/src/main/nurikabe/generator/puzzle_mutator.gd
@@ -140,6 +140,10 @@ func get_best_board() -> SolverBoard:
 	return candidates.front().board
 
 
+func get_best_solver() -> Solver:
+	return candidates.front()
+
+
 func mutate(solver: Solver) -> void:
 	# populate the mutation picker
 	var picker: MutationPicker = MutationPicker.new()


### PR DESCRIPTION
Anti-stuck logic now applies earlier. Before, we would sometimes have large puzzles which would roll back over and over and never finish.

- In addition to giving up after ~500 steps for larger puzzles, it now does an 'early surrender' if the number of fills cells doesn't increase for 25 steps.
- Early Surrender doesn't trigger if there is a successful mutation increasing the fitness.

The generator no longer rolls back if a clue fails to meet its minimum threshold. This often caused large puzzles to roll back over and over and never finish. Failing to expand a clue sufficiently sometimes causes unsolvable puzzles, but these are fixed during the mutation phase.

Bug: Generator's metrics fell out of sync with its board during mutation. It now copies its metrics from the mutated board.

The generator can now generate large 20x36 or larger puzzles. It takes a very long time (20 minutes or so).