### PR TITLE
Solve multiple puzzles at once. find_parent_of_type().

### DIFF
--- a/project/src/main/nurikabe/cursorable_area.gd
+++ b/project/src/main/nurikabe/cursorable_area.gd
@@ -1,4 +1,5 @@
 @tool
+class_name CursorableArea
 extends Area2D
 
 @export var cursor_scene: PackedScene
@@ -90,8 +91,8 @@ func set_cell(cell: Vector2i) -> void:
 
 
 func _find_game_board() -> NurikabeGameBoard:
-	return find_parent("*GameBoard")
+	return Utils.find_parent_of_type(self, NurikabeGameBoard)
 
 
 func _find_player_for_cursor(area: Area2D) -> Player:
-	return area.find_parent("Player")
+	return Utils.find_parent_of_type(area, Player)

--- a/project/src/main/nurikabe/game_board.tscn
+++ b/project/src/main/nurikabe/game_board.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=38 format=3 uid="uid://b06aw2k2o1thk"]
+[gd_scene load_steps=39 format=3 uid="uid://b06aw2k2o1thk"]
 
 [ext_resource type="Script" uid="uid://c8ofbnvv80ou2" path="res://src/main/nurikabe/nurikabe_game_board.gd" id="1_7bv3k"]
 [ext_resource type="Texture2D" uid="uid://gwh78fbjjfbb" path="res://assets/main/nurikabe/tile_blank_1.png" id="2_j45ic"]
@@ -19,6 +19,7 @@
 [ext_resource type="PackedScene" uid="uid://dn3d3m8il6qqm" path="res://src/main/nurikabe/cursorable_area.tscn" id="17_coiav"]
 [ext_resource type="PackedScene" uid="uid://bjksq0yxrx6cq" path="res://src/main/nurikabe/nurikabe_cursor.tscn" id="18_85sqx"]
 [ext_resource type="Script" uid="uid://bo2x55tn0h5yl" path="res://src/main/world/steppable_tiles.gd" id="19_7bs1t"]
