### PR TITLE
Bug: Cursor flickering.

### DIFF
--- a/project/src/main/nurikabe/cursorable_area.gd
+++ b/project/src/main/nurikabe/cursorable_area.gd
@@ -85,9 +85,8 @@ func clear() -> void:
 
 
 func set_cell(cell: Vector2i) -> void:
-	var to_point: Vector2 = (Vector2(cell) + Vector2.ONE) * tile_size
-	if not cursorable_rect.has_point(to_point):
-		cursorable_rect = cursorable_rect.expand(to_point)
+	if not cursorable_rect.has_point((Vector2(cell) + Vector2(0.5, 0.5)) * tile_size):
+		cursorable_rect = cursorable_rect.expand((Vector2(cell) + Vector2(1.0, 1.0)) * tile_size)
 
 
 func _find_game_board() -> NurikabeGameBoard:


### PR DESCRIPTION
Fixed bug where cursor would flicker when clicking cells on the bottom or right edge. This was caused because of the CursorableArea's Area2D changing its dimensions constantly, because it would expand to (2048, 2048) but then (2048, 2048) would still be out of bounds.

CursorableArea now uses the cell's center to determine if it should expand, but expands to the corner.