### PR TITLE
More sim deductions: island moat, adjacent islands

### DIFF
--- a/project/src/main/monster/sim/naive_scanner.gd
+++ b/project/src/main/monster/sim/naive_scanner.gd
@@ -1,0 +1,21 @@
+class_name NaiveScanner
+
+const CELL_INVALID: int = NurikabeUtils.CELL_INVALID
+const CELL_ISLAND: int = NurikabeUtils.CELL_ISLAND
+const CELL_WALL: int = NurikabeUtils.CELL_WALL
+const CELL_EMPTY: int = NurikabeUtils.CELL_EMPTY
+
+var monster: SimMonster
+var scanner_board: ScannerBoard
+
+func update(_start_time: int) -> bool:
+	return true
+
+
+func out_of_time(start_time: int) -> bool:
+	return Time.get_ticks_usec() - start_time >= NaiveSolver.BUDGET_USEC
+
+
+func should_deduce(cell: Vector2i) -> bool:
+	return scanner_board.cells.get(cell, CELL_INVALID) == CELL_EMPTY \
+			and not monster.pending_deductions.has(cell)

--- a/project/src/main/monster/sim/naive_scanner.gd.uid
+++ b/project/src/main/monster/sim/naive_scanner.gd.uid
@@ -1,0 +1,1 @@
+uid://cybbd2viq3m0

