### PR TITLE
More monsters (1->3), more puzzles (7->15).

### DIFF
--- a/project/src/main/nurikabe/nurikabe_game_screen.tscn
+++ b/project/src/main/nurikabe/nurikabe_game_screen.tscn
@@ -25,6 +25,8 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("1_nc88o")
+target_sim_count = 3
+target_puzzle_count = 15
 
 [node name="GameBoards" type="Control" parent="." unique_id=199475706]
 unique_name_in_owner = true


### PR DESCRIPTION
Fixed deadlock in monster politeness algorithm; sometimes if 3 or more monsters all worked on a puzzle they could decide every deduction was too close to someone else. They now decide "oh that deduction is closer to someone else", but the ratio of what counts as "closer to someone else" decays over time so they don't softlock.