### PR TITLE
Fix memory leaks in generator, mutator, solver.

### DIFF
--- a/project/src/demo/nurikabe/generator/bulk_generator.gd
+++ b/project/src/demo/nurikabe/generator/bulk_generator.gd
@@ -1,6 +1,7 @@
 class_name BulkGenerator
 extends Node
 ## [b]Keys:[/b][br]
+## 	[kbd]O[/kbd]: Print memory usage statistics.
 ## 	[kbd]G[/kbd]: Toggle generator, continuously writes new puzzles to GENERATED_PUZZLE_DIR.
 ## 	[kbd]A[/kbd]: Toggle analyzer; analyzes puzzles in PUZZLE_DIR and writes .info files.
 
@@ -85,6 +86,8 @@ func _ready() -> void:
 
 func _input(event: InputEvent) -> void:
 	match Utils.key_press(event):
+		KEY_O:
+			Utils.print_memory_stats()
 		KEY_G:
 			toggle_state("generate")
 		KEY_A:

--- a/project/src/demo/nurikabe/generator/bulk_generator_analyze_state.gd
+++ b/project/src/demo/nurikabe/generator/bulk_generator_analyze_state.gd
@@ -23,6 +23,7 @@ func update(_delta: float) -> void:
 	copy_board_from_solver()
 	var validation_result: SolverBoard.ValidationResult \
 			= solver.board.validate(SolverBoard.VALIDATE_STRICT)
+	solver.board.cleanup()
 	if validation_result.error_count > 0:
 		object.show_message("Error: Invalid solution")
 		return

--- a/project/src/demo/nurikabe/generator/bulk_generator_generate_state.gd
+++ b/project/src/demo/nurikabe/generator/bulk_generator_generate_state.gd
@@ -7,6 +7,8 @@ var rng: RandomNumberGenerator = RandomNumberGenerator.new()
 var _stuck_state: Dictionary[String, Variant] = {}
 
 func enter() -> void:
+	if generator.board:
+		generator.board.solver_board.cleanup()
 	generator.board = %GameBoard.to_generator_board()
 	create_board()
 
@@ -94,6 +96,7 @@ func output_board() -> void:
 			% [puzzle_num, path, info_json["difficulty"]])
 	
 	puzzle_num += 1
+	board.cleanup()
 
 
 func set_puzzle_size(puzzle_size: Vector2i) -> void:
@@ -105,6 +108,8 @@ func set_puzzle_size(puzzle_size: Vector2i) -> void:
 	%GameBoard.grid_string = new_grid_string
 	%GameBoard.import_grid()
 	generator.clear()
+	if generator.board:
+		generator.board.solver_board.cleanup()
 	generator.board = %GameBoard.to_generator_board()
 
 

--- a/project/src/demo/nurikabe/generator/demo_generator.gd
+++ b/project/src/demo/nurikabe/generator/demo_generator.gd
@@ -71,11 +71,15 @@ func _input(event: InputEvent) -> void:
 		KEY_H:
 			generator.log_enabled = true
 			generator.consume_events()
+			if generator.board:
+				generator.board.solver_board.cleanup()
 			generator.board = %GameBoard.to_generator_board()
 			generator_running = true
 		KEY_R:
 			generator.clear()
 			%GameBoard.reset()
+			if generator.board:
+				generator.board.solver_board.cleanup()
 			generator.board = %GameBoard.to_generator_board()
 			if fixed_seed != -1:
 				generator.rng.seed = fixed_seed
@@ -115,7 +119,9 @@ func _process(_delta: float) -> void:
 
 
 func print_grid_string() -> void:
-	%GameBoard.to_solver_board().print_cells()
+	var board: SolverBoard = %GameBoard.to_solver_board()
+	board.print_cells()
+	board.cleanup()
 	var clue_minimum_strings: Array[String] = []
 	for clue_minimum_cell: Vector2i in generator.board.clue_minimums:
 		var string: String = "%s:%s" % [clue_minimum_cell, generator.board.clue_minimums[clue_minimum_cell]]
@@ -134,6 +140,8 @@ func set_puzzle_size(puzzle_size: Vector2i) -> void:
 	%GameBoard.grid_string = new_grid_string
 	%GameBoard.import_grid()
 	generator.clear()
+	if generator.board:
+		generator.board.solver_board.cleanup()
 	generator.board = %GameBoard.to_generator_board()
 
 

--- a/project/src/demo/nurikabe/generator/demo_mutator.gd
+++ b/project/src/demo/nurikabe/generator/demo_mutator.gd
@@ -25,6 +25,7 @@ func _ready() -> void:
 	var board: SolverBoard = SolverBoard.new()
 	board.from_grid_string(grid_string)
 	mutator = PuzzleMutator.new(board)
+	board.cleanup()
 	remove_all_children(%GameBoards)
 	remove_all_children(%Labels)
 	refresh_candidates()