--- a/project/src/main/monster/sim/naive_scanners.gd
+++ b/project/src/main/monster/sim/naive_scanners.gd
@@ -1,0 +1,98 @@
+class_name NaiveScanners
+
+const CELL_INVALID: int = NurikabeUtils.CELL_INVALID
+const CELL_ISLAND: int = NurikabeUtils.CELL_ISLAND
+const CELL_WALL: int = NurikabeUtils.CELL_WALL
+const CELL_EMPTY: int = NurikabeUtils.CELL_EMPTY
+
+const NEIGHBOR_DIRS: Array[Vector2i] = NurikabeUtils.NEIGHBOR_DIRS
+
+## starting techniques
+const ISLAND_OF_ONE: Deduction.Reason = Deduction.Reason.ISLAND_OF_ONE
+const ADJACENT_CLUES: Deduction.Reason = Deduction.Reason.ADJACENT_CLUES
+
+## basic techniques
+const CORNER_BUFFER: Deduction.Reason = Deduction.Reason.CORNER_BUFFER
+const CORNER_ISLAND: Deduction.Reason = Deduction.Reason.CORNER_ISLAND
+const ISLAND_BUBBLE: Deduction.Reason = Deduction.Reason.ISLAND_BUBBLE
+const ISLAND_BUFFER: Deduction.Reason = Deduction.Reason.ISLAND_BUFFER
+const ISLAND_CHAIN: Deduction.Reason = Deduction.Reason.ISLAND_CHAIN
+const ISLAND_CHOKEPOINT: Deduction.Reason = Deduction.Reason.ISLAND_CHOKEPOINT
+const ISLAND_CONNECTOR: Deduction.Reason = Deduction.Reason.ISLAND_CONNECTOR
+const ISLAND_DIVIDER: Deduction.Reason = Deduction.Reason.ISLAND_DIVIDER
+const ISLAND_EXPANSION: Deduction.Reason = Deduction.Reason.ISLAND_EXPANSION
+const ISLAND_MOAT: Deduction.Reason = Deduction.Reason.ISLAND_MOAT
+const ISLAND_SNUG: Deduction.Reason = Deduction.Reason.ISLAND_SNUG
+const POOL_CHOKEPOINT: Deduction.Reason = Deduction.Reason.POOL_CHOKEPOINT
+const POOL_TRIPLET: Deduction.Reason = Deduction.Reason.POOL_TRIPLET
+const UNCLUED_LIFELINE: Deduction.Reason = Deduction.Reason.UNCLUED_LIFELINE
+const UNREACHABLE_CELL: Deduction.Reason = Deduction.Reason.UNREACHABLE_CELL
+const WALL_BUBBLE: Deduction.Reason = Deduction.Reason.WALL_BUBBLE
+const WALL_CONNECTOR: Deduction.Reason = Deduction.Reason.WALL_CONNECTOR
+const WALL_EXPANSION: Deduction.Reason = Deduction.Reason.WALL_EXPANSION
+const WALL_WEAVER: Deduction.Reason = Deduction.Reason.WALL_WEAVER
+
+## advanced techniques
+const ASSUMPTION: Deduction.Reason = Deduction.Reason.ASSUMPTION
+const BORDER_HUG: Deduction.Reason = Deduction.Reason.BORDER_HUG
+const ISLAND_BATTLEGROUND: Deduction.Reason = Deduction.Reason.ISLAND_BATTLEGROUND
+const ISLAND_RELEASE: Deduction.Reason = Deduction.Reason.ISLAND_RELEASE
+const ISLAND_STRANGLE: Deduction.Reason = Deduction.Reason.ISLAND_STRANGLE
+const WALL_STRANGLE: Deduction.Reason = Deduction.Reason.WALL_STRANGLE
+
+const FUN_TRIVIAL: Deduction.FunAxis = Deduction.FunAxis.FUN_TRIVIAL
+const FUN_FAST: Deduction.FunAxis = Deduction.FunAxis.FUN_FAST
+const FUN_NOVELTY: Deduction.FunAxis = Deduction.FunAxis.FUN_NOVELTY
+const FUN_THINK: Deduction.FunAxis = Deduction.FunAxis.FUN_THINK
+const FUN_BIFURCATE: Deduction.FunAxis = Deduction.FunAxis.FUN_BIFURCATE
+
+
+class IslandMoatScanner extends NaiveScanner:
+	var next_island_index: int = 0
+	
+	func update(start_time: int) -> bool:
+		while next_island_index < scanner_board.islands.size():
+			if out_of_time(start_time):
+				break
+			_check_island(scanner_board.islands[next_island_index])
+			next_island_index += 1
+		return next_island_index >= scanner_board.islands.size()
+	
+	
+	func _check_island(island: CellGroup) -> void:
+		if island.clue != island.size():
+			return
+		
+		for liberty: Vector2i in island.liberties:
+			if not should_deduce(liberty):
+				continue
+			var reason: Deduction.Reason = ISLAND_OF_ONE if island.clue == 1 else ISLAND_MOAT
+			monster.add_pending_deduction(liberty, CELL_WALL, reason)
+
+
+class AdjacentIslandScanner extends NaiveScanner:
+	var next_island_index: int = 0
+	var all_liberties: Dictionary[Vector2i, bool] = {}
+	
+	func update(start_time: int) -> bool:
+		while next_island_index < scanner_board.islands.size():
+			if out_of_time(start_time):
+				break
+			_check_island(scanner_board.islands[next_island_index])
+			next_island_index += 1
+		return next_island_index >= scanner_board.islands.size()
+	
+	
+	func _check_island(island: CellGroup) -> void:
+		for liberty: Vector2i in island.liberties:
+			if not all_liberties.has(liberty):
+				all_liberties[liberty] = true
+				continue
+			
+			var neighbor_clue_count: int = 0
+			for neighbor_dir: Vector2i in NEIGHBOR_DIRS:
+				var neighbor: Vector2i = liberty + neighbor_dir
+				if scanner_board.clues.has(neighbor):
+					neighbor_clue_count += 1
+			var reason: Deduction.Reason = ISLAND_DIVIDER if neighbor_clue_count <= 1 else ADJACENT_CLUES
+			monster.add_pending_deduction(liberty, CELL_WALL, reason)

--- a/project/src/main/monster/sim/naive_scanners.gd.uid
+++ b/project/src/main/monster/sim/naive_scanners.gd.uid
@@ -1,0 +1,1 @@
+uid://cs2tpm2qb8boa

