### PR TITLE
Refactor: 'MIN_' constants, stat comments

### DIFF
--- a/project/src/main/monster/sim/deduction_scorer.gd
+++ b/project/src/main/monster/sim/deduction_scorer.gd
@@ -86,7 +86,7 @@ const DEDUCTION_PRIORITY_FOR_REASON: Dictionary[Deduction.Reason, float] = {
 	UNKNOWN_REASON: 0.0,
 }
 
-const MIN_DEDUCTION_DELAY_FOR_REASON: Dictionary[Deduction.Reason, float] = {
+const DEDUCTION_DELAYS_MIN: Dictionary[Deduction.Reason, float] = {
 	UNKNOWN_REASON: 10.0,
 	
 	# break-in techniques
@@ -127,7 +127,7 @@ const MIN_DEDUCTION_DELAY_FOR_REASON: Dictionary[Deduction.Reason, float] = {
 	WALL_STRANGLE: 7.2,
 }
 
-const MAX_DEDUCTION_DELAY_FOR_REASON: Dictionary[Deduction.Reason, float] = {
+const DEDUCTION_DELAYS_MAX: Dictionary[Deduction.Reason, float] = {
 	UNKNOWN_REASON: 20.0,
 	
 	# break-in techniques
@@ -171,8 +171,8 @@ const MAX_DEDUCTION_DELAY_FOR_REASON: Dictionary[Deduction.Reason, float] = {
 
 static func get_delay(reason: Deduction.Reason, speed_factor: float) -> float:
 	return lerp(
-			MAX_DEDUCTION_DELAY_FOR_REASON.get(reason, 0.6),
-			MIN_DEDUCTION_DELAY_FOR_REASON.get(reason, 0.6), speed_factor)
+			DEDUCTION_DELAYS_MAX.get(reason, 0.6),
+			DEDUCTION_DELAYS_MIN.get(reason, 0.6), speed_factor)
 
 
 static func get_priority(reason: Deduction.Reason) -> float:

--- a/project/src/main/monster/sim/sim_behavior.gd
+++ b/project/src/main/monster/sim/sim_behavior.gd
@@ -1,15 +1,15 @@
 class_name SimBehavior
 
-const MOTIVATION: String = "motivation"
+const MOTIVATION: String = "motivation" # constantly active and moving
 
 ## solving a puzzle
-const PUZZLE_CURSOR_SPEED: String = "puzzle.cursor_speed"
-const PUZZLE_THINK_SPEED: String = "puzzle.think_speed"
+const PUZZLE_CURSOR_SPEED: String = "puzzle.cursor_speed" # fast cursor movements, no pauses
+const PUZZLE_THINK_SPEED: String = "puzzle.think_speed" # fast at coming up with deductions
 
 ## choosing a puzzle
-const PUZZLE_SIZE_PREFERENCE: String = "puzzle.size_preference"
-const PUZZLE_DIFFICULTY_PREFERENCE: String = "puzzle.difficulty_preference"
-const PUZZLE_PICKINESS: String = "puzzle.pickiness"
+const PUZZLE_SIZE_PREFERENCE: String = "puzzle.size_preference" # prefer large puzzles
+const PUZZLE_DIFFICULTY_PREFERENCE: String = "puzzle.difficulty_preference" # prefer hard puzzles
+const PUZZLE_PICKINESS: String = "puzzle.pickiness" # strong preferences, will search for a specific puzzle
 
 const STATS_BY_ARCHETYPE: Dictionary[String, Dictionary] = {
 	"neutral": {

--- a/project/src/main/monster/sim/sim_input.gd
+++ b/project/src/main/monster/sim/sim_input.gd
@@ -9,10 +9,10 @@ enum CursorAction {
 	MOVE,
 }
 
-const MIN_CURSOR_MOVE_SPEED: float = 100.0
-const MAX_CURSOR_MOVE_SPEED: float = 400.0
-const MIN_CURSOR_SMOOTHING: float = 3.0
-const MAX_CURSOR_SMOOTHING: float = 12.0
+const CURSOR_MOVE_SPEED_MIN: float = 100.0
+const CURSOR_MOVE_SPEED_MAX: float = 400.0
+const CURSOR_SMOOTHING_MIN: float = 3.0
+const CURSOR_SMOOTHING_MAX: float = 12.0
 
 const CURSOR_POS_EPSILON: float = 1.0
 const MOVEMENT_POS_EPSILON: float = 10.0
@@ -27,8 +27,8 @@ var target_puzzle: NurikabeGameBoard
 
 var cursor_commands: Array[CursorCommand] = []
 
-var cursor_move_speed: float = MIN_CURSOR_MOVE_SPEED
-var cursor_smoothing: float = MIN_CURSOR_SMOOTHING
+var cursor_move_speed: float = CURSOR_MOVE_SPEED_MIN
+var cursor_smoothing: float = CURSOR_SMOOTHING_MIN
 
 @onready var monster: SimMonster = Utils.find_parent_of_type(self, Monster)
 
@@ -37,9 +37,9 @@ func _ready() -> void:
 	await get_tree().process_frame
 	
 	cursor_move_speed = monster.behavior.lerp_stat(SimBehavior.PUZZLE_CURSOR_SPEED,
-			MIN_CURSOR_MOVE_SPEED, MAX_CURSOR_MOVE_SPEED)
+			CURSOR_MOVE_SPEED_MIN, CURSOR_MOVE_SPEED_MAX)
 	cursor_smoothing = monster.behavior.lerp_stat(SimBehavior.PUZZLE_CURSOR_SPEED,
-			MIN_CURSOR_SMOOTHING, MAX_CURSOR_SMOOTHING)
+			CURSOR_SMOOTHING_MIN, CURSOR_SMOOTHING_MAX)
 
 
 func update(delta: float) -> void:

--- a/project/src/main/monster/sim/work_on_puzzle_action.gd
+++ b/project/src/main/monster/sim/work_on_puzzle_action.gd
@@ -1,9 +1,9 @@
 class_name WorkOnPuzzleAction
 extends GoapAction
 
-const MIN_SOLVER_COOLDOWN: float = 2.3
-const AVG_SOLVER_COOLDOWN: float = 5.0
-const MAX_SOLVER_COOLDOWN: float = 9.0
+const SOLVER_COOLDOWN_MIN: float = 2.3
+const SOLVER_COOLDOWN_AVG: float = 5.0
+const SOLVER_COOLDOWN_MAX: float = 9.0
 
 const CHOOSE_DEDUCTION_COOLDOWN: float = 0.5
 const IDLE_COOLDOWN: float = 3.0
@@ -32,7 +32,7 @@ var _impatience_timer: float = 0.0
 var _cursor_commands_by_cell: Dictionary[Vector2i, Array] = {}
 var _interested_cells: Dictionary[Vector2i, float] = {}
 
-var _solver_cooldown: float = MIN_SOLVER_COOLDOWN
+var _solver_cooldown: float = SOLVER_COOLDOWN_MIN
 var _deduction_speed_factor: float = 0.0
 
 @onready var _solver: NaiveSolver = NaiveSolver.find_instance(self)
@@ -43,7 +43,7 @@ func _ready() -> void:
 	await get_tree().process_frame
 	
 	_solver_cooldown = monster.behavior.lerp_stat(SimBehavior.PUZZLE_THINK_SPEED,
-		MIN_SOLVER_COOLDOWN, MAX_SOLVER_COOLDOWN, AVG_SOLVER_COOLDOWN)
+		SOLVER_COOLDOWN_MIN, SOLVER_COOLDOWN_MAX, SOLVER_COOLDOWN_AVG)
 	_deduction_speed_factor = monster.behavior.lerp_stat(SimBehavior.PUZZLE_THINK_SPEED, 0.0, 1.0, 0.75)
 
 


### PR DESCRIPTION
Renamed 'MIN/MAX_FOO' constants to 'FOO_MIN/MAX'

Added comments for sim stats. My instincts are to comment on everything in the project but I'm trying to restrain myself. These stat fields are ambiguous enough that commenting them will really help avoid duplication and confusion in the long run.