### PR TITLE
Undo tweaks. 'surround island'. Conflicts.

### DIFF
--- a/project/src/main/monster/puzzle_handler.gd
+++ b/project/src/main/monster/puzzle_handler.gd
@@ -114,7 +114,7 @@ func _handle_lmb_press() -> void:
 		var changes: Array[Dictionary] = game_board.to_solver_board().surround_island(cell)
 		if changes:
 			for change: Dictionary[String, Variant] in changes:
-				_set_cell(change["pos"], change["value"])
+				_set_cell(change["pos"], change["value"], monster.id)
 			var cell_positions: Array[Vector2i] = []
 			for change: Dictionary[String, Variant] in changes:
 				cell_positions.append(change["pos"])

--- a/project/src/main/nurikabe/nurikabe_game_board.gd
+++ b/project/src/main/nurikabe/nurikabe_game_board.gd
@@ -292,17 +292,19 @@ func to_solver_board() -> SolverBoard:
 
 
 func undo(player_id: int) -> void:
-	for undo_index in _undo_stack.size():
+	var undo_index: int = 0
+	while undo_index < _undo_stack.size():
 		if _undo_stack[undo_index].player_id != player_id:
+			undo_index += 1
 			continue
-		if _can_apply_undo_action(_undo_stack[undo_index]):
-			var undo_action: UndoAction = _undo_stack[undo_index]
+		if not _can_apply_undo_action(_undo_stack[undo_index]):
 			_undo_stack.remove_at(undo_index)
-			_apply_undo_action(undo_action)
-			_redo_stack.push_front(undo_action)
-			break
-		else:
-			_undo_stack.remove_at(undo_index)
+			continue
+		var undo_action: UndoAction = _undo_stack[undo_index]
+		_undo_stack.remove_at(undo_index)
+		_apply_undo_action(undo_action)
+		_redo_stack.push_front(undo_action)
+		break
 
 
 func redo(player_id: int) -> void:


### PR DESCRIPTION
Surrounding a complete island can now be undone by pressing Z.

Fixed a bug where the undo logic could hit an out of bounds exception when undoing on a puzzle with multiple players.