### PR TITLE
Bug: SimMonster would run past puzzles they wanted to solve.

### DIFF
--- a/project/src/main/monster/monster.gd
+++ b/project/src/main/monster/monster.gd
@@ -64,7 +64,7 @@ var _fade_tween: Tween
 var id: int
 
 var on_steppable: bool = false
-var game_board: NurikabeGameBoard
+var cursor_board: NurikabeGameBoard
 
 @onready var sprite: AnimatedSprite2D = %AnimatedSprite2D
 @onready var fsm: StateMachine = %StateMachine

--- a/project/src/main/monster/player/player_input.gd
+++ b/project/src/main/monster/player/player_input.gd
@@ -11,9 +11,9 @@ var _drag_origin_in_puzzle: Dictionary[int, bool] = {
 func _unhandled_input(event: InputEvent) -> void:
 	# Initialize drag ownership when mouse buttons are pressed
 	if event is InputEventMouseButton and event.pressed:
-		_drag_origin_in_puzzle[event.button_index] = monster.game_board != null
+		_drag_origin_in_puzzle[event.button_index] = monster.cursor_board != null
 	if event is InputEventMouseMotion and not is_any_drag_origin_in_puzzle():
-		%PuzzleHandler.game_board = monster.game_board
+		%PuzzleHandler.game_board = monster.cursor_board
 	
 	# Route all input based on the drag owner
 	monster.cursor.update_position() # ensure cursor position is up to date

--- a/project/src/main/monster/sim/find_puzzle_action.gd
+++ b/project/src/main/monster/sim/find_puzzle_action.gd
@@ -29,7 +29,7 @@ func perform(actor: Variant, _delta: float) -> bool:
 	if target_game_board != null:
 		monster.input.move_to(target_game_board.get_rect().get_center())
 		if dist_to_rect(target_game_board.get_rect(), monster.position) < PUZZLE_APPROACH:
-			monster.game_board = target_game_board
+			monster.solving_board = target_game_board
 			target_game_board = null
 			monster.input.dir = Vector2.ZERO
 			finished = true
@@ -40,12 +40,7 @@ func perform(actor: Variant, _delta: float) -> bool:
 static func dist_to_rect(rect: Rect2, point: Vector2) -> float:
 	var result: float
 	if rect.has_point(point):
-		result = min(
-			abs(point.x - rect.position.x),
-			abs(point.y - rect.position.y),
-			abs(point.x - rect.end.x),
-			abs(point.y - rect.end.y),
-		)
+		result = 0.0
 	else:
 		result = point.clamp(rect.position, rect.end).distance_to(point)
 	return result

--- a/project/src/main/monster/sim/leave_puzzle_action.gd
+++ b/project/src/main/monster/sim/leave_puzzle_action.gd
@@ -3,5 +3,5 @@ extends GoapAction
 
 func perform(actor: Variant, _delta: float) -> bool:
 	var monster: SimMonster = actor
-	monster.game_board = null
+	monster.solving_board = null
 	return false

--- a/project/src/main/monster/sim/scanner_board.gd
+++ b/project/src/main/monster/sim/scanner_board.gd
@@ -24,7 +24,7 @@ var _next_cell_index: int = 0
 func _init(init_monster: SimMonster) -> void:
 	_monster = init_monster
 	
-	var board_cells: Dictionary[Vector2i, int] = _monster.game_board.get_cells()
+	var board_cells: Dictionary[Vector2i, int] = _monster.solving_board.get_cells()
 	for cell: Vector2i in board_cells:
 		var cell_value: int = board_cells[cell]
 		if NurikabeUtils.is_clue(cell_value):

--- a/project/src/main/monster/sim/sim_brain.gd
+++ b/project/src/main/monster/sim/sim_brain.gd
@@ -14,10 +14,10 @@ var _current_action: GoapAction
 func _process(delta: float) -> void:
 	# select action based on current state
 	var new_action: GoapAction = _current_action
-	if _monster.game_board == null:
+	if _monster.solving_board == null:
 		new_action = _find_puzzle_action if _monster.boredom >= 25 else _idle_action
 	else:
-		new_action = _leave_puzzle_action if _monster.game_board.is_finished() else _work_on_puzzle_action
+		new_action = _leave_puzzle_action if _monster.solving_board.is_finished() else _work_on_puzzle_action
 	
 	# handle action transitions
 	if new_action != _current_action:

--- a/project/src/main/monster/sim/sim_input.gd
+++ b/project/src/main/monster/sim/sim_input.gd
@@ -48,7 +48,7 @@ func _process_cursor_command(delta: float) -> void:
 	if cursor_command.delay > 0:
 		return
 	
-	%PuzzleHandler.game_board = monster.game_board
+	%PuzzleHandler.game_board = monster.cursor_board
 	var event: InputEvent
 	if %Cursor.global_position.distance_to(cursor_command.pos) > CURSOR_POS_EPSILON:
 		if %Cursor.global_position.distance_to(cursor_command.pos) > 10:

--- a/project/src/main/monster/sim/sim_monster.gd
+++ b/project/src/main/monster/sim/sim_monster.gd
@@ -6,6 +6,8 @@ const BOREDOM_PER_SECOND: float = 16.66667 # should be lowered to 1.66667 (100 p
 
 @onready var input: SimInput = %Input
 
+var solving_board: NurikabeGameBoard
+
 var boredom: float = 0.0
 var pending_deductions: Dictionary[Vector2i, Deduction] = {}
 
@@ -14,7 +16,7 @@ func update_input(delta: float) -> void:
 
 
 func _process(delta: float) -> void:
-	if game_board == null:
+	if solving_board == null:
 		boredom = clamp(boredom + delta * BOREDOM_PER_SECOND, 0, 100)
 	else:
 		boredom = clamp(boredom - delta * BOREDOM_PER_SECOND, 0, 100)

--- a/project/src/main/monster/sim/work_on_puzzle_action.gd
+++ b/project/src/main/monster/sim/work_on_puzzle_action.gd
@@ -33,7 +33,7 @@ func perform(actor: Variant, delta: float) -> bool:
 	if _next_deduction != null:
 		_process_next_deduction(monster, delta)
 	
-	return monster.game_board.is_finished()
+	return monster.solving_board.is_finished()
 
 
 func exit(actor: Variant) -> void:
@@ -50,7 +50,7 @@ func exit(actor: Variant) -> void:
 func _choose_deduction(monster: SimMonster) -> void:
 	var best_score: float = 0.0
 	for deduction: Deduction in monster.pending_deductions.values():
-		if monster.game_board.get_cell(deduction.pos) != CELL_EMPTY:
+		if monster.solving_board.get_cell(deduction.pos) != CELL_EMPTY:
 			monster.remove_pending_deduction_at(deduction.pos)
 			continue
 		
@@ -65,7 +65,7 @@ func _choose_deduction(monster: SimMonster) -> void:
 func _execute_next_deduction(monster: SimMonster) -> void:
 	if _solver.verbose:
 		print("monster %s deduction: %s" % [monster.id, _next_deduction])
-	var target_pos: Vector2 = monster.game_board.map_to_global(_next_deduction.pos)
+	var target_pos: Vector2 = monster.solving_board.map_to_global(_next_deduction.pos)
 	match _next_deduction.value:
 		CELL_WALL:
 			monster.input.queue_cursor_command(SimInput.LMB_PRESS, target_pos)
@@ -76,7 +76,7 @@ func _execute_next_deduction(monster: SimMonster) -> void:
 
 
 func _process_next_deduction(monster: SimMonster, delta: float) -> void:
-	if monster.game_board.get_cell(_next_deduction.pos) == _next_deduction.value:
+	if monster.solving_board.get_cell(_next_deduction.pos) == _next_deduction.value:
 		_next_deduction = null
 		return
 
@@ -90,13 +90,13 @@ func _score_deduction(monster: SimMonster, deduction: Deduction) -> float:
 	# some deductions score negative; these represent deductions which are too close to the player cursor
 	var score: float = 0.0
 	
-	var deduction_global_pos: Vector2 = monster.game_board.map_to_global(deduction.pos)
+	var deduction_global_pos: Vector2 = monster.solving_board.map_to_global(deduction.pos)
 	var cursor_dist: float = monster.cursor.global_position.distance_to(deduction_global_pos)
 	score += 10.0 * _score_distance(cursor_dist, 300)
 	for other_monster: Monster in get_tree().get_nodes_in_group("monsters"):
 		if other_monster == monster:
 			continue
-		if other_monster.game_board != monster.game_board:
+		if other_monster.cursor_board != monster.cursor_board:
 			continue
 		var other_cursor_dist: float = other_monster.cursor.global_position.distance_to(deduction_global_pos)
 		score -= 20.0 * _score_distance(other_cursor_dist, 150)

--- a/project/src/main/nurikabe/cursorable_area.gd
+++ b/project/src/main/nurikabe/cursorable_area.gd
@@ -46,7 +46,7 @@ func add_cursor(area: Area2D) -> void:
 	
 	var monster: Monster = _find_monster_for_cursor(area)
 	if monster:
-		monster.game_board = _find_game_board()
+		monster.cursor_board = _find_game_board()
 
 
 func remove_cursor(area: Area2D) -> void:
@@ -55,8 +55,8 @@ func remove_cursor(area: Area2D) -> void:
 	cursor.queue_free()
 	
 	var monster: Monster = _find_monster_for_cursor(area)
-	if monster and monster.game_board == _find_game_board():
-		monster.game_board = null
+	if monster and monster.cursor_board == _find_game_board():
+		monster.cursor_board = null
 
 
 func update_cursor(area: Area2D) -> void:


### PR DESCRIPTION
While our game logic used "Monster.game_board" as the board the cursor was over, SimMonster was repurposing it as the board they wanted to solve.

Occasionally, these would conflict -- such as when they ran to a new puzzle, but their cursor passed over another puzzle on the way.

We now define 'Monster.cursor_board' and 'SimMonster.solving_board' to disambiguate this.

Fixed bug where SimMonster would never solve a puzzle if they were already in bounds, because 'dist_rect' would return a large number, but running to the center would never cause the distance to decrease.