### PR TITLE
Puzzle size preference. Stat overrides. Find target cooldown.

### DIFF
--- a/project/assets/test/monster/monster_611.txt
+++ b/project/assets/test/monster/monster_611.txt
@@ -9,3 +9,6 @@ skin yellow
 [archetypes]
 rat 9
 pig 1
+
+[stats]
+puzzle.pickiness 0

--- a/project/src/main/monster/monster_saver.gd
+++ b/project/src/main/monster/monster_saver.gd
@@ -27,6 +27,8 @@ func load_sim_profile(filename: String) -> SimProfile:
 				_parse_metadata_line(line, profile)
 			"archetypes":
 				_parse_archetypes_line(line, profile)
+			"stats":
+				_parse_stats_line(line, profile)
 	
 	profile.apply_archetypes()
 	return profile
@@ -55,3 +57,9 @@ func _parse_archetypes_line(line: String, profile: SimProfile) -> void:
 			profile.archetypes[key] = float(value)
 		_:
 			push_warning("Unknown archetypes key: %s" % [key])
+
+
+func _parse_stats_line(line: String, profile: SimProfile) -> void:
+	var key: String = StringUtils.substring_before(line, " ")
+	var value: String = StringUtils.substring_after(line, " ")
+	profile.behavior.stats[key] = float(value)

--- a/project/src/main/monster/sim/find_puzzle_action.gd
+++ b/project/src/main/monster/sim/find_puzzle_action.gd
@@ -1,35 +1,37 @@
 class_name FindPuzzleAction
 extends GoapAction
 
+const FIND_TARGET_COOLDOWN: float = 3.0
 const PUZZLE_APPROACH: float = 80.0
 
 var target_game_board: NurikabeGameBoard
+var find_target_cooldown_remaining: float = 0.0
 
 @onready var monster: SimMonster = Utils.find_parent_of_type(self, SimMonster)
+
+func enter() -> void:
+	find_target_cooldown_remaining = randf_range(0, FIND_TARGET_COOLDOWN)
+
 
 func exit() -> void:
 	target_game_board = null
 
 
-func perform(_delta: float) -> bool:
+func perform(delta: float) -> bool:
 	var finished: bool = false
 	
+	if find_target_cooldown_remaining > 0:
+		find_target_cooldown_remaining -= delta
+	
 	# find the nearest game board
-	if target_game_board == null:
-		var game_boards: Array[Node] = get_tree().get_nodes_in_group("game_boards")
-		game_boards = game_boards.filter(func(a: Node) -> bool:
-			return not a.is_finished() and a.error_cells.is_empty())
-		if game_boards:
-			game_boards.sort_custom(func(a: Node, b: Node) -> bool:
-				return a.get_rect().get_center().distance_to(monster.position) \
-						< b.get_rect().get_center().distance_to(monster.position)
-				)
-			target_game_board = game_boards[0]
+	if target_game_board == null and find_target_cooldown_remaining <= 0:
+		find_target_cooldown_remaining = FIND_TARGET_COOLDOWN
+		_find_target()
 	
 	# move towards the nearest game board; if we're close enough, assign it
 	if target_game_board != null:
 		monster.input.move_to(target_game_board.get_rect().get_center())
-		if dist_to_rect(target_game_board.get_rect(), monster.position) < PUZZLE_APPROACH:
+		if _dist_to_rect(target_game_board.get_rect(), monster.position) < PUZZLE_APPROACH:
 			monster.solving_board = target_game_board
 			target_game_board = null
 			monster.input.dir = Vector2.ZERO
@@ -38,7 +40,62 @@ func perform(_delta: float) -> bool:
 	return finished
 
 