+[ext_resource type="Theme" uid="uid://6shp5ck1tnja" path="res://assets/main/ui/kenney/kenney_ui.tres" id="20_j45ic"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_ccndg"]
 texture = ExtResource("2_j45ic")
@@ -118,7 +119,7 @@ sources/1 = SubResource("TileSetAtlasSource_vr7lx")
 sources/2 = SubResource("TileSetAtlasSource_m1d6t")
 sources/3 = SubResource("TileSetAtlasSource_pyfk6")
 
-[node name="GameBoard" type="Control"]
+[node name="GameBoard" type="Control" groups=["game_boards"]]
 y_sort_enabled = true
 layout_mode = 3
 anchors_preset = 0
@@ -128,6 +129,18 @@ offset_right = 772.0
 offset_bottom = 320.0
 mouse_filter = 2
 script = ExtResource("1_7bv3k")
+
+[node name="Label" type="Label" parent="."]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(200, 23)
+layout_mode = 1
+anchors_preset = -1
+offset_left = 12.0
+offset_top = -40.0
+offset_right = 212.0
+theme = ExtResource("20_j45ic")
+theme_override_font_sizes/font_size = 32
+text = "Medium"
 
 [node name="TileMapGround" type="TileMapLayer" parent="."]
 unique_name_in_owner = true

--- a/project/src/main/nurikabe/nurikabe_game_screen.gd
+++ b/project/src/main/nurikabe/nurikabe_game_screen.gd
@@ -1,28 +1,126 @@
 extends Control
 
+const GAME_BOARD_SCENE: PackedScene = preload("res://src/main/nurikabe/game_board.tscn")
 const PUZZLE_DIR: String = "res://assets/main/nurikabe/official"
+const TARGET_PUZZLE_COUNT: int = 7
 
 var _all_puzzles: Array[String] = Utils.find_data_files(PUZZLE_DIR, "txt")
+var _puzzle_queue: Array[String] = []
 
 func _ready() -> void:
-	var puzzle_path: String = _all_puzzles.pick_random()
-	var new_grid_string: String = NurikabeUtils.load_grid_string_from_file(puzzle_path)
-	%GameBoard.grid_string = new_grid_string
-	%GameBoard.import_grid()
-	%GameBoard.visible = true
+	clear_game_boards()
+	refresh_game_boards()
 
 
-func _import_random_puzzle() -> void:
-	var puzzle_path: String = _all_puzzles.pick_random()
+func clear_game_boards() -> void:
+	for game_board: NurikabeGameBoard in get_game_boards():
+		remove_game_board(game_board)
+
+
+func remove_game_board(game_board: NurikabeGameBoard) -> void:
+	game_board.queue_free()
+
+
+func get_game_boards() -> Array[NurikabeGameBoard]:
+	var result: Array[NurikabeGameBoard] = []
+	result.assign(%GameBoards.get_children().filter(
+		func(node: Node) -> bool:
+			return node is NurikabeGameBoard and not node.is_queued_for_deletion()))
+	return result
+
+
+func refresh_game_boards() -> void:
+	# remove all empty/solved puzzles
+	for game_board: NurikabeGameBoard in get_game_boards():
+		if game_board.is_finished() or not game_board.is_started():
+			remove_game_board(game_board)
+	
+	# add puzzles to reach the target puzzle count
+	var new_puzzle_count: int = TARGET_PUZZLE_COUNT - get_game_boards().size()
+	for _i: int in new_puzzle_count:
+		add_random_puzzle()
+
+
+func _load_puzzle_info(puzzle_path: String) -> Dictionary[String, Variant]:
+	var result: Dictionary[String, Variant] = {}
+	var info_text: String = FileAccess.get_file_as_string(puzzle_path + ".info")
+	var test_json_conv: JSON = JSON.new()
+	test_json_conv.parse(info_text)
+	result.assign(test_json_conv.data)
+	return result
+
+
+func add_random_puzzle() -> void:
+	var puzzle_path: String = _next_puzzle_path()
 	var new_grid_string: String = NurikabeUtils.load_grid_string_from_file(puzzle_path)
 	
 	if randf() < 0.5:
 		new_grid_string = NurikabeUtils.mirror_grid_string(new_grid_string)
 	new_grid_string = NurikabeUtils.rotate_grid_string(new_grid_string, randi_range(0, 3))
 	
-	%GameBoard.grid_string = new_grid_string
-	%GameBoard.import_grid()
+	var game_board: NurikabeGameBoard = GAME_BOARD_SCENE.instantiate()
+	game_board.grid_string = new_grid_string
+	game_board.import_grid()
+	game_board.puzzle_finished.connect(%ResultsOverlay._on_game_board_puzzle_finished)
+	game_board.set_meta("puzzle_path", puzzle_path)
+	
+	var new_info: Dictionary[String, Variant] = _load_puzzle_info(puzzle_path)
+	if new_info.has("difficulty"):
+		game_board.set_meta("difficulty", new_info.get("difficulty"))
+		game_board.label_text = _difficulty_label(new_info.get("difficulty"))
+	
+	%GameBoards.add_child(game_board)
+	
+	var angle: float = randf_range(0, 2 * PI)
+	var dist: float = randf_range(0, 500)
+	while _overlaps_existing_game_board(game_board):
+		angle = fmod(angle + 0.1, 2 * PI)
+		dist = dist * 1.1 + 100
+		game_board.position = Vector2.RIGHT.rotated(angle) * dist
 
 
-func _on_results_overlay_next_level_button_pressed() -> void:
-	_import_random_puzzle()
+func _difficulty_label(score: float) -> String:
+	var result: String = ""
+	if score < 2:
+		result = "Easy"
+	elif score < 5:
+		result = "Medium"
+	elif score < 8:
+		result = "Hard"
+	else:
+		result = "Expert"
+	return result
+
+
+func _existing_game_board_has_path(path: String) -> bool:
+	var result: bool = false
+	for existing_board: NurikabeGameBoard in get_game_boards():
+		if existing_board.get_meta("puzzle_path") == path:
+			result = true
+			break
+	return result
+
+
+func _next_puzzle_path() ->  String:
+	var puzzle_path: String
+	
+	for _mercy in 50:
+		if _puzzle_queue.is_empty():
+			_puzzle_queue = _all_puzzles.duplicate()
+			_puzzle_queue.shuffle()
+		puzzle_path = _puzzle_queue.pop_front()
+		if not _existing_game_board_has_path(puzzle_path):
+			break
+	
+	return puzzle_path
+
+
+func _overlaps_existing_game_board(new_board: NurikabeGameBoard) -> bool:
+	var result: bool = false
+	for existing_board: NurikabeGameBoard in get_game_boards():
+		if existing_board == new_board:
+			continue
+		if existing_board.get_rect().grow(50).intersects(new_board.get_rect().grow(50)):
+			result = true
+			break
+	return result

--- a/project/src/main/nurikabe/nurikabe_game_screen.tscn
+++ b/project/src/main/nurikabe/nurikabe_game_screen.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=4 uid="uid://c1ikxk7sf1v"]
+[gd_scene load_steps=5 format=3 uid="uid://c1ikxk7sf1v"]
 
 [ext_resource type="PackedScene" uid="uid://b06aw2k2o1thk" path="res://src/main/nurikabe/game_board.tscn" id="1_0ph7c"]
 [ext_resource type="Script" uid="uid://dkfhvt7xta6qi" path="res://src/main/nurikabe/nurikabe_game_screen.gd" id="1_nc88o"]