--- a/project/src/demo/nurikabe/solver/demo_solver.gd
+++ b/project/src/demo/nurikabe/solver/demo_solver.gd
@@ -113,6 +113,8 @@ func _input(event: InputEvent) -> void:
 				print_grid_string()
 		KEY_R:
 			%GameBoard.reset()
+			if solver.board:
+				solver.board.cleanup()
 			solver.board = %GameBoard.to_solver_board()
 			solver.clear()
 		KEY_D:
@@ -151,7 +153,9 @@ func _show_normalized_fun_string() -> String:
 
 
 func print_grid_string() -> void:
-	%GameBoard.to_solver_board().print_cells()
+	var board: SolverBoard = %GameBoard.to_solver_board()
+	board.print_cells()
+	board.cleanup()
 
 
 func step() -> void:
@@ -204,6 +208,8 @@ func solve_until_bifurcation() -> void:
 
 func load_puzzle(new_puzzle_path: String) -> void:
 	puzzle_path = new_puzzle_path
+	if solver.board:
+		solver.board.cleanup()
 	solver.board = %GameBoard.to_solver_board()
 	solver.clear()
 

--- a/project/src/main/nurikabe/generator/puzzle_mutator.gd
+++ b/project/src/main/nurikabe/generator/puzzle_mutator.gd
@@ -134,6 +134,9 @@ func step() -> void:
 	for i in wrapped_candidates.size():
 		new_candidates[i] = wrapped_candidates[i]["candidate"]
 	
+	for candidate: Solver in candidates:
+		candidate.board.cleanup()
+	
 	candidates = new_candidates
 	_best_fitness = wrapped_candidates[0]["fitness"]
 
@@ -252,6 +255,11 @@ func calculate_fitness(solver: Solver) -> float:
 		fitness *= 10.0 / (validation_penalty + 10)
 	
 	return fitness
+
+
+func cleanup() -> void:
+	for candidate: Solver in candidates:
+		candidate.board.cleanup()
 
 
 func _refresh_difficulty() -> void:

--- a/project/src/main/nurikabe/nurikabe_game_board.gd
+++ b/project/src/main/nurikabe/nurikabe_game_board.gd
@@ -362,6 +362,7 @@ func _on_validate_timer_timeout() -> void:
 	for wrong_size_cell: Vector2i in result_strict.wrong_size:
 		new_lowlight_cells.erase(wrong_size_cell)
 	lowlight_cells = new_lowlight_cells
+	model.cleanup()
 	
 	# update error cells if the player made a mistake
 	var old_error_cells: Dictionary[Vector2i, bool] = error_cells

--- a/project/src/main/nurikabe/solver/solver.gd
+++ b/project/src/main/nurikabe/solver/solver.gd
@@ -462,6 +462,7 @@ func _apply_assumptions(solver: Solver, assumptions: Dictionary[Vector2i, int]) 
 func _disprove_assumptions(assumptions: Dictionary[Vector2i, int]) -> bool:
 	var solver: Solver = Solver.new()
 	if not _apply_assumptions(solver, assumptions):
+		solver.board.cleanup()
 		return false
 	
 	if not metrics.has("bifurcation_scenarios"):
@@ -500,6 +501,8 @@ func _disprove_assumptions(assumptions: Dictionary[Vector2i, int]) -> bool:
 	if not metrics.has("bifurcation_duration"):
 		metrics["bifurcation_duration"] = 0
 	metrics["bifurcation_duration"] += (Time.get_ticks_usec() - bifurcation_start_time) / 1000.0
+	
+	solver.board.cleanup()
 	
 	return not assumptions_valid
 

--- a/project/src/main/nurikabe/solver/solver_board.gd
+++ b/project/src/main/nurikabe/solver/solver_board.gd
@@ -453,6 +453,17 @@ func validate_local(local_cells: Array[Vector2i]) -> String:
 	return result
 
 
+## Call this when finished with a SolverBoard to prevent memory leaks.[br]
+## [br]
+## Workaround for Godot https://github.com/godotengine/godot/issues/101830: Circular references in GDScript
+## code may lead to leaks.
+func cleanup() -> void:
+	for value: Variant in _cache.values():
+		if value is SolverBoard:
+			value.cleanup()
+	clear()
+
+
 func _build_flooded_board() -> SolverBoard:
 	var flooded_board: SolverBoard = duplicate()
 	flooded_board.groups_need_rebuild = true
@@ -543,6 +554,8 @@ func _build_strict_validation_result() -> ValidationResult:
 
 func _build_validation_result(mode: ValidationMode) -> ValidationResult:
 	var result: ValidationResult = ValidationResult.new()
+	
+	get_flooded_island_group_map()
 	
 	# joined islands
 	for island: CellGroup in islands:

--- a/project/src/main/nurikabe/solver/solver_chokepoint_map.gd
+++ b/project/src/main/nurikabe/solver/solver_chokepoint_map.gd
@@ -15,14 +15,14 @@ var chokepoints_by_cell: Dictionary[Vector2i, bool]:
 			_build_chokepoint_map()
 		return _chokepoint_map.chokepoints_by_cell
 