-static func dist_to_rect(rect: Rect2, point: Vector2) -> float:
+## Sims choose the puzzle which best fits their preferences.[br]
+## [br]
+## If sims are picky, they'll travel far to find a puzzle they like. If they're not picky, they'll pick the closest
+## puzzle.
+func _find_target() -> void:
+	# find all the game boards
+	var game_boards: Array[Node] = get_tree().get_nodes_in_group("game_boards")
+	game_boards = game_boards.filter(func(a: Node) -> bool:
+		return not a.is_finished() and a.error_cells.is_empty())
+	
+	# calculate a match score for each candidate
+	var wrapped_candidates: Array[Dictionary] = []
+	var distance_weight: float = 5.0
+	
+	var desired_difficulty: float = monster.behavior.lerp_stat(
+			SimBehavior.PUZZLE_DIFFICULTY_PREFERENCE, 0, 12.0, 4.0)
+	var difficulty_weight: float = monster.behavior.lerp_stat(
+			SimBehavior.PUZZLE_PICKINESS, 0, 20, 5)
+	
+	var desired_size: float = monster.behavior.lerp_stat(
+			SimBehavior.PUZZLE_SIZE_PREFERENCE, 40.0, 600.0, 150.0)
+	var size_weight: float = monster.behavior.lerp_stat(
+			SimBehavior.PUZZLE_PICKINESS, 0, 20, 5)
+	
+	for game_board: NurikabeGameBoard in game_boards:
+		var candidate: Dictionary[String, Variant] = {}
+		candidate["board"] = game_board
+		candidate["score"] = 0.0
+		
+		var distance: float = game_board.get_rect().get_center().distance_to(monster.position)
+		distance += randf_range(0, 500)
+		var distance_match: float = _calculate_match_factor(distance, 1000.0)
+		candidate["score"] += distance_match * distance_weight
+		
+		var difficulty: float = clamp(game_board.info.difficulty, 0, 12.0)
+		var difficulty_match: float = _calculate_match_factor(desired_difficulty - difficulty, 3.0)
+		candidate["score"] += difficulty_match * difficulty_weight
+		
+		var size: float = clamp(game_board.info.size.x * game_board.info.size.y, 40.0, 600.0)
+		var size_match: float = _calculate_match_factor(desired_size - size, desired_size * 0.5)
+		candidate["score"] += size_match * size_weight
+		
+		wrapped_candidates.append(candidate)
+	
+	# assign the game board with the highest match score
+	if wrapped_candidates:
+		wrapped_candidates.sort_custom(func(a: Dictionary[String, Variant], b: Dictionary[String, Variant]) -> bool:
+			return a["score"] > b["score"])
+		target_game_board = wrapped_candidates[0]["board"]
+
+
+static func _calculate_match_factor(distance: float, tolerance: float) -> float:
+	return exp((-distance * distance) / (2.0 * tolerance * tolerance))
+
+
+static func _dist_to_rect(rect: Rect2, point: Vector2) -> float:
 	var result: float
 	if rect.has_point(point):
 		result = 0.0

--- a/project/src/main/monster/sim/sim_behavior.gd
+++ b/project/src/main/monster/sim/sim_behavior.gd
@@ -1,20 +1,38 @@
 class_name SimBehavior
 
+## solving a puzzle
 const PUZZLE_CURSOR_SPEED: String = "puzzle.cursor_speed"
 const PUZZLE_THINK_SPEED: String = "puzzle.think_speed"
+
+## choosing a puzzle
+const PUZZLE_SIZE_PREFERENCE: String = "puzzle.size_preference"
+const PUZZLE_DIFFICULTY_PREFERENCE: String = "puzzle.difficulty_preference"
+const PUZZLE_PICKINESS: String = "puzzle.pickiness"
 
 const STATS_BY_ARCHETYPE: Dictionary[String, Dictionary] = {
 	"neutral": {
 		PUZZLE_CURSOR_SPEED: 5,
 		PUZZLE_THINK_SPEED: 5,
+		
+		PUZZLE_DIFFICULTY_PREFERENCE: 5,
+		PUZZLE_SIZE_PREFERENCE: 5,
+		PUZZLE_PICKINESS: 5,
 	},
 	"rat": {
 		PUZZLE_CURSOR_SPEED: 8,
 		PUZZLE_THINK_SPEED: 8,
+		
+		PUZZLE_DIFFICULTY_PREFERENCE: 8,
+		PUZZLE_SIZE_PREFERENCE: 7,
+		PUZZLE_PICKINESS: 6,
 	},
 	"pig": {
 		PUZZLE_CURSOR_SPEED: 2,
 		PUZZLE_THINK_SPEED: 2,
+		
+		PUZZLE_DIFFICULTY_PREFERENCE: 2,
+		PUZZLE_SIZE_PREFERENCE: 3,
+		PUZZLE_PICKINESS: 8,
 	},
 }
 

--- a/project/src/test/monster/test_monster_saver.gd
+++ b/project/src/test/monster/test_monster_saver.gd
@@ -17,6 +17,7 @@ func test_load_sim_behavior() -> void:
 	
 	assert_almost_eq(profile.behavior.get_stat("puzzle.cursor_speed"), 0.74, 0.001)
 	assert_almost_eq(profile.behavior.get_stat("puzzle.think_speed"), 0.74, 0.001)
+	assert_almost_eq(profile.behavior.get_stat("puzzle.pickiness"), 0.0, 0.001)
 
 
 func test_load_sim_behavior_empty() -> void:


### PR DESCRIPTION
Added new properties:
 - puzzle.size_preference
 - puzzle.difficulty_preference
 - puzzle.pickiness

This lets sims define their favorite puzzle size and puzzle difficulty. Sims will look at all puzzles and choose the one that best fits their preferences. If they're picky, they'll travel far to find a puzzle they like. If they're not picky, they'll pick the closest puzzle.

Sim definitions can now include a [stats] section to override specific stats. This is useful when testing.

Added a cooldown for the 'find target' method. It's computationally intense, we don't want to do it every frame.