### PR TITLE
Added lifeline buffer deductions.

### DIFF
--- a/project/src/main/monster/sim/naive_scanners.gd
+++ b/project/src/main/monster/sim/naive_scanners.gd
@@ -27,6 +27,7 @@ const ISLAND_SNUG: Deduction.Reason = Deduction.Reason.ISLAND_SNUG
 const POOL_CHOKEPOINT: Deduction.Reason = Deduction.Reason.POOL_CHOKEPOINT
 const POOL_TRIPLET: Deduction.Reason = Deduction.Reason.POOL_TRIPLET
 const UNCLUED_LIFELINE: Deduction.Reason = Deduction.Reason.UNCLUED_LIFELINE
+const UNCLUED_LIFELINE_BUFFER: Deduction.Reason = Deduction.Reason.UNCLUED_LIFELINE_BUFFER
 const UNREACHABLE_CELL: Deduction.Reason = Deduction.Reason.UNREACHABLE_CELL
 const WALL_BUBBLE: Deduction.Reason = Deduction.Reason.WALL_BUBBLE
 const WALL_CONNECTOR: Deduction.Reason = Deduction.Reason.WALL_CONNECTOR

--- a/project/src/main/nurikabe/solver/deduction.gd
+++ b/project/src/main/nurikabe/solver/deduction.gd
@@ -31,6 +31,7 @@ enum Reason {
 	POOL_CHOKEPOINT, # add an island to avoid isolating or trapping a small wall region
 	POOL_TRIPLET, # add an island to avoid a 2x2 wall area
 	UNCLUED_LIFELINE, # extend an unclued island towards the only connectable clue
+	UNCLUED_LIFELINE_BUFFER, # add a wall to prevent an unclued island from becoming unreachable
 	UNREACHABLE_CELL, # add a wall where no clue can reach
 	WALL_BUBBLE, # wall in a cell surrounded by walls
 	WALL_CONNECTOR, # connect two walls through a chokepoint

--- a/project/src/main/nurikabe/solver/island_reachability_map.gd
+++ b/project/src/main/nurikabe/solver/island_reachability_map.gd
@@ -45,6 +45,24 @@ func get_clue_reachability(cell: Vector2i) -> ClueReachability:
 	return reachability
 
 
+func has_exclusive_root(cell: Vector2i) -> int:
+	return _reach_scores_by_cell.has(cell) \
+			and _reach_scores_by_cell[cell].size() == 1 \
+			and _reach_scores_by_cell[cell].values().front() >= 1
+
+
+func get_exclusive_root(cell: Vector2i) -> Vector2i:
+	return _reach_scores_by_cell[cell].keys().front()
+
+
+func get_reach_score(cell: Vector2i, root: Vector2i) -> int:
+	if not _reach_scores_by_cell.has(cell):
+		return 0
+	if not _reach_scores_by_cell[cell].has(root):
+		return 0
+	return _reach_scores_by_cell[cell][root]
+
+
 func get_nearest_clued_island_cell(cell: Vector2i) -> Vector2i:
 	if not _reach_scores_by_cell.has(cell) or _reach_scores_by_cell[cell].is_empty():
 		return POS_NOT_FOUND
@@ -117,7 +135,8 @@ func _build() -> void:
 					if _reach_scores_by_cell[neighbor].get(root, 0) >= reach_score - 1:
 						# can already reach island
 						continue
-				if board.get_island_chain_map().causes_chain_conflict(board.get_island_for_cell(root), neighbor):
+				if board.get_cell(neighbor) == CELL_EMPTY \
+						and board.get_island_chain_map().causes_chain_conflict(board.get_island_for_cell(root), neighbor):
 					_cycles_by_cell[neighbor] = true
 					continue
 				

--- a/project/src/test/nurikabe/solver/test_island_reachability_map.gd
+++ b/project/src/test/nurikabe/solver/test_island_reachability_map.gd
@@ -8,13 +8,13 @@ func test_get_clue_reachability() -> void:
 		"      ##",
 		" 2   2  ",
 	]