-var _board: SolverBoard
+var board: SolverBoard
 var _included_types: Array[int]
 var _special_cell_filter: Callable
 var _chokepoint_map: ChokepointMap
 
 func _init(init_board: SolverBoard, init_included_types: Array[int], \
 		init_special_cell_filter: Callable = Callable()) -> void:
-	_board = init_board
+	board = init_board
 	_included_types = init_included_types
 	_special_cell_filter = init_special_cell_filter
 
@@ -78,11 +78,11 @@ func get_unchoked_special_count(chokepoint: Vector2i, cell: Vector2i) -> int:
 func _build_chokepoint_map() -> void:
 	var cells: Array[Vector2i] = []
 	if CELL_EMPTY in _included_types:
-		cells.append_array(_board.empty_cells.keys())
+		cells.append_array(board.empty_cells.keys())
 	if CELL_WALL in _included_types:
-		for wall: CellGroup in _board.walls:
+		for wall: CellGroup in board.walls:
 			cells.append_array(wall.cells)
 	if CELL_ISLAND in _included_types:
-		for island: CellGroup in _board.islands:
+		for island: CellGroup in board.islands:
 			cells.append_array(island.cells)
 	_chokepoint_map = ChokepointMap.new(cells, _special_cell_filter)

--- a/project/src/main/utils/state_machine.gd
+++ b/project/src/main/utils/state_machine.gd
@@ -1,6 +1,6 @@
 @tool
-extends Node
 class_name StateMachine
+extends Node
 ## Implementation of the finite state machine pattern.
 ##
 ## State nodes can be added to this node as children. This class provides logic for switching between its child states,

--- a/project/src/test/nurikabe/generator/test_generator.gd
+++ b/project/src/test/nurikabe/generator/test_generator.gd
@@ -15,6 +15,11 @@ func before_each() -> void:
 	generator.clear()
 
 
+func after_all() -> void:
+	generator.board.solver_board.cleanup()
+	generator.solver.board.cleanup()
+
+
 func assert_placements(callable: Callable, expected_str_array: Array[String]) -> void:
 	generator.board = GeneratorTestUtils.init_board(grid)
 	callable.call()

--- a/project/src/test/nurikabe/generator/test_generator_basic.gd
+++ b/project/src/test/nurikabe/generator/test_generator_basic.gd
@@ -12,6 +12,7 @@ func test_find_island_guide_cell_candidates() -> void:
 	var candidates: Array[Vector2i] = generator.find_island_guide_cell_candidates(island)
 	candidates.sort()
 	assert_eq(candidates, [Vector2i(1, 3), Vector2i(3, 1)])
+	generator.board.cleanup()
 
 
 func test_attempt_island_buffer_from() -> void:
@@ -32,3 +33,4 @@ func test_attempt_island_buffer_from() -> void:
 			island, Vector2i(3, 2), [Vector2i.UP, Vector2i.RIGHT, Vector2i.DOWN, Vector2i.LEFT] as Array[Vector2i])
 	assert_placements(callable, expected)
 	assert_clue_minimum_changes(["{ \"pos\": (1, 1), \"value\": 3 }"])
+	generator.board.cleanup()

--- a/project/src/test/nurikabe/generator/test_generator_fix.gd
+++ b/project/src/test/nurikabe/generator/test_generator_fix.gd
@@ -80,6 +80,7 @@ func test_prepare_board_for_mutation() -> void:
 			" .## .## .## . .###### 4",
 			" 3## 2## 2######## . . .",
 		])
+	generator.board.cleanup()
 
 
 func test_prepare_board_for_mutation_2() -> void:
@@ -109,6 +110,7 @@ func test_prepare_board_for_mutation_2() -> void:
 			" .#### . . .########",
 			" . . . . . .15## 2 .",
 		])
+	generator.board.cleanup()
 
 
 func assert_board(board: SolverBoard, expected: Array[String]) -> void:

--- a/project/src/test/nurikabe/generator/test_generator_utils.gd
+++ b/project/src/test/nurikabe/generator/test_generator_utils.gd
@@ -14,6 +14,7 @@ func test_best_clue_cells_for_unclued_island() -> void:
 	var clue_cells: Array[Vector2i] = \
 			GeneratorUtils.best_clue_cells_for_unclued_island(board, island)
 	assert_eq(clue_cells, [Vector2i(4, 0)])
+	board.cleanup()
 
 
 func test_best_clue_cells_for_unclued_island_single() -> void:
@@ -30,3 +31,4 @@ func test_best_clue_cells_for_unclued_island_single() -> void:
 			Vector2i(1, 0), Vector2i(1, 1),
 			Vector2i(2, 0), Vector2i(2, 1),
 		])
+	board.cleanup()

--- a/project/src/test/nurikabe/generator/test_mutation_library_basic.gd
+++ b/project/src/test/nurikabe/generator/test_mutation_library_basic.gd
@@ -62,6 +62,7 @@ func test_get_possible_island_splits() -> void:
 		"vertical (2, 0)",
 		"vertical (3, 0)",
 		])