@@ -16,8 +16,14 @@ grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("1_nc88o")
 
-[node name="GameBoard" parent="." instance=ExtResource("1_0ph7c")]
+[node name="GameBoards" type="Control" parent="."]
 unique_name_in_owner = true
+y_sort_enabled = true
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="GameBoard" parent="GameBoards" instance=ExtResource("1_0ph7c")]
 visible = false
 layout_mode = 0
 offset_left = 741.0
@@ -34,30 +40,6 @@ grid_string = " 2                 2
                     
    1         2   4  "
 
-[node name="TileMapGround" parent="GameBoard" index="0"]
-tile_map_data = PackedByteArray("AAAAAAAAAAAAAAAAAAABAAAAAQAAAAAAAAACAAAAAAAAAAAAAAADAAAAAQAAAAAAAAAEAAAAAAAAAAAAAAAFAAAAAQAAAAAAAAAGAAAAAAAAAAAAAAAHAAAAAQAAAAAAAAAIAAAAAAAAAAAAAAAJAAAAAQAAAAAAAAAAAAEAAQAAAAAAAAABAAEAAAAAAAAAAAACAAEAAQAAAAAAAAADAAEAAAAAAAAAAAAEAAEAAQAAAAAAAAAFAAEAAAAAAAAAAAAGAAEAAQAAAAAAAAAHAAEAAAAAAAAAAAAIAAEAAQAAAAAAAAAJAAEAAAAAAAAAAAAAAAIAAAAAAAAAAAABAAIAAQAAAAAAAAACAAIAAAAAAAAAAAADAAIAAQAAAAAAAAAEAAIAAAAAAAAAAAAFAAIAAQAAAAAAAAAGAAIAAAAAAAAAAAAHAAIAAQAAAAAAAAAIAAIAAAAAAAAAAAAJAAIAAQAAAAAAAAAAAAMAAQAAAAAAAAABAAMAAAAAAAAAAAACAAMAAQAAAAAAAAADAAMAAAAAAAAAAAAEAAMAAQAAAAAAAAAFAAMAAAAAAAAAAAAGAAMAAQAAAAAAAAAHAAMAAAAAAAAAAAAIAAMAAQAAAAAAAAAJAAMAAAAAAAAAAAAAAAQAAAAAAAAAAAABAAQAAQAAAAAAAAACAAQAAAAAAAAAAAADAAQAAQAAAAAAAAAEAAQAAAAAAAAAAAAFAAQAAQAAAAAAAAAGAAQAAAAAAAAAAAAHAAQAAQAAAAAAAAAIAAQAAAAAAAAAAAAJAAQAAQAAAAAAAAAAAAUAAQAAAAAAAAABAAUAAAAAAAAAAAACAAUAAQAAAAAAAAADAAUAAAAAAAAAAAAEAAUAAQAAAAAAAAAFAAUAAAAAAAAAAAAGAAUAAQAAAAAAAAAHAAUAAAAAAAAAAAAIAAUAAQAAAAAAAAAJAAUAAAAAAAAAAAAAAAYAAAAAAAAAAAABAAYAAQAAAAAAAAACAAYAAAAAAAAAAAADAAYAAQAAAAAAAAAEAAYAAAAAAAAAAAAFAAYAAQAAAAAAAAAGAAYAAAAAAAAAAAAHAAYAAQAAAAAAAAAIAAYAAAAAAAAAAAAJAAYAAQAAAAAAAAAAAAcAAQAAAAAAAAABAAcAAAAAAAAAAAACAAcAAQAAAAAAAAADAAcAAAAAAAAAAAAEAAcAAQAAAAAAAAAFAAcAAAAAAAAAAAAGAAcAAQAAAAAAAAAHAAcAAAAAAAAAAAAIAAcAAQAAAAAAAAAJAAcAAAAAAAAAAAAAAAgAAAAAAAAAAAABAAgAAQAAAAAAAAACAAgAAAAAAAAAAAADAAgAAQAAAAAAAAAEAAgAAAAAAAAAAAAFAAgAAQAAAAAAAAAGAAgAAAAAAAAAAAAHAAgAAQAAAAAAAAAIAAgAAAAAAAAAAAAJAAgAAQAAAAAAAAA=")
-
-[node name="TileMapClue" parent="GameBoard" index="3"]
-clues_by_cell = Dictionary[Vector2i, int]({
-Vector2i(0, 0): 2,
-Vector2i(0, 6): 2,
-Vector2i(1, 2): 2,
-Vector2i(1, 8): 1,
-Vector2i(2, 5): 2,
-Vector2i(3, 6): 4,
-Vector2i(4, 2): 7,
-Vector2i(6, 1): 2,
-Vector2i(6, 4): 3,
-Vector2i(6, 8): 2,
-Vector2i(7, 5): 3,
-Vector2i(8, 4): 3,
-Vector2i(8, 8): 4,
-Vector2i(9, 0): 2
-})
-
-[node name="CursorableArea" parent="GameBoard" index="5"]
-cursorable_rect = Rect2(0, 0, 2560, 2304)
-
 [node name="Player" parent="." instance=ExtResource("7_21uqv")]
 position = Vector2(1444, 630)
 collision_mask = 2