-	var trm: IslandReachabilityMap = init_island_reachability_map()
-	assert_eq(trm.get_clue_reachability(Vector2(0, 0)), IslandReachabilityMap.ClueReachability.UNREACHABLE)
-	assert_eq(trm.get_clue_reachability(Vector2(0, 2)), IslandReachabilityMap.ClueReachability.IMPOSSIBLE)
-	assert_eq(trm.get_clue_reachability(Vector2(0, 1)), IslandReachabilityMap.ClueReachability.REACHABLE)
-	assert_eq(trm.get_clue_reachability(Vector2(1, 2)), IslandReachabilityMap.ClueReachability.CONFLICT)
-	assert_eq(trm.get_clue_reachability(Vector2(2, 0)), IslandReachabilityMap.ClueReachability.IMPOSSIBLE)
-	assert_eq(trm.get_clue_reachability(Vector2(3, 0)), IslandReachabilityMap.ClueReachability.IMPOSSIBLE)
+	var irm: IslandReachabilityMap = init_island_reachability_map()
+	assert_eq(irm.get_clue_reachability(Vector2(0, 0)), IslandReachabilityMap.ClueReachability.UNREACHABLE)
+	assert_eq(irm.get_clue_reachability(Vector2(0, 2)), IslandReachabilityMap.ClueReachability.IMPOSSIBLE)
+	assert_eq(irm.get_clue_reachability(Vector2(0, 1)), IslandReachabilityMap.ClueReachability.REACHABLE)
+	assert_eq(irm.get_clue_reachability(Vector2(1, 2)), IslandReachabilityMap.ClueReachability.CONFLICT)
+	assert_eq(irm.get_clue_reachability(Vector2(2, 0)), IslandReachabilityMap.ClueReachability.IMPOSSIBLE)
+	assert_eq(irm.get_clue_reachability(Vector2(3, 0)), IslandReachabilityMap.ClueReachability.IMPOSSIBLE)
 
 
 func test_get_clue_reachability_avoids_cycles() -> void:
@@ -23,9 +23,9 @@ func test_get_clue_reachability_avoids_cycles() -> void:
 		" 2      ",
 		"        ",
 	]
-	var trm: IslandReachabilityMap = init_island_reachability_map()
-	assert_eq(trm.get_clue_reachability(Vector2(1, 0)), IslandReachabilityMap.ClueReachability.CHAIN_CYCLE)
-	assert_eq(trm.get_clue_reachability(Vector2(1, 2)), IslandReachabilityMap.ClueReachability.CHAIN_CYCLE)
+	var irm: IslandReachabilityMap = init_island_reachability_map()
+	assert_eq(irm.get_clue_reachability(Vector2(1, 0)), IslandReachabilityMap.ClueReachability.CHAIN_CYCLE)
+	assert_eq(irm.get_clue_reachability(Vector2(1, 2)), IslandReachabilityMap.ClueReachability.CHAIN_CYCLE)
 
 
 func test_get_clue_reachability_cycles_janko_3() -> void:
@@ -41,8 +41,31 @@ func test_get_clue_reachability_cycles_janko_3() -> void:
 		"        ########## .",
 		" 3      ## 3 . .## .",
 	]
-	var trm: IslandReachabilityMap = init_island_reachability_map()
-	assert_eq(trm.get_clue_reachability(Vector2(5, 1)), IslandReachabilityMap.ClueReachability.REACHABLE)
+	var irm: IslandReachabilityMap = init_island_reachability_map()
+	assert_eq(irm.get_clue_reachability(Vector2(5, 1)), IslandReachabilityMap.ClueReachability.REACHABLE)
+
+
+func test_get_clue_reachability_janko_8() -> void:
+	# janko 8
+	grid = [
+		"   2    ## 4 . . .##",
+		"          ##########",
+		"        ## . .## 1##",
+		"        ## 3###### 3",
+		"         9#### .## .",
+		"##         .## 2## .",
+		"## .       . .######",
+		"## 6## 6    #### 1##",
+		" 3####    ## 2 .## 2",
+		" . .##    ######## .",
+	]
+	var irm: IslandReachabilityMap = init_island_reachability_map()
+	assert_eq(irm.get_reach_score(Vector2(5, 5), irm.board.get_island_for_cell(Vector2i(4, 4)).root), 7)
+	assert_eq(irm.get_reach_score(Vector2(5, 6), irm.board.get_island_for_cell(Vector2i(4, 4)).root), 6)
+	assert_eq(irm.get_reach_score(Vector2(6, 6), irm.board.get_island_for_cell(Vector2i(4, 4)).root), 5)
+	assert_eq(irm.get_reach_score(Vector2(5, 5), irm.board.get_island_for_cell(Vector2i(3, 7)).root), 2)
+	assert_eq(irm.get_reach_score(Vector2(5, 6), irm.board.get_island_for_cell(Vector2i(3, 7)).root), 3)
+	assert_eq(irm.get_reach_score(Vector2(6, 6), irm.board.get_island_for_cell(Vector2i(3, 7)).root), 2)
 
 
 func test_get_clue_reachability_unclued_cycles() -> void:
@@ -51,10 +74,10 @@ func test_get_clue_reachability_unclued_cycles() -> void:
 		" 2      ",
 		"     .  ",
 	]