--- a/project/src/main/monster/sim/scanner_board.gd
+++ b/project/src/main/monster/sim/scanner_board.gd
@@ -1,0 +1,96 @@
+class_name ScannerBoard
+## Time-budgeted board topology model for NaiveSolver scanners.[br]
+## [br]
+## Builds island groups, wall groups and liberty data incrementally across frames to avoid performance spikes when
+## multiple AI agents solve puzzles simultaneously.
+
+const CELL_INVALID: int = NurikabeUtils.CELL_INVALID
+const CELL_ISLAND: int = NurikabeUtils.CELL_ISLAND
+const CELL_WALL: int = NurikabeUtils.CELL_WALL
+const CELL_EMPTY: int = NurikabeUtils.CELL_EMPTY
+
+const NEIGHBOR_DIRS: Array[Vector2i] = NurikabeUtils.NEIGHBOR_DIRS
+
+var groups_by_cell: Dictionary[Vector2i, CellGroup] = {}
+var islands: Array[CellGroup] = []
+var walls: Array[CellGroup] = []
+var cells: Dictionary[Vector2i, int] = {}
+var clues: Dictionary[Vector2i, int] = {}
+
+var _monster: SimMonster
+var _cell_list: Array[Vector2i]
+var _next_cell_index: int = 0
+
+func _init(init_monster: SimMonster) -> void:
+	_monster = init_monster
+	
+	var board_cells: Dictionary[Vector2i, int] = _monster.game_board.get_cells()
+	for cell: Vector2i in board_cells:
+		var cell_value: int = board_cells[cell]
+		if NurikabeUtils.is_clue(cell_value):
+			clues[cell] = cell_value
+			cells[cell] = CELL_ISLAND
+		else:
+			cells[cell] = cell_value
+	
+	_cell_list = cells.keys()
+
+
+func prepare(start_time: int) -> void:
+	while _next_cell_index < _cell_list.size():
+		_build_group(_cell_list[_next_cell_index])
+		_next_cell_index += 1
+		if Time.get_ticks_usec() - start_time > NaiveSolver.BUDGET_USEC:
+			break
+
+
+func is_prepared() -> bool:
+	return _next_cell_index >= _cell_list.size()
+
+
+func _build_group(start_cell: Vector2i) -> void:
+	if cells[start_cell] == CELL_EMPTY:
+		return
+	if groups_by_cell.has(start_cell):
+		return
+	
+	# bfs to other matching cells
+	var visited: Dictionary[Vector2i, bool] = {start_cell: true}
+	var queue: Array[Vector2i] = [start_cell]
+	var current_index: int = 0
+	var group: CellGroup = CellGroup.new()
+	group.cells.append(start_cell)
+	while current_index < queue.size():
+		var next_cell: Vector2i = queue[current_index]
+		for neighbor_dir: Vector2i in NEIGHBOR_DIRS:
+			var neighbor: Vector2i = next_cell + neighbor_dir
+			if visited.has(neighbor):
+				continue
+			visited[neighbor] = true
+			var neighbor_value: int = cells.get(neighbor, CELL_INVALID)
+			if neighbor_value == CELL_INVALID:
+				continue
+			if neighbor_value == CELL_EMPTY:
+				group.liberties.append(neighbor)
+			elif neighbor_value == cells[next_cell]:
+				group.cells.append(neighbor)
+				queue.append(neighbor)
+		current_index += 1
+	
+	# assign island clue value
+	if cells.get(start_cell) == CELL_ISLAND:
+		for cell: Vector2i in group.cells:
+			if not clues.has(cell):
+				continue
+			if group.clue > 0:
+				group.clue = -1
+				break
+			group.clue = clues[cell]
+	
+	# populate groups_by_cell, walls, islands
+	for cell: Vector2i in group.cells:
+		groups_by_cell[cell] = group
+	if cells.get(start_cell) == CELL_WALL:
+		walls.append(group)
+	if cells.get(start_cell) == CELL_ISLAND:
+		islands.append(group)

--- a/project/src/main/monster/sim/scanner_board.gd.uid
+++ b/project/src/main/monster/sim/scanner_board.gd.uid
@@ -1,0 +1,1 @@
+uid://dgvgrq82dylxf

--- a/project/src/main/monster/sim/work_on_puzzle_action.gd
+++ b/project/src/main/monster/sim/work_on_puzzle_action.gd
@@ -1,7 +1,7 @@
 class_name WorkOnPuzzleAction
 extends GoapAction
 
-const SOLVER_COOLDOWN: float = 10.0
+const SOLVER_COOLDOWN: float = 3.0
 
 const CELL_INVALID: int = NurikabeUtils.CELL_INVALID
 const CELL_ISLAND: int = NurikabeUtils.CELL_ISLAND


### PR DESCRIPTION
Created SolverBoard to avoid duplicate logic between NaiveScanners. Lots of scanners were going to need stuff like "how many liberties does this island have" and "what is this island's clue."

Extracted NaiveScanners from NaiveSolver, as an archive of all the scanners. We'll probably have about 10 of these, so it makes sense to avoid cluttering up NaiveSolver with them.

Reduced SolverCooldown to 3.0s. Now that the AI can "do more stuff", it's a little strange when it pauses for such a long time.