@@ -69,7 +51,4 @@ zoom = Vector2(1.2, 1.2)
 unique_name_in_owner = true
 visible = false
 
-[connection signal="puzzle_finished" from="GameBoard" to="ResultsOverlay" method="_on_game_board_puzzle_finished"]
-[connection signal="next_level_button_pressed" from="ResultsOverlay" to="." method="_on_results_overlay_next_level_button_pressed"]
-
-[editable path="GameBoard"]
+[connection signal="puzzle_finished" from="GameBoards/GameBoard" to="ResultsOverlay" method="_on_game_board_puzzle_finished"]

--- a/project/src/main/nurikabe/results_overlay.tscn
+++ b/project/src/main/nurikabe/results_overlay.tscn
@@ -58,7 +58,7 @@ custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 32
-text = "Next Level"
+text = "Cool :)"
 
 [node name="ButtonClickEffect" parent="Panel/MarginContainer/VBoxContainer/Button" instance=ExtResource("3_trb17")]
 

--- a/project/src/main/player/player_move_handler.gd
+++ b/project/src/main/player/player_move_handler.gd
@@ -20,7 +20,7 @@ var _last_input_method: InputMethod = InputMethod.NONE
 var _mouse_target: Vector2
 var _mouse_dir: Vector2
 
-@onready var player: Player = find_parent("Player")
+@onready var player: Player = Utils.find_parent_of_type(self, Player)
 
 func handle(event: InputEvent) -> void:
 	# wasd

--- a/project/src/main/player/player_puzzle_handler.gd
+++ b/project/src/main/player/player_puzzle_handler.gd
@@ -17,9 +17,13 @@ var _last_set_cell: int = CELL_INVALID
 var _prev_cell: Vector2i = Vector2i(-577218, -577218)
 
 @onready var input_handler: PlayerInputHandler = get_parent()
-@onready var player: Player = find_parent("Player")
+@onready var player: Player = Utils.find_parent_of_type(self, Player)
 
 func handle(event: InputEvent) -> void:
+	if game_board.is_finished():
+		# cannot interact with finished game board
+		return
+	
 	_input_sfx = ""
 	
 	if event is InputEventMouseMotion:

--- a/project/src/main/utils/utils.gd
+++ b/project/src/main/utils/utils.gd
@@ -97,6 +97,16 @@ static func find_data_files(path: String, file_extension: String) -> Array[Strin
 	return found_files
 
 
+## Finds the first ancestor of this node whose type matches [param type], returning null if no match is found.
+static func find_parent_of_type(node: Node, type: Variant) -> Node:
+	var curr: Node = node.get_parent()
+	while curr != null:
+		if is_instance_of(curr, type):
+			break
+		curr = curr.get_parent()
+	return curr
+
+
 ## Returns [0-9] for a number key event, or -1 if the event is not a number key event.
 static func key_num(event: InputEvent) -> int:
 	return NUM_SCANCODES.get(key_press(event), -1)


### PR DESCRIPTION
The overworld now shows 7 puzzles instead of just one. Solving a puzzle leaves it filled (they will eventually be refreshed.) Finished puzzles cannot be interacted with.

Replaced find_parent(name) methods with find_parent_of_type(type). The new multiple puzzle logic creates puzzles with names like "@Control@007", so keying off type is the only reliable way to find the corresponding game boards.