-	var trm: IslandReachabilityMap = init_island_reachability_map()
-	assert_eq(trm.get_clue_reachability(Vector2(2, 1)), IslandReachabilityMap.ClueReachability.REACHABLE)
-	assert_eq(trm.get_clue_reachability(Vector2(3, 1)), IslandReachabilityMap.ClueReachability.REACHABLE)
-	assert_eq(trm.get_clue_reachability(Vector2(3, 2)), IslandReachabilityMap.ClueReachability.REACHABLE)
+	var irm: IslandReachabilityMap = init_island_reachability_map()
+	assert_eq(irm.get_clue_reachability(Vector2(2, 1)), IslandReachabilityMap.ClueReachability.REACHABLE)
+	assert_eq(irm.get_clue_reachability(Vector2(3, 1)), IslandReachabilityMap.ClueReachability.REACHABLE)
+	assert_eq(irm.get_clue_reachability(Vector2(3, 2)), IslandReachabilityMap.ClueReachability.REACHABLE)
 
 
 func test_get_nearest_clued_island_cell() -> void:

--- a/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
@@ -137,7 +137,7 @@ func test_deduce_all_islands_snug() -> void:
 	assert_deductions(solver.deduce_all_clued_island_snugs, expected)
 
 
-func test_deduce_all_island_chokepoints_lifeline() -> void:
+func test_deduce_unclued_lifeline() -> void:
 	grid = [
 		"    ####",
 		" 2  ## .",
@@ -147,13 +147,15 @@ func test_deduce_all_island_chokepoints_lifeline() -> void:
 		"       5",
 	]
 	var expected: Array[String] = [
+		"(2, 4)->## unclued_lifeline_buffer (3, 5)",
+		"(2, 5)->## unclued_lifeline_buffer (3, 5)",
 		"(3, 3)->. unclued_lifeline (3, 5)",
 		"(3, 4)->. unclued_lifeline (3, 5)",
 	]
 	assert_deductions(solver.deduce_unclued_lifeline, expected)
 
 
-func test_deduce_all_island_chokepoints_lifeline_2() -> void:
+func test_deduce_unclued_lifeline_2() -> void:
 	grid = [
 		"    ####",
 		" 2  ## .",
@@ -164,13 +166,16 @@ func test_deduce_all_island_chokepoints_lifeline_2() -> void:
 		"     7 .",
 	]
 	var expected: Array[String] = [
+		"(1, 6)->## unclued_lifeline_buffer (3, 5)",
+		"(2, 4)->## unclued_lifeline_buffer (3, 5)",
+		"(2, 5)->## unclued_lifeline_buffer (3, 5)",
 		"(3, 3)->. unclued_lifeline (3, 5)",
 		"(3, 4)->. unclued_lifeline (3, 5)",
 	]
 	assert_deductions(solver.deduce_unclued_lifeline, expected)
 
 
-func test_deduce_all_island_chokepoints_lifeline_3() -> void:
+func test_deduce_unclued_lifeline_3() -> void:
 	grid = [
 		"  ##  ",
 		"   .  ",
@@ -182,16 +187,28 @@ func test_deduce_all_island_chokepoints_lifeline_3() -> void:
 		"   7  ",
 	]
 	var expected: Array[String] = [
+		"(0, 2)->## unclued_lifeline_buffer (1, 7)",
+		"(0, 3)->## unclued_lifeline_buffer (1, 7)",
+		"(0, 4)->## unclued_lifeline_buffer (1, 7)",
+		"(0, 5)->## unclued_lifeline_buffer (1, 7)",
+		"(0, 6)->## unclued_lifeline_buffer (1, 7)",
+		"(0, 7)->## unclued_lifeline_buffer (1, 7)",
 		"(1, 2)->. unclued_lifeline (1, 7)",
 		"(1, 3)->. unclued_lifeline (1, 7)",
 		"(1, 4)->. unclued_lifeline (1, 7)",
 		"(1, 5)->. unclued_lifeline (1, 7)",
 		"(1, 6)->. unclued_lifeline (1, 7)",
+		"(2, 2)->## unclued_lifeline_buffer (1, 7)",
+		"(2, 3)->## unclued_lifeline_buffer (1, 7)",
+		"(2, 4)->## unclued_lifeline_buffer (1, 7)",
+		"(2, 5)->## unclued_lifeline_buffer (1, 7)",
+		"(2, 6)->## unclued_lifeline_buffer (1, 7)",
+		"(2, 7)->## unclued_lifeline_buffer (1, 7)",
 	]
 	assert_deductions(solver.deduce_unclued_lifeline, expected)
 
 
