### PR TITLE
Generator preserves author. Puzzle info version 0.02.

### DIFF
--- a/project/src/demo/nurikabe/generator/puzzle_info_generator.gd
+++ b/project/src/demo/nurikabe/generator/puzzle_info_generator.gd
@@ -25,9 +25,15 @@ func write_puzzle_info(puzzle_path: String) -> void:
 		print(validation_result)
 		return
 	
+	var info_path: String = _puzzle_info_path(puzzle_path)
+	
+	var old_info: PuzzleInfo
+	if FileAccess.file_exists(info_path):
+		old_info = PuzzleInfoSaver.new().load_puzzle_info(info_path)
+	
 	var info: PuzzleInfo = PuzzleInfo.new()
-	info.version = "0.01"
-	info.author = "poobslag v03"
+	info.version = PuzzleInfoSaver.PUZZLE_INFO_VERSION if old_info == null else old_info.version
+	info.author = "poobslag v03" if old_info == null else old_info.author
 	info.difficulty = solver.get_measured_difficulty()
 	for cell: Vector2i in solver.board.cells:
 		info.size.x = maxi(info.size.x, cell.x)
@@ -36,9 +42,7 @@ func write_puzzle_info(puzzle_path: String) -> void:
 	info.order_string = _get_order_string()
 	info.reason_string = _get_reason_string()
 	
-	var info_path: String = _puzzle_info_path(puzzle_path)
-	var saver: PuzzleInfoSaver = PuzzleInfoSaver.new()
-	saver.save_puzzle_info(info_path, info)
+	PuzzleInfoSaver.new().save_puzzle_info(info_path, info)
 	
 	_generator.log_message("Wrote %s." % [info_path])
 	solver.board.cleanup()

--- a/project/src/main/nurikabe/puzzle_info_saver.gd
+++ b/project/src/main/nurikabe/puzzle_info_saver.gd
@@ -1,6 +1,6 @@
 class_name PuzzleInfoSaver
 
-const PUZZLE_INFO_VERSION: String = "0.01"
+const PUZZLE_INFO_VERSION: String = "0.02"
 
 func save_puzzle_info(filename: String, info: PuzzleInfo) -> void:
 	var file: FileAccess = FileAccess.open(filename, FileAccess.WRITE)

--- a/project/src/test/nurikabe/test_puzzle_info_saver.gd
+++ b/project/src/test/nurikabe/test_puzzle_info_saver.gd
@@ -91,7 +91,7 @@ func test_save_and_load() -> void:
 	saver.save_puzzle_info(TEMP_PUZZLE_INFO_FILENAME, info)
 	
 	info = saver.load_puzzle_info(TEMP_PUZZLE_INFO_FILENAME)
-	assert_eq(info.version, "0.01")
+	assert_eq(info.version, "0.02")
 	assert_eq(info.author, "poobslag v02")
 	assert_almost_eq(info.difficulty, 0.031, 0.001)
 	assert_eq(info.size, Vector2i(10, 9))


### PR DESCRIPTION
Puzzle generator now preserves author when reanalyzing old puzzles. The author shouldn't change just because the metadata is rewritten.

Upgraded PUZZLE_INFO_VERSION from 0.01 to 0.02.

PuzzleInfoGenerator uses PUZZLE_INFO_VERSION instead of hard-coding constant.