+	board.cleanup()
 
 
 func test_split_island_cell() -> void:
@@ -86,6 +87,7 @@ func test_split_island_cell() -> void:
 			" . . . . .",
 			" . . . . .",
 		])
+	board.cleanup()
 
 
 func test_split_island_horizontal() -> void:
@@ -110,6 +112,7 @@ func test_split_island_horizontal() -> void:
 			" . .10 . .",
 			" . . . . .",
 		])
+	board.cleanup()
 
 
 func test_split_island_vertical() -> void:
@@ -134,6 +137,7 @@ func test_split_island_vertical() -> void:
 			" .## 9 . .",
 			" .## . . .",
 		])
+	board.cleanup()
 
 
 func test_mutate_break_wall_loop() -> void:
@@ -149,6 +153,7 @@ func test_mutate_break_wall_loop() -> void:
 	mutation_library.mutate_break_wall_loop(board)
 	var cuttable_loop_cells: Array[Vector2i] = mutation_library.find_cuttable_loop_cells(board)
 	assert_eq(cuttable_loop_cells, [])
+	board.cleanup()
 
 
 func test_find_cuttable_loop_cells() -> void:
@@ -169,6 +174,7 @@ func test_find_cuttable_loop_cells() -> void:
 			Vector2i(3, 0), Vector2i(3, 3),
 			Vector2i(4, 0), Vector2i(4, 1), Vector2i(4, 2), Vector2i(4, 3),
 		])
+	board.cleanup()
 
 
 func test_mutate_rebalance_neighbor_islands() -> void:
@@ -182,6 +188,7 @@ func test_mutate_rebalance_neighbor_islands() -> void:
 	mutation_library.mutate_rebalance_neighbor_islands(board)
 	assert_ne(board.get_clue(Vector2i(0, 0)), 3)
 	assert_ne(board.get_clue(Vector2i(0, 2)), 7)
+	board.cleanup()
 
 
 func test_move_clue() -> void:
@@ -198,6 +205,7 @@ func test_move_clue() -> void:
 	mutation_library.move_clue(board, island)
 	assert_eq(board.has_clue(Vector2i(0, 2)), false)
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).clue, 5)
+	board.cleanup()
 
 
 func test_move_clue_single() -> void:
@@ -211,6 +219,7 @@ func test_move_clue_single() -> void:
 	mutation_library.move_clue(board, island)
 	assert_eq(board.has_clue(Vector2i(0, 1)), false)
 	assert_eq(board.get_island_for_cell(Vector2i(0, 1)).clue, 4)
+	board.cleanup()
 
 
 func assert_board(board: SolverBoard, expected: Array[String]) -> void:

--- a/project/src/test/nurikabe/generator/test_mutation_library_fix.gd
+++ b/project/src/test/nurikabe/generator/test_mutation_library_fix.gd
@@ -16,6 +16,7 @@ func test_mutate_fix_enclosed_walls() -> void:
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).clue, 12)
 	assert_eq(board.get_cell(Vector2i(1, 1)), CELL_ISLAND)
 	assert_eq(board.get_cell(Vector2i(3, 0)), CELL_ISLAND)
+	board.cleanup()
 
 
 func test_mutate_fix_enclosed_walls_complex() -> void:
@@ -35,6 +36,7 @@ func test_mutate_fix_enclosed_walls_complex() -> void:
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).clue, 16)
 	assert_eq(board.get_cell(Vector2i(1, 1)), CELL_ISLAND)
 	assert_eq(board.get_cell(Vector2i(3, 0)), CELL_ISLAND)
+	board.cleanup()
 
 
 func test_mutate_fix_enclosed_walls_ok() -> void:
@@ -54,6 +56,7 @@ func test_mutate_fix_enclosed_walls_ok() -> void:
 	board.from_grid_string("\n".join(grid))
 	mutation_library.mutate_fix_enclosed_walls(board)
 	assert_eq(board.to_grid_string(), "\n".join(grid))
+	board.cleanup()
 
 
 func test_mutate_fix_joined_islands() -> void:
@@ -70,6 +73,7 @@ func test_mutate_fix_joined_islands() -> void:
 	
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).size(), 8)
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).clue, 8)
+	board.cleanup()
 
 
 func test_mutate_fix_joined_islands_single() -> void:
@@ -84,6 +88,7 @@ func test_mutate_fix_joined_islands_single() -> void:
 	
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).size(), 8)
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).clue, 8)
+	board.cleanup()
 
 
 func test_mutate_fix_pools() -> void:
@@ -100,6 +105,7 @@ func test_mutate_fix_pools() -> void:
 	
 	var validation_errors: SolverBoard.ValidationResult = board.validate(SolverBoard.VALIDATE_SIMPLE)
 	assert_eq([], validation_errors.pools)
+	board.cleanup()
 
 
 func test_mutate_fix_split_walls() -> void:
@@ -116,6 +122,7 @@ func test_mutate_fix_split_walls() -> void:
 	
 	var validation_errors: SolverBoard.ValidationResult = board.validate(SolverBoard.VALIDATE_SIMPLE)
 	assert_eq([], validation_errors.split_walls)