-func test_deduce_all_island_chokepoints_lifeline_4() -> void:
+func test_deduce_unclued_lifeline_4() -> void:
 	grid = [
 		"  ##  ",
 		"   .  ",
@@ -212,7 +229,7 @@ func test_deduce_all_island_chokepoints_lifeline_4() -> void:
 	assert_deductions(solver.deduce_unclued_lifeline, expected)
 
 
-func test_deduce_all_island_chokepoints_lifeline_5() -> void:
+func test_deduce_unclued_lifeline_5() -> void:
 	grid = [
 		"############",
 		"## .## 6    ",
@@ -223,13 +240,14 @@ func test_deduce_all_island_chokepoints_lifeline_5() -> void:
 		" . 6 . .## .",
 	]
 	var expected: Array[String] = [
+		"(2, 3)->## unclued_lifeline_buffer (2, 4)",
 		"(3, 4)->. unclued_lifeline (2, 4)",
 		"(4, 4)->. unclued_lifeline (2, 4)",
 	]
 	assert_deductions(solver.deduce_unclued_lifeline, expected)
 
 
-func test_deduce_all_island_chokepoints_lifeline_6() -> void:
+func test_deduce_unclued_lifeline_6() -> void:
 	grid = [
 		"####     4",
 		"## .      ",
@@ -239,13 +257,65 @@ func test_deduce_all_island_chokepoints_lifeline_6() -> void:
 		" 2 .  ## .",
 	]
 	var expected: Array[String] = [
+		"(2, 1)->## unclued_lifeline_buffer (1, 1)",
+		"(2, 2)->## unclued_lifeline_buffer (1, 1)",
 		"(2, 3)->. unclued_lifeline (1, 1)",
 		"(3, 3)->. unclued_lifeline (1, 1)",
 	]
 	assert_deductions(solver.deduce_unclued_lifeline, expected)
 
 
-func test_deduce_all_island_chokepoints_lifeline_invalid_too_short() -> void:
+func test_deduce_unclued_lifeline_7() -> void:
+	grid = [
+		"########",
+		"     .##",
+		"   3  ##",
+	]
+	var expected: Array[String] = [
+		"(0, 1)->## unclued_lifeline_buffer (1, 2)",
+		"(0, 2)->## unclued_lifeline_buffer (1, 2)",
+	]
+	assert_deductions(solver.deduce_unclued_lifeline, expected)
+
+
+func test_deduce_unclued_lifeline_8() -> void:
+	grid = [
+		" 2 .## . . 3######  ",
+		"############ 2 .##  ",
+		"## 2 .## 2 .####   .",
+		"###### 2####        ",
+		"## .## .## .        ",
+		"## .######         .",
+		"## .## .##      ## 7",
+		"## .## .## .## 6    ",
+		"## .## 3## .  ##    ",
+		"## . 7####   . . .10",
+	]
+	var expected: Array[String] = [
+	]
+	assert_deductions(solver.deduce_unclued_lifeline, expected)
+
+
+func test_deduce_unclued_lifeline_9() -> void:
+	# janko 8
+	grid = [
+		"   2    ## 4 . . .##",
+		"          ##########",
+		"        ## . .## 1##",
+		"        ## 3###### 3",
+		"         9#### .## .",
+		"##         .## 2## .",
+		"## .       . .######",
+		"## 6## 6    #### 1##",
+		" 3####    ## 2 .## 2",
+		" . .##    ######## .",
+	]
+	var expected: Array[String] = [
+	]
+	assert_deductions(solver.deduce_unclued_lifeline, expected)
+
+
+func test_deduce_unclued_lifeline_invalid_too_short() -> void:
 	# the unclued lifeline deduction can't apply to clues which are too close; they could swerve
 	grid = [
 		"  ##  ",
@@ -262,7 +332,7 @@ func test_deduce_all_island_chokepoints_lifeline_invalid_too_short() -> void:
 	assert_deductions(solver.deduce_unclued_lifeline, expected)
 
 
-func test_deduce_all_island_chokepoints_lifeline_invalid_bendy() -> void:
+func test_deduce_unclued_lifeline_invalid_bendy() -> void:
 	# the unclued lifeline deduction can't apply to diagonal clues
 	grid = [
 		"    ####",
@@ -274,6 +344,9 @@ func test_deduce_all_island_chokepoints_lifeline_invalid_bendy() -> void:
 		"     5 .",
 	]
 	var expected: Array[String] = [
+		"(0, 5)->## unclued_lifeline_buffer (0, 4)",
+		"(1, 3)->. unclued_lifeline (0, 4)",
+		"(2, 3)->. unclued_lifeline (0, 4)",
 	]
 	assert_deductions(solver.deduce_unclued_lifeline, expected)
 


### PR DESCRIPTION
This is a rather abstract deduction where routing a clued island the wrong way can make an unclued island unreachable.

Rewrote deduce_unclued_lifeline to use island reachability map.