### PR TITLE
Added BulkGenerator analysis. Difficulty adjustments.

### DIFF
--- a/project/src/demo/nurikabe/generator/bulk_generator.gd
+++ b/project/src/demo/nurikabe/generator/bulk_generator.gd
@@ -1,6 +1,12 @@
+class_name BulkGenerator
 extends Node
+## [b]Keys:[/b][br]
+## 	[kbd]G[/kbd]: Toggle generator, continuously writes new puzzles to GENERATED_PUZZLE_DIR.
+## 	[kbd]A[/kbd]: Toggle analyzer; analyzes puzzles in PUZZLE_DIR and writes .info files.
 
-const PUZZLE_DIR: String = "user://puzzles"
+const PUZZLE_DIR: String = "res://assets/main/nurikabe/official"
+const GENERATED_PUZZLE_DIR: String = "res://assets/main/nurikabe/official/generated"
+
 const MAX_LINES: int = 500
 const PUZZLE_TYPES: Array[Dictionary] = [
 	{
@@ -71,158 +77,31 @@ const PUZZLE_TYPES: Array[Dictionary] = [
 	},
 ]
 
-var generator: Generator = Generator.new()
 var fixed_seed: int = -1
-var rng: RandomNumberGenerator = RandomNumberGenerator.new()
-var puzzle_num: int = 1
-
-var _stuck_state: Dictionary[String, Variant] = {}
 
 func _ready() -> void:
-	while FileAccess.file_exists(user_puzzle_path()):
-		puzzle_num += 1
-	
-	generator.board = %GameBoard.to_generator_board()
 	%GameBoard.allow_unclued_islands = true
-	create_board()
 
 
 func _input(event: InputEvent) -> void:
 	match Utils.key_press(event):
-		KEY_P:
-			set_process(not is_processing())
-			_show_message("processing -> %s" % [is_processing()])
+		KEY_G:
+			toggle_state("generate")
+		KEY_A:
+			toggle_state("analyze")
 
 
-func _process(_delta: float) -> void:
-	generator.step()
-	
-	if generator.check_stuck(_stuck_state):
-		_show_message("error: stuck")
-		create_board()
-		return
-	
-	copy_board_from_generator()
-	if generator.is_done():
-		var validation_result: SolverBoard.ValidationResult \
-				= generator.board.solver_board.validate(SolverBoard.VALIDATE_STRICT)
-		if validation_result.error_count == 0:
-			# filled with no validation errors
-			output_board()
-		else:
-			_show_message("error: puzzle failed validation")
-		create_board()
+func _process(delta: float) -> void:
+	%StateMachine.update(delta)
 
 
-func create_board() -> void:
-	var weights: Array[float] = []
-	for puzzle_type: Dictionary in PUZZLE_TYPES:
-		weights.append(puzzle_type["weight"])
-	var puzzle_type: Dictionary = PUZZLE_TYPES[rng.rand_weighted(weights)]
-	
-	var cells: int = roundi(rng.randfn(puzzle_type["cells_mean"], puzzle_type["cells_spread"]))
-	cells = clampi(cells, puzzle_type["cells_min"], puzzle_type["cells_max"])
-	
-	var difficulty: float = rng.randfn(puzzle_type["difficulty_mean"], puzzle_type["difficulty_spread"])
-	difficulty = clamp(difficulty, 0.0, 1.0)
-	generator.difficulty = difficulty
-	
-	var puzzle_size: Vector2i = pick_puzzle_size(cells)
-	set_puzzle_size(puzzle_size)
-	
-	_show_message("puzzle #%s: %s size=%s target_difficulty=%.2f" \
-			% [puzzle_num, puzzle_type["id"], puzzle_size, difficulty])
-	_stuck_state.clear()
+func toggle_state(state: String) -> void:
+	var old_state: String = %StateMachine.current_state
+	%StateMachine.change_state("idle" if %StateMachine.current_state == state else state)
+	show_message("state: %s -> %s" % [old_state, %StateMachine.current_state])
 
 
-## Pick a random puzzle size close to to the target cell count.[br]
-## [br]
-## Enforces reasonable aspect ratios (< 2:1) and a minimum side length of 5.
-func pick_puzzle_size(cells: float) -> Vector2i:
-	var puzzle_size: Vector2i = Vector2i.ONE
-	var width_sigma: float = sqrt(cells) * 0.25
-	var min_width: int = int(ceil(sqrt(cells) / 1.41421))
-	min_width = maxi(min_width, 5)
-	var max_width: int = int(floor(sqrt(cells) * 1.41421))
-	puzzle_size.x = roundi(rng.randfn(sqrt(cells), width_sigma))
-	puzzle_size.x = clampi(puzzle_size.x, min_width, max_width)
-	puzzle_size.y = roundi(cells / float(puzzle_size.x))
-	puzzle_size.y = clampi(puzzle_size.y, min_width, max_width)
-	return puzzle_size
-
-
-func user_puzzle_path() -> String:
-	return PUZZLE_DIR.path_join("%s.txt" % [puzzle_num])
-
-
-func puzzle_info_path(path: String) -> String:
-	return path + ".info"
-
-
-func output_board() -> void:
-	var path: String = user_puzzle_path()
-	var board: SolverBoard = generator.board.solver_board.duplicate()
-	board.erase_solution_cells()
-	if not DirAccess.dir_exists_absolute(PUZZLE_DIR):
-		DirAccess.make_dir_recursive_absolute(PUZZLE_DIR)
-	FileAccess.open(path, FileAccess.WRITE).store_string(board.to_grid_string())
-	
-	var info_path: String = puzzle_info_path(path)
-	var info_json: Dictionary[String, Variant] = {}
-	info_json["difficulty"] = generator.solver.get_measured_difficulty()
-	info_json["cells"] = generator.solver.board.cells.size()
-	info_json["version"] = 0.01
-	FileAccess.open(info_path, FileAccess.WRITE).store_string(JSON.stringify(info_json))
-	
-	_show_message("wrote puzzle #%s to %s; measured_difficulty=%.2f" \
-			% [puzzle_num, path, info_json["difficulty"]])
-	
-	puzzle_num += 1
-
-
-func set_puzzle_size(puzzle_size: Vector2i) -> void:
-	var new_grid_string: String = ""
-	for y in puzzle_size.y:
-		new_grid_string += "  ".repeat(puzzle_size.x)
-		new_grid_string += "\n"
-	%GameBoard.reset()
-	%GameBoard.grid_string = new_grid_string
-	%GameBoard.import_grid()
-	generator.clear()
-	generator.board = %GameBoard.to_generator_board()
-
-
-func step_solver() -> void:
-	if generator.solver.board.is_filled() and not generator.has_validation_errors():
-		_show_message("--------")
-		_show_message("(finished)")
-		return
-	
-	if not %MessageLabel.text.is_empty():
-		_show_message("--------")
-	
-	generator.solver.step()
-	
-	if not generator.solver.deductions.has_changes():
-		_show_message("(no changes)")
-	else:
-		for deduction_index: int in generator.solver.deductions.size():
-			var shown_index: int = generator.solver.board.version + deduction_index
-			var deduction: Deduction = generator.solver.deductions.deductions[deduction_index]
-			_show_message("%s-%s %s" % \
-					[generator.step_count, shown_index, str(deduction)])
-		
-		for change: Dictionary[String, Variant] in generator.solver.deductions.get_changes():
-			%GameBoard.set_cell(change["pos"], change["value"])
-		
-		generator.solver.apply_changes()
-
-
-func copy_board_from_generator() -> void:
-	generator.board.solver_board.update_game_board(%GameBoard)
-
-
-func _show_message(s: String) -> void:
+func show_message(s: String) -> void:
 	if %MessageLabel.text:
 		%MessageLabel.text += "\n"
 	%MessageLabel.text += s

--- a/project/src/demo/nurikabe/generator/bulk_generator.tscn
+++ b/project/src/demo/nurikabe/generator/bulk_generator.tscn
@@ -1,8 +1,13 @@
-[gd_scene load_steps=4 format=4 uid="uid://ck4sekpb0rqx3"]
+[gd_scene load_steps=9 format=3 uid="uid://mcir660yfag2"]
 
 [ext_resource type="Script" uid="uid://dbbofwi6kvo1s" path="res://src/demo/nurikabe/generator/bulk_generator.gd" id="1_7nk3a"]
 [ext_resource type="PackedScene" uid="uid://b06aw2k2o1thk" path="res://src/main/nurikabe/game_board.tscn" id="1_o1grh"]
 [ext_resource type="FontFile" uid="uid://pq4x38hcbx4h" path="res://assets/main/ui/baloo2.ttf" id="2_7nk3a"]
+[ext_resource type="PackedScene" uid="uid://dmehh4401wsni" path="res://src/main/utils/state_machine.tscn" id="4_whffh"]
+[ext_resource type="PackedScene" uid="uid://c8e4mcx2vb5o8" path="res://src/main/utils/state.tscn" id="5_0ugav"]
+[ext_resource type="Script" uid="uid://0pb3o0nnfm07" path="res://src/demo/nurikabe/generator/bulk_generator_idle_state.gd" id="6_0ugav"]
+[ext_resource type="Script" uid="uid://54j48jtfkdq" path="res://src/demo/nurikabe/generator/bulk_generator_generate_state.gd" id="6_nmkj7"]
+[ext_resource type="Script" uid="uid://cy1dkfhepugpp" path="res://src/demo/nurikabe/generator/bulk_generator_analyze_state.gd" id="7_nmkj7"]
 
 [node name="BulkGenerator" type="Node"]
 script = ExtResource("1_7nk3a")
@@ -42,12 +47,6 @@ grid_string = "
           
 "
 
-[node name="TileMapGround" parent="HBoxContainer/GameBoardHolder/GameBoard" index="0"]
-tile_map_data = PackedByteArray("AAAAAAAAAAAAAAAAAAABAAAAAQAAAAAAAAACAAAAAAAAAAAAAAADAAAAAQAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAQAAAAAAAAABAAEAAAAAAAAAAAACAAEAAQAAAAAAAAADAAEAAAAAAAAAAAAEAAEAAQAAAAAAAAAAAAIAAAAAAAAAAAABAAIAAQAAAAAAAAACAAIAAAAAAAAAAAADAAIAAQAAAAAAAAAEAAIAAAAAAAAAAAAAAAMAAQAAAAAAAAABAAMAAAAAAAAAAAACAAMAAQAAAAAAAAADAAMAAAAAAAAAAAAEAAMAAQAAAAAAAAAAAAQAAAAAAAAAAAABAAQAAQAAAAAAAAACAAQAAAAAAAAAAAADAAQAAQAAAAAAAAAEAAQAAAAAAAAAAAA=")
-
-[node name="CursorableArea" parent="HBoxContainer/GameBoardHolder/GameBoard" index="5"]
-cursorable_rect = Rect2(0, 0, 1280, 1280)
-
 [node name="MessageLabel" type="RichTextLabel" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
@@ -58,4 +57,14 @@ theme_override_font_sizes/normal_font_size = 32
 scroll_following = true
 selection_enabled = true
 
-[editable path="HBoxContainer/GameBoardHolder/GameBoard"]
+[node name="StateMachine" parent="." instance=ExtResource("4_whffh")]
+unique_name_in_owner = true
+
+[node name="Idle" parent="StateMachine" instance=ExtResource("5_0ugav")]
+script = ExtResource("6_0ugav")
+
+[node name="Analyze" parent="StateMachine" instance=ExtResource("5_0ugav")]
+script = ExtResource("7_nmkj7")
+
+[node name="Generate" parent="StateMachine" instance=ExtResource("5_0ugav")]
+script = ExtResource("6_nmkj7")

--- a/project/src/demo/nurikabe/generator/bulk_generator_analyze_state.gd
+++ b/project/src/demo/nurikabe/generator/bulk_generator_analyze_state.gd
@@ -1,0 +1,44 @@
+extends State
+
+var solver: Solver = Solver.new()
+var queue: Array[String] = []
+
+func enter() -> void:
+	queue = Utils.find_data_files(BulkGenerator.PUZZLE_DIR, "txt")
+	object.show_message("Searching %s; found %s files." % [BulkGenerator.PUZZLE_DIR, queue.size()])
+
+
+func update(_delta: float) -> void:
+	if queue.is_empty():
+		object.show_message("Analysis complete.")
+		change_state("idle")
+		return
+	
+	var puzzle_path: String = queue.pop_front()
+	%GameBoard.grid_string = NurikabeUtils.load_grid_string_from_file(puzzle_path)
+	%GameBoard.import_grid()
+	solver.clear()
+	solver.board = %GameBoard.to_solver_board()
+	solver.step_until_done()
+	copy_board_from_solver()
+	var validation_result: SolverBoard.ValidationResult \
+			= solver.board.validate(SolverBoard.VALIDATE_STRICT)
+	if validation_result.error_count > 0:
+		object.show_message("Error: Invalid solution")
+		return
+	
+	var info_path: String = puzzle_info_path(puzzle_path)
+	var info_json: Dictionary[String, Variant] = {}
+	info_json["difficulty"] = solver.get_measured_difficulty()
+	info_json["cells"] = solver.board.cells.size()
+	info_json["version"] = 0.01
+	FileAccess.open(info_path, FileAccess.WRITE).store_string(JSON.stringify(info_json))
+	object.show_message("Wrote %s." % [info_path])
+
+
+func copy_board_from_solver() -> void:
+	solver.board.update_game_board(%GameBoard)
+
+
+func puzzle_info_path(path: String) -> String:
+	return path + ".info"

--- a/project/src/demo/nurikabe/generator/bulk_generator_analyze_state.gd.uid
+++ b/project/src/demo/nurikabe/generator/bulk_generator_analyze_state.gd.uid
@@ -1,0 +1,1 @@
+uid://cy1dkfhepugpp

--- a/project/src/demo/nurikabe/generator/bulk_generator_generate_state.gd
+++ b/project/src/demo/nurikabe/generator/bulk_generator_generate_state.gd
@@ -1,0 +1,116 @@
+extends State
+
+var generator: Generator = Generator.new()
+var puzzle_num: int = 1
+var rng: RandomNumberGenerator = RandomNumberGenerator.new()
+
+var _stuck_state: Dictionary[String, Variant] = {}
+
+func enter() -> void:
+	generator.board = %GameBoard.to_generator_board()
+	create_board()
+
+
+func update(_delta: float) -> void:
+	generator.step()
+	
+	if generator.check_stuck(_stuck_state):
+		object.show_message("error: stuck")
+		create_board()
+		return
+	
+	copy_board_from_generator()
+	if generator.is_done():
+		var validation_result: SolverBoard.ValidationResult \
+				= generator.board.solver_board.validate(SolverBoard.VALIDATE_STRICT)
+		if validation_result.error_count == 0:
+			# filled with no validation errors
+			output_board()
+		else:
+			object.show_message("error: puzzle failed validation")
+		create_board()
+
+
+func copy_board_from_generator() -> void:
+	generator.board.solver_board.update_game_board(%GameBoard)
+
+
+func create_board() -> void:
+	while FileAccess.file_exists(user_puzzle_path()):
+		puzzle_num += 1
+	
+	var weights: Array[float] = []
+	for puzzle_type: Dictionary in BulkGenerator.PUZZLE_TYPES:
+		weights.append(puzzle_type["weight"])
+	var puzzle_type: Dictionary = BulkGenerator.PUZZLE_TYPES[rng.rand_weighted(weights)]
+	
+	var cells: int = roundi(rng.randfn(puzzle_type["cells_mean"], puzzle_type["cells_spread"]))
+	cells = clampi(cells, puzzle_type["cells_min"], puzzle_type["cells_max"])
+	
+	var puzzle_size: Vector2i = pick_puzzle_size(cells)
+	set_puzzle_size(puzzle_size)
+	
+	var difficulty: float = rng.randfn(puzzle_type["difficulty_mean"], puzzle_type["difficulty_spread"])
+	difficulty = clamp(difficulty, 0.0, 1.0)
+	generator.difficulty = difficulty
+	
+	object.show_message("puzzle #%s: %s size=%s target_difficulty=%.2f" \
+			% [puzzle_num, puzzle_type["id"], puzzle_size, difficulty])
+	_stuck_state.clear()
+
+
+## Pick a random puzzle size close to to the target cell count.[br]
+## [br]
+## Enforces reasonable aspect ratios (< 2:1) and a minimum side length of 5.
+func pick_puzzle_size(cells: float) -> Vector2i:
+	var puzzle_size: Vector2i = Vector2i.ONE
+	var width_sigma: float = sqrt(cells) * 0.25
+	var min_width: int = int(ceil(sqrt(cells) / 1.41421))
+	min_width = maxi(min_width, 5)
+	var max_width: int = int(floor(sqrt(cells) * 1.41421))
+	puzzle_size.x = roundi(rng.randfn(sqrt(cells), width_sigma))
+	puzzle_size.x = clampi(puzzle_size.x, min_width, max_width)
+	puzzle_size.y = roundi(cells / float(puzzle_size.x))
+	puzzle_size.y = clampi(puzzle_size.y, min_width, max_width)
+	return puzzle_size
+
+
+func output_board() -> void:
+	var path: String = user_puzzle_path()
+	var board: SolverBoard = generator.board.solver_board.duplicate()
+	board.erase_solution_cells()
+	if not DirAccess.dir_exists_absolute(BulkGenerator.GENERATED_PUZZLE_DIR):
+		DirAccess.make_dir_recursive_absolute(BulkGenerator.GENERATED_PUZZLE_DIR)
+	FileAccess.open(path, FileAccess.WRITE).store_string(board.to_grid_string())
+	
+	var info_path: String = puzzle_info_path(path)
+	var info_json: Dictionary[String, Variant] = {}
+	info_json["difficulty"] = generator.solver.get_measured_difficulty()
+	info_json["cells"] = generator.solver.board.cells.size()
+	info_json["version"] = 0.01
+	FileAccess.open(info_path, FileAccess.WRITE).store_string(JSON.stringify(info_json))
+	
+	object.show_message("wrote puzzle #%s to %s; measured_difficulty=%.2f" \
+			% [puzzle_num, path, info_json["difficulty"]])
+	
+	puzzle_num += 1
+
+
+func set_puzzle_size(puzzle_size: Vector2i) -> void:
+	var new_grid_string: String = ""
+	for y in puzzle_size.y:
+		new_grid_string += "  ".repeat(puzzle_size.x)
+		new_grid_string += "\n"
+	%GameBoard.reset()
+	%GameBoard.grid_string = new_grid_string
+	%GameBoard.import_grid()
+	generator.clear()
+	generator.board = %GameBoard.to_generator_board()
+
+
+func user_puzzle_path() -> String:
+	return BulkGenerator.GENERATED_PUZZLE_DIR.path_join("%s.txt" % [puzzle_num])
+
+
+func puzzle_info_path(path: String) -> String:
+	return path + ".info"

--- a/project/src/demo/nurikabe/generator/bulk_generator_generate_state.gd.uid
+++ b/project/src/demo/nurikabe/generator/bulk_generator_generate_state.gd.uid
@@ -1,0 +1,1 @@
+uid://54j48jtfkdq

--- a/project/src/demo/nurikabe/generator/bulk_generator_idle_state.gd
+++ b/project/src/demo/nurikabe/generator/bulk_generator_idle_state.gd
@@ -1,0 +1,1 @@
+extends State

--- a/project/src/demo/nurikabe/generator/bulk_generator_idle_state.gd.uid
+++ b/project/src/demo/nurikabe/generator/bulk_generator_idle_state.gd.uid
@@ -1,0 +1,1 @@
+uid://0pb3o0nnfm07

--- a/project/src/main/nurikabe/generator/generator.gd
+++ b/project/src/main/nurikabe/generator/generator.gd
@@ -110,12 +110,14 @@ func consume_events() -> Array[String]:
 func clear() -> void:
 	placements.clear()
 	solver.clear()
-	_checkpoint_stack.clear()
-	_event_log.clear()
-	_break_in_count = 0
-	mutate_steps = 0
-	_mutator = null
 	step_count = 0
+	mutate_steps = 0
+	
+	_checkpoint_stack.clear()
+	_break_in_count = 0
+	_event_log.clear()
+	_successfully_mutated = false
+	_mutator = null
 
 
 func step_until_done() -> void:

--- a/project/src/main/nurikabe/solver/solver.gd
+++ b/project/src/main/nurikabe/solver/solver.gd
@@ -847,7 +847,7 @@ func get_measured_difficulty() -> float:
 	unscaled = log(unscaled + 1.0) / log(1.5)
 	
 	var scaled: float = inverse_lerp(UNSCALED_DIFFICULTY_EASY, UNSCALED_DIFFICULTY_HARD, unscaled)
-	scaled = lerp(1.0, 10.0, scaled)
+	scaled = lerp(2.5, 10.0, scaled)
 	scaled = clamp(scaled, 0.0, 20.0)
 	return scaled
 

--- a/project/src/main/utils/sound_manager.gd
+++ b/project/src/main/utils/sound_manager.gd
@@ -145,7 +145,7 @@ func _fill_audio_stream_player_pool() -> void:
 
 ## Recursively loads all .wav files from [constant BASE_DIR] into the [member sounds] cache.
 func _fill_sounds_cache() -> void:
-	var sfx_paths: Array[String] = Utils.find_files(BASE_DIR, "wav")
+	var sfx_paths: Array[String] = Utils.find_imported_files(BASE_DIR, "wav")
 	
 	for sfx_path: String in sfx_paths:
 		var source_key: String = sfx_path

--- a/project/src/main/utils/utils.gd
+++ b/project/src/main/utils/utils.gd
@@ -35,8 +35,8 @@ static func enum_to_snake_case(
 	return result
 
 
-## Recursively finds all files with the given extension starting at [param path].
-static func find_files(path: String, file_extension: String) -> Array[String]:
+## Recursively finds all imported files (png, ogg, wav) with the given extension starting at [param path].
+static func find_imported_files(path: String, file_extension: String) -> Array[String]:
 	var found_files: Array[String] = []
 	var dir_queue: Array[String] = [path]
 	
@@ -53,6 +53,37 @@ static func find_files(path: String, file_extension: String) -> Array[String]:
 				dir_queue.append(resource_path)
 			elif file.ends_with(".%s.import" % [file_extension]):
 				found_files.append(resource_path.trim_suffix(".import"))
+		else:
+			if dir:
+				dir.list_dir_end()
+			if dir_queue.is_empty():
+				break
+			# open the next directory from the queue
+			dir = DirAccess.open(dir_queue.pop_front())
+			dir.list_dir_begin()
+		file = dir.get_next()
+	
+	return found_files
+
+
+## Recursively finds all data files (txt, json, cfg) with the given extension starting at [param path].
+static func find_data_files(path: String, file_extension: String) -> Array[String]:
+	var found_files: Array[String] = []
+	var dir_queue: Array[String] = [path]
+	
+	var dir: DirAccess = DirAccess.open("res://")
+	var file: String
+	
+	while true:
+		if file and file.begins_with("."):
+			# ignore .gitkeep and other hidden files
+			pass
+		elif file:
+			var resource_path: String = "%s/%s" % [dir.get_current_dir(), file.get_file()]
+			if dir.current_is_dir():
+				dir_queue.append(resource_path)
+			elif file.get_extension() == file_extension:
+				found_files.append(resource_path)
 		else:
 			if dir:
 				dir.list_dir_end()


### PR DESCRIPTION
BulkGenerator uses state machine, and can toggle between generate/analyze with 'G' and 'A'.

Generator.clear() now unsets the 'successfully_mutated' flag.

Adjusted difficulty calculation. There are puzzles easier than Nurikabe 1, such as little example 5x5 puzzles which you can solve in 5 seconds. Our generator generates these, so Nurikabe 1 now represents a 2.5 on the difficulty scale.

Split out Utils.find_data_files(). We need to find .txt files which do not have a corresponding .txt.import file.