+	board.cleanup()
 
 
 func test_mutate_fix_split_walls_wide() -> void:
@@ -132,6 +139,7 @@ func test_mutate_fix_split_walls_wide() -> void:
 	
 	var validation_errors: SolverBoard.ValidationResult = board.validate(SolverBoard.VALIDATE_SIMPLE)
 	assert_eq([], validation_errors.split_walls)
+	board.cleanup()
 
 
 func test_mutate_fix_unclued_islands_clue() -> void:
@@ -148,6 +156,7 @@ func test_mutate_fix_unclued_islands_clue() -> void:
 	
 	var validation_errors: SolverBoard.ValidationResult = board.validate(SolverBoard.VALIDATE_SIMPLE)
 	assert_eq([], validation_errors.unclued_islands)
+	board.cleanup()
 
 
 func test_mutate_fix_unclued_islands_join() -> void:
@@ -164,6 +173,7 @@ func test_mutate_fix_unclued_islands_join() -> void:
 	
 	var validation_errors: SolverBoard.ValidationResult = board.validate(SolverBoard.VALIDATE_SIMPLE)
 	assert_eq([], validation_errors.unclued_islands)
+	board.cleanup()
 
 
 func test_mutate_fix_wrong_size() -> void:
@@ -180,3 +190,4 @@ func test_mutate_fix_wrong_size() -> void:
 	
 	var validation_errors: SolverBoard.ValidationResult = board.validate(SolverBoard.VALIDATE_SIMPLE)
 	assert_eq([], validation_errors.wrong_size)
+	board.cleanup()

--- a/project/src/test/nurikabe/generator/test_mutation_library_force.gd
+++ b/project/src/test/nurikabe/generator/test_mutation_library_force.gd
@@ -16,6 +16,7 @@ func test_mutate_force_exaggerate() -> void:
 	solver.board = board
 	solver.step_until_done(Solver.SolverPass.BIFURCATION)
 	assert_eq(board.is_filled(), true)
+	board.cleanup()
 
 
 func test_mutate_force_exaggerate_single() -> void:
@@ -30,6 +31,7 @@ func test_mutate_force_exaggerate_single() -> void:
 	board.from_grid_string("\n".join(grid))
 	mutation_library.mutate_force_exaggerate(board)
 	assert_eq(board.get_clue(Vector2i(0, 2)), 18)
+	board.cleanup()
 
 
 func test_mutate_force_inject() -> void:
@@ -48,6 +50,7 @@ func test_mutate_force_inject() -> void:
 	solver.board = board
 	solver.step_until_done(Solver.SolverPass.BIFURCATION)
 	assert_eq(board.is_filled(), true)
+	board.cleanup()
 
 
 func test_mutate_force_partition() -> void:
@@ -64,3 +67,4 @@ func test_mutate_force_partition() -> void:
 	assert_eq(1, board.get_clue(Vector2i(0, 2)))
 	assert_eq(3, board.get_clue(Vector2i(0, 4)))
 	assert_eq(15, board.get_island_for_cell(Vector2i(0, 0)).clue)
+	board.cleanup()

--- a/project/src/test/nurikabe/generator/test_puzzle_mutator.gd
+++ b/project/src/test/nurikabe/generator/test_puzzle_mutator.gd
@@ -5,6 +5,7 @@ var mutator: PuzzleMutator
 func test_fun_weights_exact() -> void:
 	var board: SolverBoard = SolverBoard.new()
 	mutator = PuzzleMutator.new(board)
+	board.cleanup()
 	mutator.difficulty = 0.0
 	assert_fun_weight(Deduction.FunAxis.FUN_BIFURCATE, -1.0)
 	
@@ -19,6 +20,7 @@ func assert_fun_weight(fun_axis: Deduction.FunAxis, expected: float) -> void:
 func test_fun_weights_interpolated() -> void:
 	var board: SolverBoard = SolverBoard.new()
 	mutator = PuzzleMutator.new(board)
+	board.cleanup()
 	mutator.difficulty = 0.25
 	assert_fun_weight(Deduction.FunAxis.FUN_THINK, -0.5)
 	
@@ -41,6 +43,7 @@ func test_fun_weights_interpolated() -> void:
 func test_fun_weights_interpolated_min() -> void:
 	var board: SolverBoard = SolverBoard.new()
 	mutator = PuzzleMutator.new(board)
+	board.cleanup()
 	mutator.difficulty = 0.25
 	assert_fun_weight(Deduction.FunAxis.FUN_FAST, 2.0)
 	
@@ -57,6 +60,7 @@ func test_fun_weights_interpolated_min() -> void:
 func test_fun_weights_interpolated_max() -> void:
 	var board: SolverBoard = SolverBoard.new()
 	mutator = PuzzleMutator.new(board)
+	board.cleanup()
 	mutator.difficulty = 0.75
 	assert_fun_weight(Deduction.FunAxis.FUN_BIFURCATE, 1.0)
 	

--- a/project/src/test/nurikabe/solver/test_global_reachability_map.gd
+++ b/project/src/test/nurikabe/solver/test_global_reachability_map.gd
@@ -15,6 +15,7 @@ func test_get_clue_reachability() -> void:
 	assert_eq(grm.get_clue_reachability(Vector2(1, 2)), GlobalReachabilityMap.ClueReachability.CONFLICT)
 	assert_eq(grm.get_clue_reachability(Vector2(2, 0)), GlobalReachabilityMap.ClueReachability.UNKNOWN)
 	assert_eq(grm.get_clue_reachability(Vector2(3, 0)), GlobalReachabilityMap.ClueReachability.IMPOSSIBLE)
+	grm.board.cleanup()
 
 
 func test_get_nearest_clued_island_cell() -> void:
@@ -27,6 +28,7 @@ func test_get_nearest_clued_island_cell() -> void:
 	assert_eq(grm.get_nearest_clued_island_cell(Vector2(1, 1)), Vector2i(0, 1))
 	assert_eq(grm.get_nearest_clued_island_cell(Vector2(2, 0)), Vector2i(2, 2))
 	assert_eq(grm.get_nearest_clued_island_cell(Vector2(2, 1)), Vector2i(2, 2))
+	grm.board.cleanup()
 
 
 func init_global_reachability_map() -> GlobalReachabilityMap:

--- a/project/src/test/nurikabe/solver/test_per_clue_chokepoint_map.gd
+++ b/project/src/test/nurikabe/solver/test_per_clue_chokepoint_map.gd
@@ -103,6 +103,7 @@ func test_get_reachable_clues_by_cell() -> void:
 	var pccm: PerClueChokepointMap = init_per_clue_chokepoint_map()
 	var reachable_clues_by_cell: Dictionary[Vector2i, Dictionary] = pccm.get_reachable_clues_by_cell()
 	assert_eq([Vector2i(3, 5)], reachable_clues_by_cell.get(Vector2i(3, 1), {} as Dictionary[Vector2i, bool]).keys())
+	pccm.board.cleanup()
 
 
 func assert_chokepoint_cells(island_cell: Vector2i, expected: Dictionary[Vector2i, int]) -> void:
@@ -110,6 +111,7 @@ func assert_chokepoint_cells(island_cell: Vector2i, expected: Dictionary[Vector2
 	var island: CellGroup = pccm.board.get_island_for_cell(island_cell)
 	var actual: Dictionary[Vector2i, int] = pccm.find_chokepoint_cells(island)
 	assert_eq(actual, expected)
+	pccm.board.cleanup()
 
 
 func assert_component_cells(island_cell: Vector2i, expected: Array[Vector2i]) -> void:
@@ -119,6 +121,7 @@ func assert_component_cells(island_cell: Vector2i, expected: Array[Vector2i]) ->
 	actual.sort()
 	expected.sort()
 	assert_eq(actual, expected)
+	pccm.board.cleanup()
 
 
 func init_per_clue_chokepoint_map() -> PerClueChokepointMap:

--- a/project/src/test/nurikabe/solver/test_solver.gd
+++ b/project/src/test/nurikabe/solver/test_solver.gd
@@ -7,11 +7,15 @@ const CELL_ISLAND: int = NurikabeUtils.CELL_ISLAND
 const CELL_WALL: int = NurikabeUtils.CELL_WALL
 const CELL_EMPTY: int = NurikabeUtils.CELL_EMPTY
 
-var solver: Solver = Solver.new()
+var solver: Solver
 var grid: Array[String] = []
 
 func before_each() -> void:
-	solver.clear()
+	solver = Solver.new()
+
+
+func after_each() -> void:
+	solver.board.cleanup()
 
 
 func assert_deductions(callable: Callable, expected_str_array: Array[String]) -> void:

--- a/project/src/test/nurikabe/solver/test_solver_board.gd
+++ b/project/src/test/nurikabe/solver/test_solver_board.gd
@@ -23,6 +23,7 @@ func test_islands() -> void:
 		{"cells": [Vector2i(0, 0)], "clue": 3, "liberties": [Vector2i(0, 1)]},
 		{"cells": [Vector2i(2, 0)], "clue": 2, "liberties": [Vector2i(2, 1)]},
 	])
+	board.cleanup()
 
 
 func test_islands_mystery_clue_1() -> void:
@@ -34,6 +35,7 @@ func test_islands_mystery_clue_1() -> void:
 	assert_groups(board.islands, [
 		{"cells": [Vector2i(1, 0), Vector2i(1, 1)], "clue": CELL_MYSTERY_CLUE, "liberties": [Vector2i(0, 0)]},
 	])
+	board.cleanup()
 
 
 func test_islands_mystery_clue_joined() -> void:
@@ -45,6 +47,7 @@ func test_islands_mystery_clue_joined() -> void:
 	assert_groups(board.islands, [
 		{"cells": [Vector2i(0, 0), Vector2i(1, 0), Vector2i(1, 1)], "clue": -1, "liberties": []},
 	])
+	board.cleanup()
 
 
 func test_islands_mystery_clue_2() -> void:
@@ -60,6 +63,7 @@ func test_islands_mystery_clue_2() -> void:
 	assert_groups(board.islands, [
 		{"cells": [Vector2i(1, 0), Vector2i(1, 1)], "clue": CELL_MYSTERY_CLUE, "liberties": [Vector2i(0, 0)]},
 	])
+	board.cleanup()
 
 
 func test_set_cell_island_open_islands() -> void:
@@ -84,6 +88,7 @@ func test_set_cell_island_open_islands() -> void:
 			"liberties": [Vector2i(0, 2), Vector2i(1, 0), Vector2i(2, 0), Vector2i(2, 2)],
 		},
 	])
+	board.cleanup()
 
 
 func test_set_cell_island_merge_islands() -> void:
@@ -113,6 +118,7 @@ func test_set_cell_island_merge_islands() -> void:
 			"liberties": [Vector2i(0, 2), Vector2i(2, 1)],
 		},
 	])
+	board.cleanup()
 
 
 func test_set_cell_island_merge_islands_2() -> void:
@@ -141,6 +147,7 @@ func test_set_cell_island_merge_islands_2() -> void:
 			"liberties": [Vector2i(0, 1)],
 		},
 	])
+	board.cleanup()
 
 
 func test_set_cell_wall_close_island() -> void:
@@ -165,6 +172,7 @@ func test_set_cell_wall_close_island() -> void:
 			"liberties": [Vector2i(1, 0), Vector2i(2, 1)],
 		},
 	])
+	board.cleanup()
 
 
 func test_walls() -> void:
@@ -178,6 +186,7 @@ func test_walls() -> void:
 		{"cells": [Vector2i(1, 1)], "clue": 0, "liberties": [Vector2i(0, 1), Vector2i(2, 1)]},
 		{"cells": [Vector2i(2, 0)], "clue": 0, "liberties": [Vector2i(2, 1)]},
 	])
+	board.cleanup()
 
 
 func test_set_cell_walls() -> void:
@@ -195,6 +204,7 @@ func test_set_cell_walls() -> void:
 	assert_groups(board.walls, [
 		{"cells": [Vector2i(0, 0), Vector2i(1, 0), Vector2i(1, 1), Vector2i(2, 0)], "clue": 0, "liberties": []},
 	])
+	board.cleanup()
 
 
 func test_joined_islands_two() -> void:
@@ -572,6 +582,7 @@ func test_island_chain_map_cycle() -> void:
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(1, 1)), true)
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(0, 0)), false)
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(1, 2)), false)
+	board.cleanup()
 
 
 func test_island_chain_map_cycle_clueless() -> void:
@@ -583,6 +594,7 @@ func test_island_chain_map_cycle_clueless() -> void:
 	var board: SolverBoard = SolverTestUtils.init_board(grid)
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(0, 1)), false)
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(1, 1)), false)
+	board.cleanup()
 
 
 func test_island_chain_map_cycle_middle() -> void:
@@ -598,6 +610,7 @@ func test_island_chain_map_cycle_middle() -> void:
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(2, 3)), true)
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(2, 4)), true)
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(2, 5)), false)
+	board.cleanup()
 
 
 func test_island_chain_map_cycle_middle_big() -> void:
@@ -612,6 +625,7 @@ func test_island_chain_map_cycle_middle_big() -> void:
 	var board: SolverBoard = SolverTestUtils.init_board(grid)
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(2, 3)), true)
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(2, 4)), true)
+	board.cleanup()
 
 
 func test_island_chain_map_cycle_janko_3() -> void:
@@ -632,6 +646,7 @@ func test_island_chain_map_cycle_janko_3() -> void:
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(4, 7)), true)
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(6, 6)), false)
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(8, 2)), false)
+	board.cleanup()
 
 
 func test_island_chain_map_cycle_janko_83() -> void:
@@ -649,6 +664,7 @@ func test_island_chain_map_cycle_janko_83() -> void:
 	var board: SolverBoard = SolverTestUtils.init_board(grid)
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(4, 7)), false)
 	assert_eq(board.get_island_chain_map().has_chain_conflict(Vector2i(5, 6)), false)
+	board.cleanup()
 
 
 func assert_groups(actual_groups: Array[CellGroup], expected_props_list: Array[Dictionary]) -> void:
@@ -700,6 +716,7 @@ func _assert_validate(mode: SolverBoard.ValidationMode, expected_result_dict: Di
 		var validation_result_value: Array[Vector2i] = validation_result.get(key)
 		validation_result_value.sort()
 		assert_eq(expected_result_dict.get(key, []), validation_result_value, "Incorrect %s." % [key])
+	board.cleanup()
 
 
 func _assert_validate_local(local_cells: Array[Vector2i], expected_result: String, \
@@ -709,3 +726,4 @@ func _assert_validate_local(local_cells: Array[Vector2i], expected_result: Strin
 		configure_board.call(board)
 	var validation_result: String = board.validate_local(local_cells)
 	assert_eq(validation_result, expected_result)
+	board.cleanup()

--- a/project/src/test/nurikabe/solver/test_solver_chokepoint_map.gd
+++ b/project/src/test/nurikabe/solver/test_solver_chokepoint_map.gd
@@ -16,6 +16,7 @@ func test_chokepoints_1() -> void:
 	]
 	var chokepoint_map: SolverChokepointMap = _build_island_chokepoint_map()
 	assert_chokepoints(chokepoint_map, [Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2)])
+	chokepoint_map.board.cleanup()
 
 
 func test_unchoked_cell_count_1() -> void:
@@ -31,6 +32,7 @@ func test_unchoked_cell_count_1() -> void:
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 2), Vector2(0, 0)), 3)
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 2), Vector2(2, 2)), 5)
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(1, 3), Vector2(2, 2)), 8)
+	chokepoint_map.board.cleanup()
 
 
 func test_unchoked_cell_count_2() -> void:
@@ -43,6 +45,7 @@ func test_unchoked_cell_count_2() -> void:
 	]
 	var chokepoint_map: SolverChokepointMap = _build_island_chokepoint_map()
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(3, 3), Vector2(3, 2)), 15)
+	chokepoint_map.board.cleanup()
 
 
 func test_chokepoints_donut() -> void:
@@ -53,6 +56,7 @@ func test_chokepoints_donut() -> void:
 	]
 	var chokepoint_map: SolverChokepointMap = _build_island_chokepoint_map()
 	assert_chokepoints(chokepoint_map, [])
+	chokepoint_map.board.cleanup()
 
 
 func test_chokepoints_2() -> void:
@@ -63,6 +67,7 @@ func test_chokepoints_2() -> void:
 	]
 	var chokepoint_map: SolverChokepointMap = _build_island_chokepoint_map()
 	assert_chokepoints(chokepoint_map, [Vector2i(1, 1)])
+	chokepoint_map.board.cleanup()
 
 
 func test_chokepoints_3() -> void:
@@ -73,6 +78,7 @@ func test_chokepoints_3() -> void:
 	]
 	var chokepoint_map: SolverChokepointMap = _build_island_chokepoint_map()
 	assert_chokepoints(chokepoint_map, [Vector2i(1, 1)])
+	chokepoint_map.board.cleanup()
 
 
 func test_chokepoints_two_clues() -> void:
@@ -83,6 +89,7 @@ func test_chokepoints_two_clues() -> void:
 	]
 	var chokepoint_map: SolverChokepointMap = _build_island_chokepoint_map()
 	assert_chokepoints(chokepoint_map, [Vector2i(0, 1), Vector2(2, 1)])
+	chokepoint_map.board.cleanup()
 
 
 func test_unchoked_cell_count_two_clues() -> void:
@@ -98,6 +105,7 @@ func test_unchoked_cell_count_two_clues() -> void:
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 1), Vector2(2, 0)), 3)
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 2), Vector2(0, 1)), 2)
 	assert_eq(chokepoint_map.get_unchoked_cell_count(Vector2(0, 2), Vector2(2, 0)), 3)
+	chokepoint_map.board.cleanup()
 
 
 func test_component_cell_count_two_clues() -> void:
@@ -112,6 +120,7 @@ func test_component_cell_count_two_clues() -> void:
 	assert_eq(chokepoint_map.get_component_cell_count(Vector2(0, 2)), 3)
 	assert_eq(chokepoint_map.get_component_cell_count(Vector2(2, 0)), 2)
 	assert_eq(chokepoint_map.get_component_cell_count(Vector2(2, 1)), 2)
+	chokepoint_map.board.cleanup()
 
 
 func test_component_cells_two_clues() -> void:
@@ -123,6 +132,7 @@ func test_component_cells_two_clues() -> void:
 	var chokepoint_map: SolverChokepointMap = _build_island_chokepoint_map()
 	assert_component_cells(chokepoint_map, Vector2(0, 0), [Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2)])
 	assert_component_cells(chokepoint_map, Vector2(2, 0), [Vector2i(2, 0), Vector2i(2, 1)])
+	chokepoint_map.board.cleanup()
 
 
 func test_special_cell_count_1() -> void:
@@ -138,6 +148,7 @@ func test_special_cell_count_1() -> void:
 	assert_eq(chokepoint_map.get_unchoked_special_count(Vector2i(1, 1), Vector2i(1, 2)), 2)
 	assert_eq(chokepoint_map.get_unchoked_special_count(Vector2i(1, 1), Vector2i(2, 0)), 1)
 	assert_eq(chokepoint_map.get_unchoked_special_count(Vector2i(1, 1), Vector2i(2, 2)), 2)
+	chokepoint_map.board.cleanup()
 
 
 func _build_island_chokepoint_map() -> SolverChokepointMap:


### PR DESCRIPTION
Workaround for Godot https://github.com/godotengine/godot/issues/101830: Circular references in GDScript code may lead to leaks.