### PR TITLE
Updated puzzle.txt.info: version 0.02, missing solution

### DIFF
--- a/project/assets/main/nurikabe/official/generated/1.txt.info
+++ b/project/assets/main/nurikabe/official/generated/1.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.87

--- a/project/assets/main/nurikabe/official/generated/10.txt.info
+++ b/project/assets/main/nurikabe/official/generated/10.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/100.txt.info
+++ b/project/assets/main/nurikabe/official/generated/100.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 12.86

--- a/project/assets/main/nurikabe/official/generated/101.txt.info
+++ b/project/assets/main/nurikabe/official/generated/101.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.68

--- a/project/assets/main/nurikabe/official/generated/102.txt.info
+++ b/project/assets/main/nurikabe/official/generated/102.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 18.00

--- a/project/assets/main/nurikabe/official/generated/103.txt.info
+++ b/project/assets/main/nurikabe/official/generated/103.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.09

--- a/project/assets/main/nurikabe/official/generated/104.txt.info
+++ b/project/assets/main/nurikabe/official/generated/104.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.48

--- a/project/assets/main/nurikabe/official/generated/105.txt.info
+++ b/project/assets/main/nurikabe/official/generated/105.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 7.28

--- a/project/assets/main/nurikabe/official/generated/106.txt.info
+++ b/project/assets/main/nurikabe/official/generated/106.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.41

--- a/project/assets/main/nurikabe/official/generated/107.txt.info
+++ b/project/assets/main/nurikabe/official/generated/107.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.68

--- a/project/assets/main/nurikabe/official/generated/108.txt.info
+++ b/project/assets/main/nurikabe/official/generated/108.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.78

--- a/project/assets/main/nurikabe/official/generated/109.txt.info
+++ b/project/assets/main/nurikabe/official/generated/109.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.15

--- a/project/assets/main/nurikabe/official/generated/11.txt.info
+++ b/project/assets/main/nurikabe/official/generated/11.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.79

--- a/project/assets/main/nurikabe/official/generated/110.txt.info
+++ b/project/assets/main/nurikabe/official/generated/110.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.68

--- a/project/assets/main/nurikabe/official/generated/111.txt.info
+++ b/project/assets/main/nurikabe/official/generated/111.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 16.07

--- a/project/assets/main/nurikabe/official/generated/112.txt.info
+++ b/project/assets/main/nurikabe/official/generated/112.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.33

--- a/project/assets/main/nurikabe/official/generated/113.txt.info
+++ b/project/assets/main/nurikabe/official/generated/113.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.30

--- a/project/assets/main/nurikabe/official/generated/114.txt.info
+++ b/project/assets/main/nurikabe/official/generated/114.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.36

--- a/project/assets/main/nurikabe/official/generated/115.txt.info
+++ b/project/assets/main/nurikabe/official/generated/115.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/116.txt.info
+++ b/project/assets/main/nurikabe/official/generated/116.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.30

--- a/project/assets/main/nurikabe/official/generated/117.txt.info
+++ b/project/assets/main/nurikabe/official/generated/117.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.40

--- a/project/assets/main/nurikabe/official/generated/118.txt.info
+++ b/project/assets/main/nurikabe/official/generated/118.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.23

--- a/project/assets/main/nurikabe/official/generated/119.txt.info
+++ b/project/assets/main/nurikabe/official/generated/119.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 7.69

--- a/project/assets/main/nurikabe/official/generated/12.txt.info
+++ b/project/assets/main/nurikabe/official/generated/12.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.33

--- a/project/assets/main/nurikabe/official/generated/120.txt.info
+++ b/project/assets/main/nurikabe/official/generated/120.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.49

--- a/project/assets/main/nurikabe/official/generated/121.txt.info
+++ b/project/assets/main/nurikabe/official/generated/121.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.23

--- a/project/assets/main/nurikabe/official/generated/122.txt.info
+++ b/project/assets/main/nurikabe/official/generated/122.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.87

--- a/project/assets/main/nurikabe/official/generated/123.txt.info
+++ b/project/assets/main/nurikabe/official/generated/123.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.85

--- a/project/assets/main/nurikabe/official/generated/124.txt.info
+++ b/project/assets/main/nurikabe/official/generated/124.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.61

--- a/project/assets/main/nurikabe/official/generated/125.txt.info
+++ b/project/assets/main/nurikabe/official/generated/125.txt.info
@@ -1,7 +1,7 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
-difficulty 10.90
+difficulty 10.58
 width 14
 height 13
 author poobslag v02

--- a/project/assets/main/nurikabe/official/generated/126.txt.info
+++ b/project/assets/main/nurikabe/official/generated/126.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.66

--- a/project/assets/main/nurikabe/official/generated/127.txt.info
+++ b/project/assets/main/nurikabe/official/generated/127.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.82

--- a/project/assets/main/nurikabe/official/generated/128.txt.info
+++ b/project/assets/main/nurikabe/official/generated/128.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.52

--- a/project/assets/main/nurikabe/official/generated/129.txt.info
+++ b/project/assets/main/nurikabe/official/generated/129.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.28

--- a/project/assets/main/nurikabe/official/generated/13.txt.info
+++ b/project/assets/main/nurikabe/official/generated/13.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.99

--- a/project/assets/main/nurikabe/official/generated/130.txt.info
+++ b/project/assets/main/nurikabe/official/generated/130.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 12.87

--- a/project/assets/main/nurikabe/official/generated/131.txt.info
+++ b/project/assets/main/nurikabe/official/generated/131.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 20.00

--- a/project/assets/main/nurikabe/official/generated/132.txt.info
+++ b/project/assets/main/nurikabe/official/generated/132.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/133.txt.info
+++ b/project/assets/main/nurikabe/official/generated/133.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.99

--- a/project/assets/main/nurikabe/official/generated/134.txt.info
+++ b/project/assets/main/nurikabe/official/generated/134.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.90

--- a/project/assets/main/nurikabe/official/generated/135.txt.info
+++ b/project/assets/main/nurikabe/official/generated/135.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.65

--- a/project/assets/main/nurikabe/official/generated/136.txt.info
+++ b/project/assets/main/nurikabe/official/generated/136.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.69

--- a/project/assets/main/nurikabe/official/generated/137.txt.info
+++ b/project/assets/main/nurikabe/official/generated/137.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.76

--- a/project/assets/main/nurikabe/official/generated/138.txt.info
+++ b/project/assets/main/nurikabe/official/generated/138.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.61

--- a/project/assets/main/nurikabe/official/generated/139.txt.info
+++ b/project/assets/main/nurikabe/official/generated/139.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 11.06

--- a/project/assets/main/nurikabe/official/generated/14.txt.info
+++ b/project/assets/main/nurikabe/official/generated/14.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 20.00

--- a/project/assets/main/nurikabe/official/generated/140.txt.info
+++ b/project/assets/main/nurikabe/official/generated/140.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.38

--- a/project/assets/main/nurikabe/official/generated/141.txt.info
+++ b/project/assets/main/nurikabe/official/generated/141.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.80

--- a/project/assets/main/nurikabe/official/generated/142.txt.info
+++ b/project/assets/main/nurikabe/official/generated/142.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 20.00

--- a/project/assets/main/nurikabe/official/generated/143.txt.info
+++ b/project/assets/main/nurikabe/official/generated/143.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/144.txt.info
+++ b/project/assets/main/nurikabe/official/generated/144.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 12.12

--- a/project/assets/main/nurikabe/official/generated/145.txt.info
+++ b/project/assets/main/nurikabe/official/generated/145.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.94

--- a/project/assets/main/nurikabe/official/generated/146.txt.info
+++ b/project/assets/main/nurikabe/official/generated/146.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.82

--- a/project/assets/main/nurikabe/official/generated/147.txt.info
+++ b/project/assets/main/nurikabe/official/generated/147.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 15.07

--- a/project/assets/main/nurikabe/official/generated/148.txt.info
+++ b/project/assets/main/nurikabe/official/generated/148.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.82

--- a/project/assets/main/nurikabe/official/generated/149.txt.info
+++ b/project/assets/main/nurikabe/official/generated/149.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.14

--- a/project/assets/main/nurikabe/official/generated/15.txt.info
+++ b/project/assets/main/nurikabe/official/generated/15.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.72

--- a/project/assets/main/nurikabe/official/generated/150.txt.info
+++ b/project/assets/main/nurikabe/official/generated/150.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.48

--- a/project/assets/main/nurikabe/official/generated/151.txt.info
+++ b/project/assets/main/nurikabe/official/generated/151.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.64

--- a/project/assets/main/nurikabe/official/generated/152.txt.info
+++ b/project/assets/main/nurikabe/official/generated/152.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.78

--- a/project/assets/main/nurikabe/official/generated/153.txt.info
+++ b/project/assets/main/nurikabe/official/generated/153.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 11.12

--- a/project/assets/main/nurikabe/official/generated/154.txt.info
+++ b/project/assets/main/nurikabe/official/generated/154.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.53

--- a/project/assets/main/nurikabe/official/generated/155.txt.info
+++ b/project/assets/main/nurikabe/official/generated/155.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 7.42

--- a/project/assets/main/nurikabe/official/generated/156.txt.info
+++ b/project/assets/main/nurikabe/official/generated/156.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.00

--- a/project/assets/main/nurikabe/official/generated/157.txt.info
+++ b/project/assets/main/nurikabe/official/generated/157.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.50

--- a/project/assets/main/nurikabe/official/generated/158.txt.info
+++ b/project/assets/main/nurikabe/official/generated/158.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.30

--- a/project/assets/main/nurikabe/official/generated/159.txt.info
+++ b/project/assets/main/nurikabe/official/generated/159.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.98

--- a/project/assets/main/nurikabe/official/generated/16.txt.info
+++ b/project/assets/main/nurikabe/official/generated/16.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/160.txt.info
+++ b/project/assets/main/nurikabe/official/generated/160.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.73

--- a/project/assets/main/nurikabe/official/generated/161.txt.info
+++ b/project/assets/main/nurikabe/official/generated/161.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/162.txt.info
+++ b/project/assets/main/nurikabe/official/generated/162.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.93

--- a/project/assets/main/nurikabe/official/generated/163.txt.info
+++ b/project/assets/main/nurikabe/official/generated/163.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.79

--- a/project/assets/main/nurikabe/official/generated/164.txt.info
+++ b/project/assets/main/nurikabe/official/generated/164.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 7.29

--- a/project/assets/main/nurikabe/official/generated/165.txt.info
+++ b/project/assets/main/nurikabe/official/generated/165.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.83

--- a/project/assets/main/nurikabe/official/generated/166.txt.info
+++ b/project/assets/main/nurikabe/official/generated/166.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 8.46

--- a/project/assets/main/nurikabe/official/generated/167.txt.info
+++ b/project/assets/main/nurikabe/official/generated/167.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 10.96

--- a/project/assets/main/nurikabe/official/generated/168.txt.info
+++ b/project/assets/main/nurikabe/official/generated/168.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.14

--- a/project/assets/main/nurikabe/official/generated/169.txt.info
+++ b/project/assets/main/nurikabe/official/generated/169.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.75

--- a/project/assets/main/nurikabe/official/generated/17.txt.info
+++ b/project/assets/main/nurikabe/official/generated/17.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.05

--- a/project/assets/main/nurikabe/official/generated/170.txt.info
+++ b/project/assets/main/nurikabe/official/generated/170.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 14.92

--- a/project/assets/main/nurikabe/official/generated/171.txt.info
+++ b/project/assets/main/nurikabe/official/generated/171.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/172.txt.info
+++ b/project/assets/main/nurikabe/official/generated/172.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.65

--- a/project/assets/main/nurikabe/official/generated/173.txt.info
+++ b/project/assets/main/nurikabe/official/generated/173.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 20.00

--- a/project/assets/main/nurikabe/official/generated/174.txt.info
+++ b/project/assets/main/nurikabe/official/generated/174.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 7.23

--- a/project/assets/main/nurikabe/official/generated/175.txt.info
+++ b/project/assets/main/nurikabe/official/generated/175.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 8.76

--- a/project/assets/main/nurikabe/official/generated/176.txt.info
+++ b/project/assets/main/nurikabe/official/generated/176.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.78

--- a/project/assets/main/nurikabe/official/generated/177.txt.info
+++ b/project/assets/main/nurikabe/official/generated/177.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.96

--- a/project/assets/main/nurikabe/official/generated/178.txt.info
+++ b/project/assets/main/nurikabe/official/generated/178.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.18

--- a/project/assets/main/nurikabe/official/generated/179.txt.info
+++ b/project/assets/main/nurikabe/official/generated/179.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.24

--- a/project/assets/main/nurikabe/official/generated/18.txt.info
+++ b/project/assets/main/nurikabe/official/generated/18.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 7.52

--- a/project/assets/main/nurikabe/official/generated/180.txt.info
+++ b/project/assets/main/nurikabe/official/generated/180.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 7.11

--- a/project/assets/main/nurikabe/official/generated/181.txt.info
+++ b/project/assets/main/nurikabe/official/generated/181.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.70

--- a/project/assets/main/nurikabe/official/generated/182.txt.info
+++ b/project/assets/main/nurikabe/official/generated/182.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.48

--- a/project/assets/main/nurikabe/official/generated/183.txt.info
+++ b/project/assets/main/nurikabe/official/generated/183.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.89

--- a/project/assets/main/nurikabe/official/generated/184.txt.info
+++ b/project/assets/main/nurikabe/official/generated/184.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.74

--- a/project/assets/main/nurikabe/official/generated/185.txt.info
+++ b/project/assets/main/nurikabe/official/generated/185.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.90

--- a/project/assets/main/nurikabe/official/generated/186.txt.info
+++ b/project/assets/main/nurikabe/official/generated/186.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.55

--- a/project/assets/main/nurikabe/official/generated/187.txt.info
+++ b/project/assets/main/nurikabe/official/generated/187.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.46

--- a/project/assets/main/nurikabe/official/generated/188.txt.info
+++ b/project/assets/main/nurikabe/official/generated/188.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/189.txt.info
+++ b/project/assets/main/nurikabe/official/generated/189.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.48

--- a/project/assets/main/nurikabe/official/generated/19.txt.info
+++ b/project/assets/main/nurikabe/official/generated/19.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.18

--- a/project/assets/main/nurikabe/official/generated/190.txt.info
+++ b/project/assets/main/nurikabe/official/generated/190.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.27

--- a/project/assets/main/nurikabe/official/generated/191.txt.info
+++ b/project/assets/main/nurikabe/official/generated/191.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.94

--- a/project/assets/main/nurikabe/official/generated/192.txt.info
+++ b/project/assets/main/nurikabe/official/generated/192.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.37

--- a/project/assets/main/nurikabe/official/generated/193.txt.info
+++ b/project/assets/main/nurikabe/official/generated/193.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.65

--- a/project/assets/main/nurikabe/official/generated/194.txt.info
+++ b/project/assets/main/nurikabe/official/generated/194.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 20.00

--- a/project/assets/main/nurikabe/official/generated/195.txt.info
+++ b/project/assets/main/nurikabe/official/generated/195.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.86

--- a/project/assets/main/nurikabe/official/generated/196.txt.info
+++ b/project/assets/main/nurikabe/official/generated/196.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.06

--- a/project/assets/main/nurikabe/official/generated/197.txt.info
+++ b/project/assets/main/nurikabe/official/generated/197.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.22

--- a/project/assets/main/nurikabe/official/generated/198.txt.info
+++ b/project/assets/main/nurikabe/official/generated/198.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.74

--- a/project/assets/main/nurikabe/official/generated/199.txt.info
+++ b/project/assets/main/nurikabe/official/generated/199.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.05

--- a/project/assets/main/nurikabe/official/generated/2.txt.info
+++ b/project/assets/main/nurikabe/official/generated/2.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.48

--- a/project/assets/main/nurikabe/official/generated/20.txt.info
+++ b/project/assets/main/nurikabe/official/generated/20.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.12

--- a/project/assets/main/nurikabe/official/generated/200.txt.info
+++ b/project/assets/main/nurikabe/official/generated/200.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.24

--- a/project/assets/main/nurikabe/official/generated/201.txt.info
+++ b/project/assets/main/nurikabe/official/generated/201.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.84

--- a/project/assets/main/nurikabe/official/generated/202.txt.info
+++ b/project/assets/main/nurikabe/official/generated/202.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 11.86

--- a/project/assets/main/nurikabe/official/generated/203.txt.info
+++ b/project/assets/main/nurikabe/official/generated/203.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.07

--- a/project/assets/main/nurikabe/official/generated/204.txt.info
+++ b/project/assets/main/nurikabe/official/generated/204.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/205.txt.info
+++ b/project/assets/main/nurikabe/official/generated/205.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.40

--- a/project/assets/main/nurikabe/official/generated/206.txt.info
+++ b/project/assets/main/nurikabe/official/generated/206.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 11.54

--- a/project/assets/main/nurikabe/official/generated/207.txt.info
+++ b/project/assets/main/nurikabe/official/generated/207.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.70

--- a/project/assets/main/nurikabe/official/generated/208.txt.info
+++ b/project/assets/main/nurikabe/official/generated/208.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.80

--- a/project/assets/main/nurikabe/official/generated/209.txt.info
+++ b/project/assets/main/nurikabe/official/generated/209.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.29

--- a/project/assets/main/nurikabe/official/generated/21.txt.info
+++ b/project/assets/main/nurikabe/official/generated/21.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/210.txt.info
+++ b/project/assets/main/nurikabe/official/generated/210.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.71

--- a/project/assets/main/nurikabe/official/generated/211.txt.info
+++ b/project/assets/main/nurikabe/official/generated/211.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.12

--- a/project/assets/main/nurikabe/official/generated/212.txt.info
+++ b/project/assets/main/nurikabe/official/generated/212.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.70

--- a/project/assets/main/nurikabe/official/generated/213.txt.info
+++ b/project/assets/main/nurikabe/official/generated/213.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.00

--- a/project/assets/main/nurikabe/official/generated/214.txt.info
+++ b/project/assets/main/nurikabe/official/generated/214.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.31

--- a/project/assets/main/nurikabe/official/generated/215.txt.info
+++ b/project/assets/main/nurikabe/official/generated/215.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 9.60

--- a/project/assets/main/nurikabe/official/generated/216.txt.info
+++ b/project/assets/main/nurikabe/official/generated/216.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.95

--- a/project/assets/main/nurikabe/official/generated/217.txt.info
+++ b/project/assets/main/nurikabe/official/generated/217.txt.info
@@ -1,7 +1,7 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
-difficulty 16.33
+difficulty 16.22
 width 20
 height 10
 author poobslag v02

--- a/project/assets/main/nurikabe/official/generated/218.txt.info
+++ b/project/assets/main/nurikabe/official/generated/218.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.48

--- a/project/assets/main/nurikabe/official/generated/219.txt.info
+++ b/project/assets/main/nurikabe/official/generated/219.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.63

--- a/project/assets/main/nurikabe/official/generated/22.txt.info
+++ b/project/assets/main/nurikabe/official/generated/22.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.33

--- a/project/assets/main/nurikabe/official/generated/220.txt.info
+++ b/project/assets/main/nurikabe/official/generated/220.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/221.txt.info
+++ b/project/assets/main/nurikabe/official/generated/221.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.92

--- a/project/assets/main/nurikabe/official/generated/222.txt.info
+++ b/project/assets/main/nurikabe/official/generated/222.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.66

--- a/project/assets/main/nurikabe/official/generated/223.txt.info
+++ b/project/assets/main/nurikabe/official/generated/223.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.92

--- a/project/assets/main/nurikabe/official/generated/224.txt.info
+++ b/project/assets/main/nurikabe/official/generated/224.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.27

--- a/project/assets/main/nurikabe/official/generated/225.txt.info
+++ b/project/assets/main/nurikabe/official/generated/225.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.09

--- a/project/assets/main/nurikabe/official/generated/226.txt.info
+++ b/project/assets/main/nurikabe/official/generated/226.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.43

--- a/project/assets/main/nurikabe/official/generated/227.txt.info
+++ b/project/assets/main/nurikabe/official/generated/227.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/228.txt.info
+++ b/project/assets/main/nurikabe/official/generated/228.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/229.txt.info
+++ b/project/assets/main/nurikabe/official/generated/229.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 13.05

--- a/project/assets/main/nurikabe/official/generated/23.txt.info
+++ b/project/assets/main/nurikabe/official/generated/23.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.19

--- a/project/assets/main/nurikabe/official/generated/230.txt.info
+++ b/project/assets/main/nurikabe/official/generated/230.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.06

--- a/project/assets/main/nurikabe/official/generated/231.txt.info
+++ b/project/assets/main/nurikabe/official/generated/231.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.53

--- a/project/assets/main/nurikabe/official/generated/232.txt.info
+++ b/project/assets/main/nurikabe/official/generated/232.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.38

--- a/project/assets/main/nurikabe/official/generated/233.txt.info
+++ b/project/assets/main/nurikabe/official/generated/233.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 20.00

--- a/project/assets/main/nurikabe/official/generated/234.txt.info
+++ b/project/assets/main/nurikabe/official/generated/234.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.76

--- a/project/assets/main/nurikabe/official/generated/235.txt.info
+++ b/project/assets/main/nurikabe/official/generated/235.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.27

--- a/project/assets/main/nurikabe/official/generated/236.txt.info
+++ b/project/assets/main/nurikabe/official/generated/236.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.20

--- a/project/assets/main/nurikabe/official/generated/237.txt.info
+++ b/project/assets/main/nurikabe/official/generated/237.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/238.txt.info
+++ b/project/assets/main/nurikabe/official/generated/238.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 17.42

--- a/project/assets/main/nurikabe/official/generated/239.txt.info
+++ b/project/assets/main/nurikabe/official/generated/239.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.06

--- a/project/assets/main/nurikabe/official/generated/24.txt.info
+++ b/project/assets/main/nurikabe/official/generated/24.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.49

--- a/project/assets/main/nurikabe/official/generated/240.txt.info
+++ b/project/assets/main/nurikabe/official/generated/240.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.19

--- a/project/assets/main/nurikabe/official/generated/241.txt.info
+++ b/project/assets/main/nurikabe/official/generated/241.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 20.00

--- a/project/assets/main/nurikabe/official/generated/242.txt.info
+++ b/project/assets/main/nurikabe/official/generated/242.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 17.40

--- a/project/assets/main/nurikabe/official/generated/243.txt.info
+++ b/project/assets/main/nurikabe/official/generated/243.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.58

--- a/project/assets/main/nurikabe/official/generated/244.txt.info
+++ b/project/assets/main/nurikabe/official/generated/244.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.54

--- a/project/assets/main/nurikabe/official/generated/245.txt.info
+++ b/project/assets/main/nurikabe/official/generated/245.txt.info
@@ -1,7 +1,7 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
-difficulty 18.05
+difficulty 17.98
 width 9
 height 8
 author poobslag v02

--- a/project/assets/main/nurikabe/official/generated/246.txt.info
+++ b/project/assets/main/nurikabe/official/generated/246.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.09

--- a/project/assets/main/nurikabe/official/generated/247.txt.info
+++ b/project/assets/main/nurikabe/official/generated/247.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.54

--- a/project/assets/main/nurikabe/official/generated/248.txt.info
+++ b/project/assets/main/nurikabe/official/generated/248.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 16.39

--- a/project/assets/main/nurikabe/official/generated/249.txt.info
+++ b/project/assets/main/nurikabe/official/generated/249.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.90

--- a/project/assets/main/nurikabe/official/generated/25.txt.info
+++ b/project/assets/main/nurikabe/official/generated/25.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.11

--- a/project/assets/main/nurikabe/official/generated/250.txt.info
+++ b/project/assets/main/nurikabe/official/generated/250.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.87

--- a/project/assets/main/nurikabe/official/generated/251.txt.info
+++ b/project/assets/main/nurikabe/official/generated/251.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/252.txt.info
+++ b/project/assets/main/nurikabe/official/generated/252.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 9.12

--- a/project/assets/main/nurikabe/official/generated/253.txt.info
+++ b/project/assets/main/nurikabe/official/generated/253.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.40

--- a/project/assets/main/nurikabe/official/generated/254.txt.info
+++ b/project/assets/main/nurikabe/official/generated/254.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 20.00

--- a/project/assets/main/nurikabe/official/generated/255.txt.info
+++ b/project/assets/main/nurikabe/official/generated/255.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.84

--- a/project/assets/main/nurikabe/official/generated/256.txt.info
+++ b/project/assets/main/nurikabe/official/generated/256.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.79

--- a/project/assets/main/nurikabe/official/generated/257.txt.info
+++ b/project/assets/main/nurikabe/official/generated/257.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.06

--- a/project/assets/main/nurikabe/official/generated/258.txt.info
+++ b/project/assets/main/nurikabe/official/generated/258.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.01

--- a/project/assets/main/nurikabe/official/generated/259.txt.info
+++ b/project/assets/main/nurikabe/official/generated/259.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.79

--- a/project/assets/main/nurikabe/official/generated/26.txt.info
+++ b/project/assets/main/nurikabe/official/generated/26.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.67

--- a/project/assets/main/nurikabe/official/generated/260.txt.info
+++ b/project/assets/main/nurikabe/official/generated/260.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.41

--- a/project/assets/main/nurikabe/official/generated/261.txt.info
+++ b/project/assets/main/nurikabe/official/generated/261.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.72

--- a/project/assets/main/nurikabe/official/generated/262.txt.info
+++ b/project/assets/main/nurikabe/official/generated/262.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.45

--- a/project/assets/main/nurikabe/official/generated/263.txt.info
+++ b/project/assets/main/nurikabe/official/generated/263.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.91

--- a/project/assets/main/nurikabe/official/generated/264.txt.info
+++ b/project/assets/main/nurikabe/official/generated/264.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.90

--- a/project/assets/main/nurikabe/official/generated/265.txt.info
+++ b/project/assets/main/nurikabe/official/generated/265.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 8.27

--- a/project/assets/main/nurikabe/official/generated/266.txt.info
+++ b/project/assets/main/nurikabe/official/generated/266.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.67

--- a/project/assets/main/nurikabe/official/generated/267.txt.info
+++ b/project/assets/main/nurikabe/official/generated/267.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/268.txt.info
+++ b/project/assets/main/nurikabe/official/generated/268.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.54

--- a/project/assets/main/nurikabe/official/generated/269.txt.info
+++ b/project/assets/main/nurikabe/official/generated/269.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 20.00

--- a/project/assets/main/nurikabe/official/generated/27.txt.info
+++ b/project/assets/main/nurikabe/official/generated/27.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.29

--- a/project/assets/main/nurikabe/official/generated/270.txt.info
+++ b/project/assets/main/nurikabe/official/generated/270.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 8.83

--- a/project/assets/main/nurikabe/official/generated/271.txt.info
+++ b/project/assets/main/nurikabe/official/generated/271.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 7.87

--- a/project/assets/main/nurikabe/official/generated/272.txt.info
+++ b/project/assets/main/nurikabe/official/generated/272.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 9.44

--- a/project/assets/main/nurikabe/official/generated/273.txt.info
+++ b/project/assets/main/nurikabe/official/generated/273.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.85

--- a/project/assets/main/nurikabe/official/generated/274.txt.info
+++ b/project/assets/main/nurikabe/official/generated/274.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.69

--- a/project/assets/main/nurikabe/official/generated/275.txt.info
+++ b/project/assets/main/nurikabe/official/generated/275.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 8.02

--- a/project/assets/main/nurikabe/official/generated/276.txt.info
+++ b/project/assets/main/nurikabe/official/generated/276.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.81

--- a/project/assets/main/nurikabe/official/generated/277.txt.info
+++ b/project/assets/main/nurikabe/official/generated/277.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.76

--- a/project/assets/main/nurikabe/official/generated/278.txt.info
+++ b/project/assets/main/nurikabe/official/generated/278.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.38

--- a/project/assets/main/nurikabe/official/generated/279.txt.info
+++ b/project/assets/main/nurikabe/official/generated/279.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.63

--- a/project/assets/main/nurikabe/official/generated/28.txt.info
+++ b/project/assets/main/nurikabe/official/generated/28.txt.info
@@ -1,7 +1,7 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
-difficulty 15.23
+difficulty 15.11
 width 8
 height 11
 author poobslag v02

--- a/project/assets/main/nurikabe/official/generated/280.txt.info
+++ b/project/assets/main/nurikabe/official/generated/280.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.00

--- a/project/assets/main/nurikabe/official/generated/281.txt.info
+++ b/project/assets/main/nurikabe/official/generated/281.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 9.93

--- a/project/assets/main/nurikabe/official/generated/282.txt.info
+++ b/project/assets/main/nurikabe/official/generated/282.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.48

--- a/project/assets/main/nurikabe/official/generated/283.txt.info
+++ b/project/assets/main/nurikabe/official/generated/283.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.33

--- a/project/assets/main/nurikabe/official/generated/284.txt.info
+++ b/project/assets/main/nurikabe/official/generated/284.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.26

--- a/project/assets/main/nurikabe/official/generated/285.txt.info
+++ b/project/assets/main/nurikabe/official/generated/285.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.59

--- a/project/assets/main/nurikabe/official/generated/286.txt.info
+++ b/project/assets/main/nurikabe/official/generated/286.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/287.txt.info
+++ b/project/assets/main/nurikabe/official/generated/287.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.32

--- a/project/assets/main/nurikabe/official/generated/288.txt.info
+++ b/project/assets/main/nurikabe/official/generated/288.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 8.60

--- a/project/assets/main/nurikabe/official/generated/289.txt.info
+++ b/project/assets/main/nurikabe/official/generated/289.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 7.47

--- a/project/assets/main/nurikabe/official/generated/29.txt.info
+++ b/project/assets/main/nurikabe/official/generated/29.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.52

--- a/project/assets/main/nurikabe/official/generated/290.txt.info
+++ b/project/assets/main/nurikabe/official/generated/290.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.94

--- a/project/assets/main/nurikabe/official/generated/291.txt.info
+++ b/project/assets/main/nurikabe/official/generated/291.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/292.txt.info
+++ b/project/assets/main/nurikabe/official/generated/292.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.13

--- a/project/assets/main/nurikabe/official/generated/293.txt.info
+++ b/project/assets/main/nurikabe/official/generated/293.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 19.93

--- a/project/assets/main/nurikabe/official/generated/294.txt.info
+++ b/project/assets/main/nurikabe/official/generated/294.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 11.10

--- a/project/assets/main/nurikabe/official/generated/295.txt.info
+++ b/project/assets/main/nurikabe/official/generated/295.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.74

--- a/project/assets/main/nurikabe/official/generated/296.txt.info
+++ b/project/assets/main/nurikabe/official/generated/296.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.22

--- a/project/assets/main/nurikabe/official/generated/297.txt.info
+++ b/project/assets/main/nurikabe/official/generated/297.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.29

--- a/project/assets/main/nurikabe/official/generated/298.txt.info
+++ b/project/assets/main/nurikabe/official/generated/298.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.59

--- a/project/assets/main/nurikabe/official/generated/299.txt.info
+++ b/project/assets/main/nurikabe/official/generated/299.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.99

--- a/project/assets/main/nurikabe/official/generated/3.txt.info
+++ b/project/assets/main/nurikabe/official/generated/3.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.16

--- a/project/assets/main/nurikabe/official/generated/30.txt.info
+++ b/project/assets/main/nurikabe/official/generated/30.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 8.24

--- a/project/assets/main/nurikabe/official/generated/300.txt.info
+++ b/project/assets/main/nurikabe/official/generated/300.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.24

--- a/project/assets/main/nurikabe/official/generated/301.txt.info
+++ b/project/assets/main/nurikabe/official/generated/301.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.74

--- a/project/assets/main/nurikabe/official/generated/302.txt.info
+++ b/project/assets/main/nurikabe/official/generated/302.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.23

--- a/project/assets/main/nurikabe/official/generated/303.txt.info
+++ b/project/assets/main/nurikabe/official/generated/303.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.58

--- a/project/assets/main/nurikabe/official/generated/304.txt.info
+++ b/project/assets/main/nurikabe/official/generated/304.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/305.txt.info
+++ b/project/assets/main/nurikabe/official/generated/305.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 7.44

--- a/project/assets/main/nurikabe/official/generated/306.txt.info
+++ b/project/assets/main/nurikabe/official/generated/306.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.29

--- a/project/assets/main/nurikabe/official/generated/307.txt.info
+++ b/project/assets/main/nurikabe/official/generated/307.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 10.22

--- a/project/assets/main/nurikabe/official/generated/308.txt.info
+++ b/project/assets/main/nurikabe/official/generated/308.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.72

--- a/project/assets/main/nurikabe/official/generated/309.txt.info
+++ b/project/assets/main/nurikabe/official/generated/309.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.62

--- a/project/assets/main/nurikabe/official/generated/31.txt.info
+++ b/project/assets/main/nurikabe/official/generated/31.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/310.txt.info
+++ b/project/assets/main/nurikabe/official/generated/310.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.99

--- a/project/assets/main/nurikabe/official/generated/311.txt.info
+++ b/project/assets/main/nurikabe/official/generated/311.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.83

--- a/project/assets/main/nurikabe/official/generated/312.txt.info
+++ b/project/assets/main/nurikabe/official/generated/312.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.22

--- a/project/assets/main/nurikabe/official/generated/313.txt.info
+++ b/project/assets/main/nurikabe/official/generated/313.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.09

--- a/project/assets/main/nurikabe/official/generated/314.txt.info
+++ b/project/assets/main/nurikabe/official/generated/314.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 10.38

--- a/project/assets/main/nurikabe/official/generated/315.txt.info
+++ b/project/assets/main/nurikabe/official/generated/315.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 9.85

--- a/project/assets/main/nurikabe/official/generated/316.txt.info
+++ b/project/assets/main/nurikabe/official/generated/316.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/317.txt.info
+++ b/project/assets/main/nurikabe/official/generated/317.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/318.txt.info
+++ b/project/assets/main/nurikabe/official/generated/318.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.02

--- a/project/assets/main/nurikabe/official/generated/319.txt.info
+++ b/project/assets/main/nurikabe/official/generated/319.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 18.54

--- a/project/assets/main/nurikabe/official/generated/32.txt.info
+++ b/project/assets/main/nurikabe/official/generated/32.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.66

--- a/project/assets/main/nurikabe/official/generated/320.txt.info
+++ b/project/assets/main/nurikabe/official/generated/320.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.38

--- a/project/assets/main/nurikabe/official/generated/321.txt.info
+++ b/project/assets/main/nurikabe/official/generated/321.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.28

--- a/project/assets/main/nurikabe/official/generated/322.txt.info
+++ b/project/assets/main/nurikabe/official/generated/322.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.80

--- a/project/assets/main/nurikabe/official/generated/323.txt.info
+++ b/project/assets/main/nurikabe/official/generated/323.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 7.49

--- a/project/assets/main/nurikabe/official/generated/324.txt.info
+++ b/project/assets/main/nurikabe/official/generated/324.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.26

--- a/project/assets/main/nurikabe/official/generated/325.txt.info
+++ b/project/assets/main/nurikabe/official/generated/325.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.49

--- a/project/assets/main/nurikabe/official/generated/326.txt.info
+++ b/project/assets/main/nurikabe/official/generated/326.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.99

--- a/project/assets/main/nurikabe/official/generated/327.txt.info
+++ b/project/assets/main/nurikabe/official/generated/327.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.53

--- a/project/assets/main/nurikabe/official/generated/328.txt.info
+++ b/project/assets/main/nurikabe/official/generated/328.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 20.00

--- a/project/assets/main/nurikabe/official/generated/329.txt.info
+++ b/project/assets/main/nurikabe/official/generated/329.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 15.85

--- a/project/assets/main/nurikabe/official/generated/33.txt.info
+++ b/project/assets/main/nurikabe/official/generated/33.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.89

--- a/project/assets/main/nurikabe/official/generated/330.txt.info
+++ b/project/assets/main/nurikabe/official/generated/330.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.38

--- a/project/assets/main/nurikabe/official/generated/331.txt.info
+++ b/project/assets/main/nurikabe/official/generated/331.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.59

--- a/project/assets/main/nurikabe/official/generated/332.txt.info
+++ b/project/assets/main/nurikabe/official/generated/332.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.95

--- a/project/assets/main/nurikabe/official/generated/333.txt.info
+++ b/project/assets/main/nurikabe/official/generated/333.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.85

--- a/project/assets/main/nurikabe/official/generated/334.txt.info
+++ b/project/assets/main/nurikabe/official/generated/334.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 14.16

--- a/project/assets/main/nurikabe/official/generated/335.txt.info
+++ b/project/assets/main/nurikabe/official/generated/335.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.87

--- a/project/assets/main/nurikabe/official/generated/336.txt.info
+++ b/project/assets/main/nurikabe/official/generated/336.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.73

--- a/project/assets/main/nurikabe/official/generated/337.txt.info
+++ b/project/assets/main/nurikabe/official/generated/337.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.58

--- a/project/assets/main/nurikabe/official/generated/338.txt.info
+++ b/project/assets/main/nurikabe/official/generated/338.txt.info
@@ -1,1 +1,37 @@
-{"cells":64,"difficulty":5.9428609636219,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.94
+width 7
+height 7
+author 
+
+[solution]
+ . . .## . . . .
+ . . 6## .######
+######## 6## 1##
+ . . 3#### 3####
+###### 1## . .##
+## . 2##########
+######## . .## 1
+ . . 3## 4 .####
+
+[order]
+16 16 6 12 11 14 14 14
+16 16 - 2 5 1 0 7
+3 16 0 13 - 0 - 0
+17 2 - 0 0 - 0 7
+4 1 0 - 0 2 8 7
+2 2 - 0 18 9 3 0
+3 2 0 1 15 10 0 -
+3 2 - 0 - 19 1 0
+
+[reason]
+is is ix id ix ix ix ix
+is is - cb ix wx i1 ur
+ci iB ac wx - i1 - i1
+ix ix - i1 ac - i1 ur
+wx wx i1 - i1 ix p3 ur
+im ix - i1 wx im ci i1
+im im ac wx ix p3 i1 -
+ix ix - ac - ix wx i1

--- a/project/assets/main/nurikabe/official/generated/339.txt.info
+++ b/project/assets/main/nurikabe/official/generated/339.txt.info
@@ -1,1 +1,49 @@
-{"cells":84,"difficulty":0.0,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.00
+width 6
+height 11
+author 
+
+[solution]
+ 5 . .########
+ .###### 1## .
+ .## 2 .## . .
+############ .
+## . 3## 1## .
+## .## 1## 7 .
+##############
+## . . .## 2 .
+###### . 5####
+## .###### 1##
+## . . 4######
+######## . . 3
+
+[order]
+- 13 12 11 0 10 9
+16 14 3 0 - 0 9
+16 3 - 2 0 7 8
+16 14 0 1 0 6 5
+17 4 - 0 - 0 5
+16 18 0 - 0 - 4
+19 18 6 4 1 0 4
+21 21 21 5 0 - 4
+20 19 20 4 - 0 1
+18 19 15 6 0 - 0
+18 16 16 - 14 0 6
+18 18 15 14 14 14 -
+
+[reason]
+- ie p3 wx i1 wx im
+ix wx im i1 - i1 ix
+ix im - p3 i1 p3 ie
+im wx ac wx i1 wx ix
+wx ix - i1 - i1 ix
+ci ix ac - i1 - ix
+wx im wx i1 wx ac im
+im ix ix p3 ac - ix
+wx im wx ix - i1 wx
+wx ix wx id i1 - i1
+wx ix ix - im i1 wx
+wx wx wx im ix ix -

--- a/project/assets/main/nurikabe/official/generated/34.txt.info
+++ b/project/assets/main/nurikabe/official/generated/34.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.83

--- a/project/assets/main/nurikabe/official/generated/340.txt.info
+++ b/project/assets/main/nurikabe/official/generated/340.txt.info
@@ -1,1 +1,46 @@
-{"cells":77,"difficulty":3.90468038035029,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.90
+width 6
+height 10
+author 
+
+[solution]
+#### . .######
+## 1## 3## .##
+########## .##
+## .## .## .##
+## 2## 2## .##
+ 2## 1## 6 .##
+ .############
+## 1## 1## .##
+#### 8#### .##
+## . . . . .##
+##############
+
+[order]
+5 0 19 19 18 16 17
+0 - 0 - 16 16 16
+3 0 3 2 15 16 15
+1 2 1 2 2 14 15
+0 - 0 - 0 14 6
+- 0 - 0 - 4 6
+2 0 0 0 3 13 6
+0 - 0 - 2 13 13
+3 0 - 0 10 13 12
+8 7 2 9 9 11 12
+8 6 6 6 10 10 12
+
+[reason]
+wb i1 ix ix wx im wx
+i1 - i1 - im ix im
+wx i1 wx im wx ix wx
+wx ix wx ix im ix wx
+ac - i1 - ac ix ic
+- i1 - i1 - ix ic
+ix i1 i1 i1 wx im ic
+i1 - i1 - i1 ix im
+wx i1 - i1 wx ix wx
+wx pk ix ix ix ix wx
+wx ic ic ic wx wx wx

--- a/project/assets/main/nurikabe/official/generated/341.txt.info
+++ b/project/assets/main/nurikabe/official/generated/341.txt.info
@@ -1,1 +1,46 @@
-{"cells":66,"difficulty":3.47141080896037,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.47
+width 5
+height 10
+author 
+
+[solution]
+###### 2## .
+## 1## .## .
+########## .
+ . 2## 1## 4
+######## 3##
+ 4 .## . .##
+ . .########
+###### 1## 6
+## . .#### .
+## 3#### . .
+#### 1## . .
+
+[order]
+7 0 9 - 3 10
+0 - 0 8 9 2
+14 0 7 0 1 2
+16 - 0 - 0 -
+2 15 6 0 - 0
+- 15 5 5 2 1
+15 11 14 0 4 4
+4 11 0 - 0 -
+1 2 12 0 17 5
+1 - 0 13 18 19
+1 0 - 0 20 20
+
+[reason]
+wb i1 im - ci ix
+i1 - i1 p3 im ix
+ur i1 wb i1 wx ix
+ix - i1 - i1 -
+ci iB wx i1 - ac
+- is im ix ix wx
+is ik wb i1 wx wx
+wx iB i1 - i1 -
+wx ix ix i1 wx ix
+wx - i1 wx p3 ix
+wx i1 - i1 is is

--- a/project/assets/main/nurikabe/official/generated/342.txt.info
+++ b/project/assets/main/nurikabe/official/generated/342.txt.info
@@ -1,1 +1,58 @@
-{"cells":120,"difficulty":2.56313364960537,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 2.56
+width 7
+height 14
+author 
+
+[solution]
+######## . . 3##
+## . .##########
+## 3## 2 .## 1##
+ .##############
+ .## . .## .## .
+ 3## .#### 2## .
+## 5 .## .#### .
+######## . 3## .
+ .## 6 .###### 5
+ . 3## .## . 7##
+###### .## .####
+ 1## . .## .## 4
+########## .## .
+ .## .## . .## .
+ 2## 2######## .
+
+[order]
+30 30 29 32 33 34 - 35
+26 28 31 27 25 35 0 36
+25 - 0 - 26 0 - 0
+25 3 24 23 25 10 0 11
+2 24 23 22 7 10 10 11
+- 0 23 21 8 - 6 11
+0 - 9 8 8 0 10 5
+1 20 2 7 5 - 4 2
+19 0 - 4 7 4 0 -
+19 - 0 8 10 2 - 0
+0 18 10 11 12 11 1 1
+- 0 16 13 14 13 12 -
+0 4 15 17 37 15 14 13
+2 0 16 2 38 39 18 15
+- 0 - 17 39 39 16 19
+
+[reason]
+wx wx ci wx p3 ie - im
+wx ix ix im ci im i1 wx
+im - ac - p3 i1 - i1
+ix ci im id wx im i1 im
+ix im ix p3 ci ix im ix
+- ac ix wx im - cb ix
+ac - p3 im ix ac wx ix
+wx wx cb id ix - id ix
+ix ac - ix id id ac -
+ix - ac ix id ix - ac
+i1 wx wx ix id ix wx wx
+- i1 p3 ix id ix wx -
+i1 wx ci im wx ix wx ix
+ix ci p3 ci p3 ix wx ix
+- ac - im wx wx ci ix

--- a/project/assets/main/nurikabe/official/generated/343.txt.info
+++ b/project/assets/main/nurikabe/official/generated/343.txt.info
@@ -1,1 +1,52 @@
-{"cells":91,"difficulty":20.0,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 20.00
+width 6
+height 12
+author 
+
+[solution]
+ .########## 1
+ .## 3 . .####
+ . 7###### 1##
+ . . .## 1####
+############ .
+## 4 . . .## .
+ .########## .
+ 3## 8 . . . .
+ .############
+#### . .## .##
+ 5 . .#### .##
+######## . .##
+10 . . . . .##
+
+[order]
+26 15 11 11 8 0 -
+16 0 - 10 9 0 0
+14 - 0 11 0 - 2
+20 17 12 0 - 0 8
+25 17 19 13 0 27 28
+24 - 19 21 26 26 29
+24 18 19 22 26 30 29
+- 0 - 32 32 32 31
+3 23 32 33 33 33 32
+3 4 33 35 35 36 40
+- 5 5 34 37 39 40
+0 1 6 6 38 39 40
+- 2 2 7 7 41 39
+
+[reason]
+ix wb im im ur i1 -
+pk ac - ie p3 i1 i1
+pk - ac im i1 - i1
+ix ix p3 i1 - i1 ur
+wx iB iB wx i1 wx p3
+im - ix ix ix im ie
+ix Bw iB Bj im wx ie
+- ac - ul ul ul ie
+ix Bw uL im im im uL
+iB wx p3 ix im p3 wx
+- ix ix Bj wb ul wx
+ac wx wx wx p3 ul wx
+- ix ix ix ix ix uL

--- a/project/assets/main/nurikabe/official/generated/344.txt.info
+++ b/project/assets/main/nurikabe/official/generated/344.txt.info
@@ -1,1 +1,37 @@
-{"cells":48,"difficulty":5.47335888699271,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.47
+width 5
+height 7
+author 
+
+[solution]
+ . . . . 9##
+ .##########
+ .## . . . .
+ .######## 5
+ .## . . 3##
+############
+## . . 3## .
+######## 3 .
+
+[order]
+24 24 24 20 - 25
+24 23 15 21 3 12
+19 22 22 13 13 2
+17 18 7 14 0 -
+16 15 15 6 - 0
+11 5 8 2 4 1
+9 9 4 - 0 2
+10 6 1 0 - 2
+
+[reason]
+ie ie ie ix - im
+ie wx ci id cb ic
+ie im ix ix ix ix
+ie wx ci wx ac -
+p3 im ix ix - ac
+wx ci wx cb wx wx
+im ix ix - ac ix
+wx wx wx ac - ix

--- a/project/assets/main/nurikabe/official/generated/345.txt.info
+++ b/project/assets/main/nurikabe/official/generated/345.txt.info
@@ -1,1 +1,43 @@
-{"cells":120,"difficulty":2.94310822116729,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 2.46
+width 11
+height 9
+author 
+
+[solution]
+ .######################
+ .## . . . . . . .## .##
+ .## .##########10## 2##
+ 6## .## . . . 4## 3####
+ .################ . .##
+ .## . . .## . . 3#### 1
+#### 4############## 3##
+## 1## . . .## .## . .##
+########## .## .########
+ . . . 4## 5## 3## . . 3
+
+[order]
+36 21 21 17 17 13 13 10 10 9 7 9
+36 33 19 19 15 15 11 11 2 1 7 2
+32 31 34 18 17 13 13 0 - 0 - 6
+- 35 24 17 17 17 4 - 0 - 0 5
+29 30 23 23 17 16 15 3 1 2 4 0
+28 23 21 22 18 15 15 15 - 3 0 -
+27 0 - 20 21 17 14 13 13 5 - 0
+0 - 0 22 19 2 13 13 11 11 7 1
+26 0 25 21 1 2 1 13 12 8 9 9
+26 26 22 - 0 - 0 - 11 11 11 -
+
+[reason]
+ix wx wx wx wx wx wx wx wx wx im wx
+ix ic ix ix ix ix ix ix ix wx ix ci
+ix wb ix wx im wx wx ac - ac - wx
+- im p3 im ix ix ix - ac - ac wx
+ie wx im im im wx im wx wx ix ix i1
+p3 im ix ie p3 im ix ix - id i1 -
+wx i1 - ci id wx wx im wx wx - i1
+i1 - i1 ix ix ix im ix im ix ix wx
+im i1 wx wx wx ix wx ix wx ci cb wx
+ix ix ix - ac - ac - im ix ix -

--- a/project/assets/main/nurikabe/official/generated/346.txt.info
+++ b/project/assets/main/nurikabe/official/generated/346.txt.info
@@ -1,1 +1,31 @@
-{"cells":54,"difficulty":12.4577623468225,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 11.90
+width 8
+height 5
+author 
+
+[solution]
+ . . .## . 3######
+ . . .## .#### 1##
+ . .###### . 2####
+ .10## . 2###### 1
+############ .####
+## . . . 4## 4 . .
+
+[order]
+23 23 23 17 13 - 17 0 4
+23 23 22 15 16 9 0 - 0
+23 23 21 3 9 9 - 0 0
+14 - 10 10 - 2 8 0 -
+20 12 18 10 0 1 7 6 0
+19 19 11 2 - 0 - 5 9
+
+[reason]
+is is is im ix - im i1 wb
+is is p3 iC p3 im i1 - i1
+is is wx ci im ix - i1 i1
+Bi - im ix - ci id i1 -
+wx ci wx im ac wx ix ic i1
+im ix ix ix - ac - ix ix

--- a/project/assets/main/nurikabe/official/generated/347.txt.info
+++ b/project/assets/main/nurikabe/official/generated/347.txt.info
@@ -1,1 +1,82 @@
-{"cells":414,"difficulty":5.97500080696052,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.98
+width 17
+height 22
+author 
+
+[solution]
+ 7 . . . . . .#### . . . . 5########
+################ 1############ . .##
+ 3## 3 . .## . 2#### . . . .## .####
+ . .############## 1###### .## .## .
+#### 1## .## . .###### .## .## .## .
+ 2###### 2## . . . .## .## 7## .## .
+ .## .############ 7## . .#### .## .
+#### 4 . .## . . 3## 1## .## . .## .
+ 7 .#################### 6##10#### .
+ . . . .## .## . . . . 5###### .## .
+###### .## 2############ .## . .## 8
+ 7## 1###### . 5## . 2## 2## 4######
+ .###### . . .## 1#### .## 4## 2 .##
+ .## . 3############ 3 .## .########
+ .## .#### . 4## . 2###### . .##11 .
+ .#### 1## .## 3###### . 5####10## .
+ . .###### .## .## . . .#### . .## .
+#### 1## 3#### .########## . .#### .
+## 3#### . .###### . . . . .##10## .
+## . .######## 1############## .## .
+###### 1## 2 .## . . . . . . . .## .
+## .############################## .
+## . . . . . . . . . . . . .15## . .
+
+[order]
+- 2 2 5 9 9 15 15 0 70 70 67 67 - 66 66 31 68
+0 1 4 7 7 12 10 0 - 0 68 69 66 29 29 30 67 67
+- 0 - 5 9 9 13 - 0 0 69 67 30 28 29 28 29 28
+2 5 0 7 9 64 2 14 0 - 0 22 25 28 27 28 26 28
+4 0 - 0 10 11 65 71 70 0 20 22 21 23 27 25 27 25
+- 7 0 11 - 11 65 72 22 2 21 19 16 - 22 25 23 25
+9 5 8 79 11 64 8 23 0 - 0 19 15 3 16 21 23 22
+9 10 - 79 65 25 25 7 - 0 - 0 2 12 12 19 20 22
+- 83 74 80 80 75 21 7 5 1 0 0 - 0 - 9 21 19
+83 74 74 74 15 76 7 7 4 4 4 - 0 4 4 9 6 19
+83 75 0 78 77 - 2 7 5 2 2 2 2 1 2 5 7 -
+- 0 - 0 21 12 9 - 0 4 - 0 - 0 - 0 7 17
+79 66 0 22 22 19 15 0 - 0 0 33 0 - 0 - 15 15
+79 81 23 - 20 21 16 16 0 0 - 2 4 2 1 12 2 16
+79 24 82 0 34 19 - 0 17 - 0 32 3 5 9 0 - 4
+73 84 0 - 0 35 0 - 2 18 34 30 - 7 6 - 0 19
+86 85 0 0 35 35 35 4 49 49 49 35 29 23 22 7 21 19
+87 0 - 0 - 35 36 50 37 49 48 48 37 28 25 9 21 22
+58 - 0 55 37 54 53 0 49 49 49 47 47 38 27 - 23 22
+58 57 56 0 55 55 0 - 0 49 48 48 46 46 39 28 27 25
+75 58 0 - 0 - 60 0 52 49 49 47 47 45 45 40 29 28
+75 76 88 0 62 61 59 53 50 51 48 48 46 46 41 44 42 30
+79 89 63 63 63 60 59 52 52 49 49 47 47 45 - 43 43 43
+
+[reason]
+- ix ix ix ix ix ix im i1 ix ix ix ix - ic ic ci wx
+ac wx id wx wx wx ci i1 - i1 ci wx ic id wx ix ix im
+- ac - ix ix im p3 - i1 i1 p3 ix ix ix wx ix wx im
+ix ix i1 wx im wb ci im i1 - i1 im wx ix wx ix ci ix
+id i1 - i1 p3 im p3 p3 wx i1 ci ix wx ix wx ix wx ix
+- wx i1 im - im p3 ie ix ix wx ix id - wx ix wx ix
+ix ci p3 uL im wb ci wx ac - i1 ix ix cb wx ix wx ix
+im wx - ul p3 im ix ix - i1 - i1 ix wx ix ix cb ix
+- is iB im im ur wx im id wx i1 ac - ac - im wx ix
+is ik ik ik ci p3 im ix ix ix ix - ac wx id ix ci ix
+iB wb i1 p3 im - cb im wx ci cb im ix wx ix ix id -
+- i1 - i1 wx id ix - i1 ix - ac - ac - ac wx wx
+ul ic i1 im ix ix ix i1 - i1 ac ix ac - ac - ix im
+ul id ix - ci id id wx i1 ac - ix id ix wx wx ci wx
+ul ci ix i1 wx ix - ac p3 - ac id cb ix ix ac - ix
+pk wx i1 - i1 ix ac - ci im wx ix - id ci - ac ix
+ie p3 i1 i1 im ix im ix im ix ix ix wx wx ix ix wx ix
+im i1 - i1 - im wx p3 ci im wx wx wx ix ix id wx ix
+im - i1 im ix p3 wx i1 im ix ix ix ix ix id - id ix
+im ie p3 i1 im im i1 - i1 im wx wx wx wx wx ix wx ix
+ur im i1 - i1 - p3 i1 ix ix ix ix ix ix ix ix wx ix
+ur p3 wx i1 wx im ci wx ci wx wx wx wx wx cb wx wx ix
+uL ix ix ix ix ix ix ix ix ix ix ix ix ix - im ix ix

--- a/project/assets/main/nurikabe/official/generated/348.txt.info
+++ b/project/assets/main/nurikabe/official/generated/348.txt.info
@@ -1,1 +1,46 @@
-{"cells":88,"difficulty":3.12288922668285,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.12
+width 7
+height 10
+author 
+
+[solution]
+ . . . . 5######
+########## 3## 4
+ 1## .## . .## .
+#### .######## .
+## . .## . .## .
+## 5#### 3######
+ 4## 2 .## 2 .##
+ .##############
+ .## 6 . . . . .
+ .##############
+#### 6 . . . . .
+
+[order]
+20 20 20 2 - 0 1 25
+0 9 8 18 0 - 0 -
+- 0 8 8 19 2 18 24
+0 4 8 7 18 8 23 22
+1 2 5 7 4 20 20 21
+0 - 0 2 - 0 13 17
+- 0 - 2 0 - 13 13
+2 1 0 2 4 12 2 16
+2 4 - 5 9 11 13 16
+5 3 0 8 10 12 15 14
+5 6 - 7 9 11 13 16
+
+[reason]
+ix ix ix ix - ac wx im
+i1 wx im ic ac - ac -
+- i1 ix im p3 ix ic ie
+i1 wx ix wx ic ci wx ie
+wx ix ix wx ix ix im p3
+ac - ac im - ac im wx
+- ac - ix ac - ix im
+ix wx ac im wx id ci im
+ix id - ix ix ix ix ix
+ix ci ac id id id id ci
+im wx - ix ix ix ix ix

--- a/project/assets/main/nurikabe/official/generated/349.txt.info
+++ b/project/assets/main/nurikabe/official/generated/349.txt.info
@@ -1,1 +1,34 @@
-{"cells":49,"difficulty":2.3548521065093,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 2.35
+width 6
+height 6
+author 
+
+[solution]
+ .###### 3 . .
+ .## .########
+ 3## 2## 1## 6
+## 3## 1#### .
+## .###### . .
+## .## .## . .
+###### 2######
+
+[order]
+2 2 2 3 - 6 6
+2 1 2 1 0 4 6
+- 0 - 0 - 0 -
+0 - 0 - 0 7 9
+1 2 1 2 5 8 9
+2 2 2 3 6 10 13
+3 2 4 - 6 12 11
+
+[reason]
+ix im im wx - ix ix
+ix wx ix wx i1 wx im
+- ac - i1 - i1 -
+ac - ac - i1 wx ix
+wx ix wx i1 wx p3 ix
+im ix im p3 im Bi ix
+wx im wx - im wx ci

--- a/project/assets/main/nurikabe/official/generated/35.txt.info
+++ b/project/assets/main/nurikabe/official/generated/35.txt.info
@@ -1,7 +1,7 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
-difficulty 2.57
+difficulty 3.10
 width 9
 height 10
 author poobslag v02
@@ -26,11 +26,11 @@ author poobslag v02
 3 3 2 7 7 7 0 12 7 12
 4 10 8 - 0 0 - 0 14 12
 11 10 11 0 - 0 0 - 13 16
-11 12 11 12 0 19 19 14 16 16
-14 12 14 27 27 - 18 19 17 16
-14 16 28 15 20 25 20 19 - 20
-18 29 28 31 26 23 23 23 21 20
-30 30 30 30 32 24 23 22 22 22
+11 12 11 12 0 20 20 14 16 16
+14 12 14 27 27 - 18 20 17 16
+14 16 28 15 21 25 21 20 - 21
+18 29 28 31 26 24 24 24 22 21
+30 30 30 30 32 25 19 23 23 23
 
 [reason]
 - wx ac - ix id - ix im -
@@ -43,4 +43,4 @@ ix wx ix wx i1 iB is ix im ix
 ix wx ix im ix - cb is wx im
 ix wx ix ci ci wx wx iB - wx
 ix wx im wx p3 im ix ix ix wx
-ix ix ix ix ix wx im wx wx wx
+ix ix ix ix ix wx ur wx wx wx

--- a/project/assets/main/nurikabe/official/generated/350.txt.info
+++ b/project/assets/main/nurikabe/official/generated/350.txt.info
@@ -1,1 +1,37 @@
-{"cells":64,"difficulty":16.1599101409853,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 16.13
+width 7
+height 7
+author 
+
+[solution]
+ . 3## 1## 1## .
+ .############ .
+## 4 . . .## . .
+############ . .
+## .## 1## 9 . .
+## . .##########
+## 4#### . . . .
+####10 . . . . .
+
+[order]
+2 - 0 - 0 - 2 26
+2 0 1 0 1 0 15 17
+2 - 7 7 7 7 16 18
+3 6 6 0 7 19 26 26
+4 5 0 - 0 - 13 23
+1 2 7 0 10 12 22 25
+1 - 0 8 11 21 24 14
+1 0 - 2 9 20 24 24
+
+[reason]
+ix - i1 - i1 - i1 is
+ix ac wx i1 wx i1 Bh pk
+im - ix ix ix im p3 ul
+wx wx wx i1 im ic is is
+wx ix i1 - i1 - Bi ix
+wx ix ix i1 Bw Bg Bg im
+wx - ac wx p3 Bi is ik
+wx ac - ix ix Bi is is

--- a/project/assets/main/nurikabe/official/generated/351.txt.info
+++ b/project/assets/main/nurikabe/official/generated/351.txt.info
@@ -1,1 +1,40 @@
-{"cells":90,"difficulty":7.98148034491965,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 8.41
+width 9
+height 8
+author 
+
+[solution]
+ . . 4## 4## 2 .####
+ .###### .###### 1##
+## . 3## . .## .####
+## .########## 3 .##
+#### 2 .## .########
+ 3######## .## . . 3
+ . .## .## 3########
+###### .#### 3 . .##
+ 1## . . . 6########
+
+[order]
+7 2 - 0 - 0 - 20 0 21
+7 6 0 1 2 1 18 0 - 0
+7 5 - 4 2 17 17 19 0 22
+7 8 0 8 15 5 21 - 31 32
+9 8 - 14 14 16 29 32 23 33
+- 10 12 9 24 28 29 33 35 -
+11 11 11 13 27 - 0 34 3 36
+0 11 24 26 1 0 - 2 35 35
+- 0 25 2 2 - 0 1 4 30
+
+[reason]
+ix ix - ac - ac - ix i1 wx
+ix id ac wx ix wx wx i1 - i1
+im ix - id ix ix im p3 i1 wx
+ci ix ac wx wx ci wx - Bi im
+wx im - ix im p3 im im ci wx
+- wx wx ci ic ix im p3 ie -
+ix ix im p3 im - ac id ci wx
+i1 im ic ix wx ac - ix ix im
+- i1 p3 ix ix - ac wx wx ur

--- a/project/assets/main/nurikabe/official/generated/352.txt.info
+++ b/project/assets/main/nurikabe/official/generated/352.txt.info
@@ -1,1 +1,46 @@
-{"cells":99,"difficulty":3.08662646985114,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.09
+width 8
+height 10
+author 
+
+[solution]
+##################
+ . .## . 2## 2 .##
+ .############## 1
+ 4## .## . . 3####
+#### .######## .##
+ . 7 .## . .## .##
+ .######## .## .##
+ .## . 2## 4## 4##
+######## 1## 2####
+## . 2###### .## .
+###### . 2#### 3 .
+
+[order]
+35 28 33 13 35 32 31 2 29
+27 34 33 34 - 0 - 30 0
+27 25 24 27 12 26 0 0 -
+- 24 24 24 25 11 - 9 0
+22 23 24 20 9 11 8 9 8
+21 - 15 13 13 2 8 7 8
+18 19 2 14 1 2 1 7 6
+17 16 16 - 0 - 0 - 6
+10 7 7 0 - 0 - 0 5
+8 8 - 4 0 1 2 2 5
+9 6 5 5 - 3 2 - 5
+
+[reason]
+im ci ur ci im wx im ci wb
+ix p3 ur p3 - ac - p3 i1
+ix wx im wx ci im ac i1 -
+- im ix im p3 ix - im i1
+id wx ix wx ci wx wx ix wx
+ie - p3 im ix ix wx ix wx
+ie wx ci wx wx ix wx ix wx
+p3 im ix - i1 - ac - wx
+wx ci wx i1 - i1 - ac im
+im ix - wx i1 wx ix im ix
+wx wx im ix - wx im - ix

--- a/project/assets/main/nurikabe/official/generated/353.txt.info
+++ b/project/assets/main/nurikabe/official/generated/353.txt.info
@@ -1,1 +1,46 @@
-{"cells":132,"difficulty":9.79242634840276,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 10.07
+width 11
+height 10
+author 
+
+[solution]
+ . . . .###### . . . . .
+ .######## . .## . . . 9
+ .## . .#### 3##########
+ .## . . . .## 3 . .## 1
+ .## 8#### .############
+ .#### 1###### . .## .##
+ .## 2## 1## . .#### .##
+11## .###### 5#### 5 .##
+######## . .## 2 .## .##
+ 2## 2## 3##############
+ .## .#### 6 . . . . .##
+
+[order]
+48 47 46 45 39 37 36 36 36 36 36 36
+42 47 46 44 38 38 35 36 36 36 36 -
+8 41 43 45 39 34 - 0 28 28 1 0
+6 7 6 40 33 33 0 - 27 25 0 -
+4 5 - 0 31 32 34 26 28 24 18 0
+4 1 0 - 0 31 30 29 25 23 19 20
+4 2 - 0 - 2 8 25 24 21 22 17
+- 2 4 1 2 7 - 0 4 - 16 15
+0 1 4 6 2 7 0 - 4 4 12 15
+- 0 - 0 - 0 8 3 2 11 10 14
+2 2 5 1 0 - 2 9 9 9 13 13
+
+[reason]
+ie ie ie p3 wx wx iB is is is is is
+ix wx im ci im ix ix iB is is is -
+ix wx Bi p3 wx id - ac im im wx i1
+ix id ix ie ul ul ac - ix p3 i1 -
+ix id - i1 wb p3 wx cb im iC iC i1
+ix wx i1 - i1 wb im ie p3 im pk Bh
+ix cb - i1 - i1 ix p3 iC cb ix wx
+- ci ix wx i1 im - ac im - ie wx
+ac wx im wx ix ix ac - ix im p3 wx
+- ac - ac - ac wx cb ci wx ci wx
+ix im ix wx ac - ix ix ix ix ix im

--- a/project/assets/main/nurikabe/official/generated/354.txt.info
+++ b/project/assets/main/nurikabe/official/generated/354.txt.info
@@ -1,1 +1,34 @@
-{"cells":42,"difficulty":6.86761875601296,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 6.87
+width 5
+height 6
+author 
+
+[solution]
+ . .###### .
+ .#### 1## .
+ .## .#### 3
+ .## . . 4##
+ .##########
+ . .## . . .
+ .10## 6 . .
+
+[order]
+16 15 12 0 2 2
+13 14 0 - 0 2
+13 8 11 0 0 -
+9 10 7 7 - 0
+13 14 5 4 6 1
+17 15 1 3 6 6
+18 - 0 - 6 6
+
+[reason]
+ie p3 wx i1 im ix
+ik wb i1 - i1 ix
+ik ci ix i1 ac -
+pk id ix ix - ac
+ik wb wb cb iB wx
+ie p3 wx ix is is
+ix - ac - is is

--- a/project/assets/main/nurikabe/official/generated/355.txt.info
+++ b/project/assets/main/nurikabe/official/generated/355.txt.info
@@ -1,1 +1,58 @@
-{"cells":180,"difficulty":7.88135208584615,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 7.88
+width 11
+height 14
+author 
+
+[solution]
+ 3## . .#### 3 .## 5 . .
+ .## 3#### 4## .###### .
+ .#### 3## .#### 6 .## .
+##10## .## .## 1## .####
+## .## .## .###### .## 3
+## .########## .## .## .
+## . .## . . . .## .## .
+## . .## .##############
+## .#### 7## .## .## .##
+## .## 1#### .## .## .##
+## .#### . . .## 4## .##
+#### .## .###### .## .##
+## . 4## 7## 2 .## 6 .##
+## .###### .############
+###### 1## 2## 5 . . . .
+
+[order]
+- 4 2 5 1 0 - 2 4 - 5 8
+5 0 - 0 7 - 0 5 3 2 7 8
+5 5 0 - 2 8 7 0 - 4 8 8
+5 - 5 4 10 8 0 - 0 10 9 8
+6 7 6 11 7 11 10 0 11 10 11 -
+8 7 12 11 12 11 22 23 24 12 11 12
+8 14 32 31 32 37 37 25 13 25 12 12
+15 33 27 26 30 37 37 37 42 25 22 12
+34 33 22 0 - 29 38 39 43 49 23 22
+34 35 0 - 0 17 28 39 48 49 37 37
+35 35 35 0 16 16 28 28 - 41 37 51
+36 35 40 39 2 4 17 2 50 50 37 37
+46 44 - 0 - 0 - 18 18 - 52 37
+45 47 42 0 1 2 1 4 19 6 52 21
+22 47 0 - 0 - 0 - 5 20 20 53
+
+[reason]
+- id ix ix wx ac - ix id - ix ix
+ix cb - ac wx - ac ix ci cb wx ix
+ix im ac - cb ix wx i1 - ix im ix
+im - id ix wx ix i1 - i1 ix wx im
+wx ix wx ix ci ix wx i1 wx ix wx -
+wx ix wx im wx im iC p3 id ix wx ix
+wx ix p3 wb p3 ul ul ie ci ix im ix
+wx ix p3 uL ix uL uL uL ic im ur im
+wx ix wb i1 - wx p3 im p3 id p3 ur
+wx ix i1 - i1 wx ik im ix id ul uL
+im ix im i1 ix ik ix iB - id ul wx
+wx im p3 im ix wx wx ci ix im ul uL
+wx ix - ac - ac - ix im - ix uL
+ci ix ic i1 wx ix wx wx wx cb wx ci
+ur im i1 - i1 - ac - ix ix ix ix

--- a/project/assets/main/nurikabe/official/generated/356.txt.info
+++ b/project/assets/main/nurikabe/official/generated/356.txt.info
@@ -1,1 +1,37 @@
-{"cells":48,"difficulty":7.91325229131741,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 7.91
+width 5
+height 7
+author 
+
+[solution]
+ . 2####11 .
+###### 1## .
+## .###### .
+## .## . . .
+## .## . . .
+## 4###### .
+#### 4## 1##
+ . . .######
+
+[order]
+16 - 1 0 - 2
+2 15 0 - 0 2
+10 15 9 0 3 2
+11 15 13 12 14 4
+6 7 14 14 14 12
+6 - 0 10 0 14
+6 0 - 0 - 0
+16 8 2 15 0 5
+
+[reason]
+ix - wx i1 - ix
+ci im i1 - i1 ix
+ur ix wv i1 wx ix
+ic ix cb ik is ix
+ic ix iB is is ix
+ic - ac iC i1 is
+ic ac - i1 - i1
+ix ix ix wx i1 wb

--- a/project/assets/main/nurikabe/official/generated/357.txt.info
+++ b/project/assets/main/nurikabe/official/generated/357.txt.info
@@ -1,1 +1,49 @@
-{"cells":84,"difficulty":0.0897194087421695,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.09
+width 6
+height 11
+author 
+
+[solution]
+ .###### 5 . .
+ .## . 3#### .
+ 3## .## 1## .
+##############
+ .## .## 2## 3
+ 2## 2## .## .
+## 5## 3#### .
+## .## . .####
+## .###### 3##
+## .## 2## .##
+## .## .## .##
+##############
+
+[order]
+6 6 1 0 - 2 2
+6 5 2 - 0 1 2
+- 3 4 0 - 0 2
+2 3 2 6 0 3 2
+2 1 2 2 - 0 -
+- 0 - 0 6 6 6
+0 - 0 - 6 7 7
+1 2 1 8 11 11 7
+6 2 10 10 9 - 12
+6 11 8 - 15 14 12
+11 11 11 16 11 16 15
+12 11 13 16 17 16 18
+
+[reason]
+ix im wx ac - ix ix
+ix im ix - i1 wx ix
+- ci p3 i1 - i1 ix
+im wx im wx i1 wx im
+ix wx ix im - ac -
+- ac - ac ix im ix
+ac - ac - im wx ix
+wx ix wx ix ix im im
+wx ix wx id ci - wx
+wx ix cb - id ix wx
+im ix im ix ci ix wx
+wx im wx im wx im wx

--- a/project/assets/main/nurikabe/official/generated/358.txt.info
+++ b/project/assets/main/nurikabe/official/generated/358.txt.info
@@ -1,1 +1,40 @@
-{"cells":90,"difficulty":1.68388572014226,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 1.68
+width 9
+height 8
+author 
+
+[solution]
+ .## .##############
+ .## 2## 1## .## 1##
+ 3######## 3 .######
+#### 3 .###### . .##
+ . .## .## 1## .## .
+ 3########## . 5## 2
+## 1## . .##########
+######## 5 . .## 1##
+## . . 3########## 1
+
+[order]
+7 2 6 6 0 15 13 15 0 9
+7 5 - 0 - 0 13 0 - 0
+- 6 0 8 0 - 2 12 0 9
+4 3 - 6 16 0 12 11 10 2
+2 5 5 17 0 - 0 13 2 2
+- 0 6 17 20 0 17 - 0 -
+0 - 0 18 19 22 14 15 0 1
+1 0 20 0 - 23 16 0 - 0
+21 21 2 - 0 1 24 1 0 -
+
+[reason]
+ix ci ix im i1 wx im wx i1 wb
+ix cb - i1 - i1 ix i1 - i1
+- wx ac wx i1 - ix id i1 wb
+id ci - ix wx i1 id ie p3 im
+ix ix im ix i1 - i1 ie im ix
+- i1 wx im wx i1 ix - ac -
+i1 - i1 p3 ie wx ci wx i1 wx
+wx i1 wx ac - ix p3 i1 - i1
+im ix ix - ac wx im wx i1 -

--- a/project/assets/main/nurikabe/official/generated/359.txt.info
+++ b/project/assets/main/nurikabe/official/generated/359.txt.info
@@ -1,1 +1,61 @@
-{"cells":480,"difficulty":5.48725170711538,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.49
+width 29
+height 15
+author 
+
+[solution]
+ . . . . . 7######## 7 .## 4## 3## 7## 6 . . . . .######## 5
+ .############ 1## 2## .## .## .## .############## 4 . .## .
+#### . . . . .#### .## .## .## .## .## 4## 3 . .###### .## .
+## . .###### 8##10#### .## .###### .## . .######## 1###### .
+######## 1#### . .## . .#### 3 .## . .## .## 3 . .## 2 .## .
+## . . 3## . . .########## 6## .#### .#### 5################
+########## .###### . . . . .#### 9#### 8## .## 3## 2 .## 1##
+## . . 3## .## .10########## 2## . .## .## .## . .######## .
+######## . .## .#### . . 3## .#### .## .## . .#### 2 .## . .
+## . 7######## .## 4###### 6## 6## .## .######## .###### . .
+## .## . . 4## .## .## 6## .## .## .## . . . .## 2## . . . .
+## .## .#### . .## .## .## .## .## .################ . . . .
+## .#### 2## .#### .## .## .## .## .## . . .## . . . . . . .
+## . .## .## .## 3#### .## .## .## .## .###### . . . . . . .
+############ .## . .## .## .## .###### 8## 1## . . . . . . .
+## . 2## 1############ .########## . . .####42 . . . . . . .
+
+[order]
+47 44 44 41 41 - 39 0 1 0 - 2 5 - 0 - 0 - 0 - 2 20 20 23 24 24 25 27 31 -
+47 46 42 42 40 39 0 - 0 - 0 7 6 7 1 2 1 2 1 0 19 3 22 23 24 - 26 29 30 33
+47 48 44 41 41 38 38 0 2 2 2 7 9 7 2 2 2 2 5 - 0 - 23 23 23 0 27 28 30 33
+54 54 49 42 0 37 - 0 - 2 9 10 8 10 9 2 3 7 9 7 20 22 5 23 0 - 0 5 29 33
+55 44 51 0 - 0 29 27 5 20 20 10 12 0 - 10 12 10 17 19 23 0 - 7 26 0 - 5 5 33
+54 54 2 - 0 35 35 31 26 21 14 19 13 - 0 14 11 15 20 18 23 - 0 9 26 4 2 2 0 33
+56 43 42 0 37 35 33 33 23 23 20 20 17 14 15 14 - 22 20 - 2 26 27 - 0 - 3 0 - 0
+43 43 42 - 36 38 37 26 - 21 22 19 19 15 - 16 23 27 29 22 27 29 31 29 87 0 4 88 0 91
+57 43 37 41 41 38 39 38 24 23 23 20 - 0 17 17 26 31 29 31 31 33 83 83 33 - 87 87 89 91
+61 59 - 58 41 39 39 41 39 - 21 22 0 - 0 - 33 31 33 32 35 81 34 75 84 85 35 90 91 91
+61 62 58 54 54 - 42 41 42 41 42 - 5 2 19 35 33 35 33 37 78 83 86 85 - 85 86 91 91 91
+63 62 59 59 44 51 49 44 42 44 46 44 46 20 37 35 37 35 38 77 82 84 84 88 85 90 91 91 91 91
+63 65 63 53 - 50 54 48 46 47 45 47 48 47 37 38 37 39 77 77 84 84 84 89 91 91 91 91 91 91
+66 65 64 51 52 53 54 58 - 47 71 49 51 49 48 38 41 78 40 74 76 0 87 91 91 91 91 91 91 91
+67 2 65 1 0 59 59 55 59 70 70 72 50 54 42 49 49 78 81 - 0 - 0 91 91 91 91 91 91 91
+68 68 - 0 - 0 59 61 69 60 71 72 72 54 58 49 73 79 80 83 1 0 - 2 91 91 91 91 91 91
+
+[reason]
+ix ix ix ix ix - wx i1 wx ac - ix id - ac - ac - ac - ix ix ix ix ix im wx wx wx -
+ix wx wx wx wx id i1 - i1 - ac ix wx ix wx ix wx ix wx ac wx cb wx im wx - ix ix im ix
+im wx ix ix ix ix ix i1 im ix im ix wx ix im ix im ix id - ac - ix ix im i1 wx p3 im ix
+im ix ix wx i1 wx - ac - im wx ix ci ix wx im wx ix id ix ix id cb im i1 - i1 im wx ix
+wx ci wx i1 - i1 id ix ix im ix ix wx ac - ix wx ix ix id ix ac - ix ix i1 - ix im ix
+im ix ix - i1 ix ix ix wx wx ci wx wx - ac ix ci wx ix ci im - ac id im im ci ci i1 im
+wx wx wx ac wx ix wx wx im ix ix ix ix ix wx im - wx im - cb ix id - ac - p3 i1 - i1
+im ix ix - cb ix wx ix - ci wx wx wx id - wx ix ix wx ix wx ix id ix ix ac im wx i1 is
+wx im cb im ix ix wx ix wx im ix ix - ac ix im wx ix wx ix wx ix ix im ci - ix im p3 is
+wx ix - wx im id wx ix wx - ci id ac - ac - wx ix wx ix wx wx ci ur p3 im ci wb is is
+wx ix id ix ix - id ix wx ix id - id ix wx ix wx ix wx ix ix ix p3 im - im p3 is is is
+wx ix im ix cb id ix ix wx ix id ix id ix wx ix wx ix wx iB wx im ci wx im wb is is is is
+wx ix wx im - cb ix wx wx ix ci ix id ix wx ix wx ix iB ix ix ix im p3 is is is is is is
+im ix p3 ci p3 im ix wx - im wx ix id ix wx ix wx ix ci ix Bh i1 wx is is is is is is is
+wx ci id wx i1 im ix ci ix ix im ix ci ix ci ix im im wx - i1 - i1 is is is is is is is
+im ix - i1 - i1 im wx wx ci wx ix im im wx im wx p3 ie ie wx i1 - ix is is is is is is

--- a/project/assets/main/nurikabe/official/generated/36.txt.info
+++ b/project/assets/main/nurikabe/official/generated/36.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.71

--- a/project/assets/main/nurikabe/official/generated/360.txt.info
+++ b/project/assets/main/nurikabe/official/generated/360.txt.info
@@ -1,1 +1,37 @@
-{"cells":96,"difficulty":0.267771189848125,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.27
+width 11
+height 7
+author 
+
+[solution]
+############ . . 3#### .
+## . . . .######## 1## .
+## 5###### 3## . 4#### .
+12## 3 .## .## .## 2## 4
+ .#### .## .## .## .####
+ .## 1################ 3
+ .###### . .## .## .## .
+ . . . . . .## 2## 2## .
+
+[order]
+3 3 3 8 8 2 2 2 - 0 1 2
+1 2 6 6 9 9 2 1 0 - 0 2
+0 - 0 8 8 - 3 2 - 0 1 2
+- 0 - 2 11 11 10 6 0 - 0 -
+2 1 0 14 9 12 7 11 2 2 1 0
+2 0 - 0 16 12 14 11 8 2 3 -
+2 16 0 18 19 15 2 12 1 4 2 6
+17 17 17 17 20 21 13 - 0 - 5 6
+
+[reason]
+wx wx wx wx wx im ix ix - i1 wx ix
+wx ix ix ix ix im im wx i1 - i1 ix
+ac - ac wx wx - id ix - i1 wx ix
+- ac - ix wx ix wx ix ac - ac -
+ix wx i1 ix ci ix ci ix im ix wx ac
+ix i1 - i1 wx im wx im wx im wx -
+ix wx i1 wx p3 p3 ci p3 wx p3 ci ix
+ix ix ix ix ix ix im - ac - im ix

--- a/project/assets/main/nurikabe/official/generated/361.txt.info
+++ b/project/assets/main/nurikabe/official/generated/361.txt.info
@@ -1,1 +1,58 @@
-{"cells":195,"difficulty":8.76334393612985,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 8.76
+width 12
+height 14
+author 
+
+[solution]
+#### . . 3#### 7 . . .##13
+## .###### 9######## .## .
+## . .## . .## 7 .## .## .
+#### 4## .## 7## .## .## .
+ 5###### .## .## .###### .
+ .## 4## .## .## . . .## .
+ .## .## .## .########## .
+ .## .## .## . . .## 4## .
+ .## .## .########## .## .
+###### 1#### 4 . .## .## .
+ 7## 3## 4 .#### .## .## .
+ .## .#### . .######## . .
+ .## .## 5###### 2 .######
+ .###### . . . .###### 1##
+ . . .############ 2 .####
+
+[order]
+63 9 9 2 - 0 1 - 2 5 5 7 -
+63 64 3 7 0 - 1 0 4 4 9 8 9
+65 24 47 46 5 2 0 - 2 10 9 10 9
+66 65 - 6 26 4 - 0 11 10 11 10 11
+- 67 0 46 26 26 5 12 11 12 11 12 11
+56 56 - 26 26 27 28 12 13 35 21 20 13
+56 58 57 46 31 29 28 29 33 34 36 25 20
+68 62 59 46 45 32 30 33 33 33 - 22 20
+68 60 61 0 44 43 20 21 21 42 37 38 20
+68 48 0 - 0 4 - 20 19 21 41 42 39
+- 0 - 0 - 2 4 10 18 15 16 40 41
+68 48 2 1 0 5 9 9 17 15 15 16 41
+68 3 49 7 - 7 6 17 - 16 15 0 20
+54 63 49 50 9 25 23 53 17 17 0 - 0
+55 52 51 25 48 48 48 15 69 - 70 0 14
+
+[reason]
+ur im ix ix - ac wx - ix ix ix id -
+ur p3 ci wx ac - wx ac wx wx ix wx ix
+im ik p3 im ix ix ac - ix wx ix wx ix
+wx im - cb ix id - ac ix wx ix wx ix
+- wx ac im ik iB ix wx ix wx im wx ix
+ix iB - iB ik wx ix wx ix ix p3 uL ix
+ik id ix im ix wx ix wx im wx im uL ul
+ix im ix im ie wx ix ix ix im - id ul
+ix ci p3 i1 p3 ur uL im im im ix id ul
+im ic i1 - i1 id - ul ie im ie im ix
+- ac - i1 - ix id wx p3 ur p3 cb ie
+ie ic ix wx ac ix ix im im ur ur p3 ie
+ie ci ix wx - id ci im - p3 ur i1 uL
+pk wb im wx ix ul pk ix im im i1 - i1
+ib ie p3 uL ic ic ic ur wx - ix i1 wb

--- a/project/assets/main/nurikabe/official/generated/362.txt.info
+++ b/project/assets/main/nurikabe/official/generated/362.txt.info
@@ -1,1 +1,64 @@
-{"cells":289,"difficulty":6.51326156343463,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.86
+width 16
+height 16
+author 
+
+[solution]
+## . . . . 5## . . .##############
+############## 4###### 5 . . . .##
+ . 2## . . . 4## 3 . .############
+######################## 8 . .## 7
+ .## .## .## 6 . . . . .#### .## .
+ .## 3## . 3############ 1## .## .
+ 3## .###### 7 .## 6 .###### .## .
+###### . .#### . .## . . .## .## .
+ . .## .#### 1## .###### .## .## .
+ 3## 5 .## 3#### . .## 1######## .
+########## . .############ .## 3##
+## 4 . . .#### 4## 4 .## 4 .## .##
+ 4########## . . .## . .## .## .##
+ .## 3 . .########################
+ . .###### 8 . . . . . . .## . .##
+###### .################## 5 . .##
+ 5 . . .## 7 . . . . . .##########
+
+[order]
+24 24 24 6 6 - 4 2 6 6 6 11 11 15 19 22 26
+25 24 23 22 5 4 0 - 0 6 7 - 13 17 20 24 24
+53 - 22 22 22 2 - 0 - 6 10 10 15 19 22 21 27
+26 52 54 22 19 20 0 1 4 8 7 10 - 17 20 22 -
+56 55 49 19 19 0 - 2 2 6 10 10 0 11 24 30 28
+51 6 - 4 2 - 0 1 4 8 8 0 - 0 32 33 32
+- 57 58 17 17 0 - 2 4 - 10 11 0 26 35 36 35
+4 3 13 17 16 8 0 6 6 8 13 24 24 36 37 39 37
+2 6 6 11 15 0 - 0 10 15 22 0 37 25 40 38 40
+- 0 - 8 10 - 0 11 17 20 0 - 0 42 40 40 40
+1 1 4 8 9 11 15 15 19 18 26 0 39 43 44 - 40
+0 - 2 6 13 13 12 - 0 - 26 28 - 40 42 45 41
+- 0 4 11 10 20 21 17 24 24 30 33 33 45 45 45 45
+2 4 - 11 19 19 22 21 24 25 32 31 33 45 47 45 46
+6 10 10 17 12 - 20 24 24 28 28 33 33 33 48 61 60
+8 7 11 17 14 0 20 21 26 26 30 29 33 - 35 59 62
+- 10 10 13 15 - 17 22 22 28 28 32 32 34 34 36 50
+
+[reason]
+im ix ix ix ix - id ix ix ix im wx wx wx wx wx wx
+wx im wx im wx id ac - ac im wx - ix ix ix ix im
+ix - im ix ix ix - ac - ix ix im id id id ci wx
+ci Bj wx im im wx ac wx id id ci im - ix ix id -
+p3 Bg ix im ix ac - ix ix ix ix ix i1 wx ix id ix
+ix cb - id ix - ac wx wx wx wx i1 - i1 ix id ix
+- im p3 wx wx ac - ix id - ix wx i1 wx ix id ix
+id ci wx ix p3 wx i1 ix ix id ix ix ix wx ix id ix
+ix ix im ix wx i1 - i1 ix wx wx i1 ix ci ix ci ix
+- ac - ix id - i1 wx ix ix i1 - i1 wx im im ix
+wx wx id wx wx ix ix im wx ci wx i1 wx p3 id - im
+ac - ix ix ix im ci - ac - ix id - ix cb ix wx
+- ac id wx ci wx p3 ix ix im ix ix im ix im ix im
+ix id - ix ix im wx cb im wx wx ci im im ic im wx
+ix ix im im ci - ix ix ix ix ix ix ix im p3 p3 ci
+id ci wx ix ci ac wx wx wx wx wx ci im - ix Bi im
+- ix ix ix id - ix ix ix ix ix ix im wx wx wx ur

--- a/project/assets/main/nurikabe/official/generated/363.txt.info
+++ b/project/assets/main/nurikabe/official/generated/363.txt.info
@@ -1,1 +1,40 @@
-{"cells":117,"difficulty":0.0,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.00
+width 12
+height 8
+author 
+
+[solution]
+ . 3## 2## 4 .## . . .## .
+ .#### .#### .###### 4## 2
+## 1#### 3## .## . 7######
+###### . .###### .#### . 2
+ 3## 2#### 5 .## .## 4####
+ .## .## 3## .## .## .## 4
+ .###### .## .## .## .## .
+#### .## .## .## .## .## .
+## . 3################## .
+
+[order]
+2 - 0 - 0 - 5 3 3 3 2 2 2
+2 0 1 2 1 4 5 5 3 0 - 0 -
+0 - 0 2 - 6 6 6 4 - 0 1 0
+4 0 8 8 8 4 6 7 8 3 2 2 -
+- 0 - 8 0 - 5 10 8 10 - 1 0
+5 9 10 9 - 0 11 10 11 10 11 4 -
+10 6 10 11 10 12 11 12 11 12 11 12 5
+10 18 14 13 13 12 13 12 13 12 13 12 13
+19 19 - 17 13 16 13 15 13 14 13 13 13
+
+[reason]
+ix - ac - ac - ix im ix ix ix im ix
+ix i1 wx ix wx wx ix wx im ac - ac -
+i1 - i1 im - im ix wx ix - ac wx ac
+wx i1 im ix ix cb im wx ix wx im ix -
+- ac - im ac - ix wx ix wx - wx ac
+ix wx ix wx - ac ix wx ix wx ix wx -
+ix ci im wx ix wx ix wx ix wx ix wx ix
+im wx p3 im ix ci ix wx ix wx ix wx ix
+im ix - wx im wx im wx im wx im im ix

--- a/project/assets/main/nurikabe/official/generated/364.txt.info
+++ b/project/assets/main/nurikabe/official/generated/364.txt.info
@@ -1,1 +1,43 @@
-{"cells":80,"difficulty":0.856371757642414,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 6.69
+width 7
+height 9
+author 
+
+[solution]
+ . . .##########
+ .###### .## .##
+ 5## 1## 2## .##
+###### 1## 4 .##
+## . 2######## .
+######## 6 . . .
+ . .## 1###### .
+ 3###### 3## 2##
+## 1## . .## .##
+################
+
+[order]
+18 13 12 11 3 11 11 11
+15 19 0 1 3 3 12 11
+- 0 - 0 - 0 13 14
+15 1 0 - 0 - 5 14
+15 16 - 0 1 4 6 20
+10 3 17 0 - 3 5 7
+3 9 0 - 0 1 6 20
+- 0 8 0 - 0 - 13
+0 - 0 9 3 10 12 7
+1 0 2 10 10 11 11 11
+
+[reason]
+ib ie p3 ur im ur ur ur
+ul im i1 wx ix im p3 ur
+- i1 - i1 - ac ie im
+uL wx i1 - ac - ix im
+uL p3 - ac wx id id is
+im ci im i1 - ix ix ix
+ix p3 i1 - i1 wx id is
+- i1 wb i1 - ac - im
+i1 - i1 p3 ix im p3 ci
+wx i1 wx im im ur ur ur

--- a/project/assets/main/nurikabe/official/generated/365.txt.info
+++ b/project/assets/main/nurikabe/official/generated/365.txt.info
@@ -1,1 +1,37 @@
-{"cells":80,"difficulty":8.91784945174658,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 8.92
+width 9
+height 7
+author 
+
+[solution]
+## . . . . . 8######
+## .########## 2 .##
+## .## . . .########
+########## .## . .##
+## .## .## .## . .##
+## 2## 2## . 7## 5##
+ 6################ 5
+ . . . . .## . . . .
+
+[order]
+21 27 24 24 24 2 - 0 1 9
+21 27 26 23 23 24 0 - 7 8
+19 20 28 29 22 25 14 8 2 10
+4 2 19 16 30 16 17 12 11 4
+1 2 2 16 4 16 13 18 2 1
+0 - 0 - 15 14 - 0 - 0
+- 0 4 3 5 6 3 4 0 -
+2 2 2 5 5 5 5 2 2 2
+
+[reason]
+uL ix ul ul ul ix - ac wx wx
+uL ix Bw iC iC uL ac - pk im
+ur p3 im p3 ik p3 wx im ci wx
+wx im wb im im ix id ix p3 wx
+wx ix im ix ci ix ci ix ix wx
+ac - ac - id ix - ac - ac
+- ac wx cb im wx ci wx ac -
+ix ix ix ix ix im ix ix ix ix

--- a/project/assets/main/nurikabe/official/generated/366.txt.info
+++ b/project/assets/main/nurikabe/official/generated/366.txt.info
@@ -1,1 +1,43 @@
-{"cells":60,"difficulty":1.57812110191294,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 1.58
+width 5
+height 9
+author 
+
+[solution]
+ 2 .########
+###### . .##
+## 5 . .####
+ 5###### 1##
+ .## .######
+ .## 2## . .
+ .#### 3##10
+ .## . .## .
+########## .
+## . . . . .
+
+[order]
+- 2 2 10 9 12
+1 0 4 8 11 11
+0 - 2 8 0 12
+- 0 5 0 - 0
+2 2 5 5 0 13
+3 4 - 0 6 7
+5 14 0 - 0 -
+17 6 15 2 8 17
+17 18 10 16 18 17
+19 19 19 19 19 19
+
+[reason]
+- ix im wx ci wx
+wx ci wx ix ix im
+ac - ix ix i1 wx
+- ac im i1 - i1
+ix ci ix im i1 wx
+ix id - ac p3 ie
+ix wx ac - ac -
+ix ci p3 ix wx ix
+im wx ci im wx ix
+im ix ix ix ix ix

--- a/project/assets/main/nurikabe/official/generated/367.txt.info
+++ b/project/assets/main/nurikabe/official/generated/367.txt.info
@@ -1,1 +1,76 @@
-{"cells":231,"difficulty":10.6330303834638,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 10.45
+width 10
+height 20
+author 
+
+[solution]
+ . . . . . . . . . . .
+ .################## .
+ .## . . . . . . .##17
+ .############## . 9##
+ .## . . . . . 6######
+################ 4## 6
+ 1## .## 3 . .## .## .
+#### . 3###### . .## .
+ .###### 2## 4###### .
+ .## .## .## .## 4## .
+ .## 2###### .## .## .
+ .#### . .## .## . .##
+ 5## 4 .##############
+######## 4 . . .## 1##
+## . 3 .##############
+########## . . .## . 3
+ .## 7 . . .###### .##
+ . .########## 1######
+ .#### . 3 .###### 1##
+ .## .######## .######
+ 6## 2## 5 . . .## 1##
+
+[order]
+45 21 14 14 12 12 10 10 8 8 8
+45 42 20 13 13 11 11 9 9 7 2
+45 41 41 18 12 12 10 10 5 0 -
+44 45 19 40 17 11 11 4 2 - 0
+43 42 42 40 40 16 5 - 0 1 1
+0 22 22 29 40 17 41 0 - 0 -
+- 0 23 0 - 34 41 41 2 4 2
+0 24 2 - 0 1 35 42 42 4 5
+25 22 24 0 - 0 - 35 30 45 5
+26 8 25 2 2 2 35 30 - 6 33
+26 26 - 7 2 35 32 32 30 32 46
+27 7 0 5 8 8 31 30 31 23 22
+- 0 - 2 4 9 30 22 30 0 22
+28 54 0 4 - 30 24 23 0 - 0
+58 39 - 57 30 31 31 22 22 0 30
+37 38 0 55 60 61 32 31 30 31 -
+37 6 - 35 56 59 62 0 22 23 32
+5 36 35 47 50 49 0 - 0 0 30
+2 4 2 48 - 51 51 0 0 - 0
+2 1 2 1 0 50 52 15 22 0 3
+- 0 - 0 - 2 51 53 2 - 2
+
+[reason]
+ix ix ix ix ix ix ix ix ix ix ix
+ix wx wx wx wx wx wx wx wx wx ix
+ix im ix ix ix ix ix ix ix ac -
+ie wx ci iB wx wx wx id ix - ac
+p3 im ix ik ix ix ix - ac wx wx
+i1 iC ur wx iB cb im ac - ac -
+- i1 p3 ac - ix ix im ix wx ix
+i1 im ix - ac wx uL ix ix wx ix
+p3 ur im ac - ac - uL uL wx ix
+ie ci p3 im ix im ul uL - cb ix
+ie im - id im uL ie im ul im ix
+ie wx ac ix ix im p3 uL p3 p3 ur
+- ac - ix id wx uL ur uL i1 ur
+im Bj ac id - ul ie p3 i1 - i1
+im pk - Bi uL im im ur ur i1 uL
+im wx ac Bg uL p3 ie p3 uL p3 -
+ix cb - ul ix Bi im i1 ur p3 im
+ix p3 uL uL wx ci i1 - i1 i1 uL
+ix wx im p3 - ix im i1 i1 - i1
+ix wx ix wx ac wx wx pk ur i1 wx
+- ac - ac - ix ix ix i1 - i1

--- a/project/assets/main/nurikabe/official/generated/368.txt.info
+++ b/project/assets/main/nurikabe/official/generated/368.txt.info
@@ -1,1 +1,55 @@
-{"cells":126,"difficulty":14.3332347396563,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 14.33
+width 8
+height 13
+author 
+
+[solution]
+ .########## . .##
+ .## . . .#### 3##
+ .## 4#### 1######
+ .#### .#### .10 .
+ .## 3 .## . . . .
+ .############## .
+ 7## . . .## 1## .
+#### . .## 1#### .
+## 7 .######## .##
+14#### 3 . .## 2##
+ . .##############
+ .## 4 . . .## 1##
+ .################
+ . . . . . . . . .
+
+[order]
+56 14 14 14 11 11 62 58 63
+45 52 51 13 12 0 61 - 57
+10 10 - 47 0 - 0 0 59
+10 44 0 48 23 0 60 - 36
+10 8 - 22 49 50 36 60 30
+7 55 46 21 53 25 0 29 28
+- 6 54 20 24 0 - 2 30
+1 1 5 27 0 - 0 31 60
+0 - 2 4 26 0 11 32 33
+- 0 4 - 18 34 33 - 33
+2 39 38 17 35 14 14 0 11
+14 3 - 37 37 15 0 - 0
+14 40 16 37 38 38 42 0 43
+19 14 14 14 41 41 14 9 43
+
+[reason]
+ix uL uL uL ur ur p3 Bi im
+ix im ix ie p3 i1 ic - Bg
+ik iB - Bg i1 - i1 ac wv
+ik Bw ac p3 ur i1 is - ix
+ix cb - ix im p3 ik is ik
+ix wx Bj cb ic wx i1 ic ik
+- wx ix ik ik i1 - i1 ik
+wx wx ix p3 i1 - i1 iC is
+ac - ix id ic i1 ur p3 im
+- ac id - ix p3 im - im
+ix p3 im cb im uL uL i1 ur
+ul cb - ix ik p3 i1 - i1
+ul wx id iB im im wx i1 im
+ib ul ul ul ix ix ul pk ix

--- a/project/assets/main/nurikabe/official/generated/369.txt.info
+++ b/project/assets/main/nurikabe/official/generated/369.txt.info
@@ -1,1 +1,43 @@
-{"cells":90,"difficulty":4.64443976004677,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 4.64
+width 8
+height 9
+author 
+
+[solution]
+ 1#### . . . . . .
+## 1## . . . . . .
+########## . . . .
+ 5 . . .## . . . .
+###### .######23 .
+ 2 .#### 1## 1## .
+###### 1##########
+## 1###### . . 3##
+#### 3 . .########
+ . 2######## 3 . .
+
+[order]
+- 0 1 22 22 22 22 22 22
+0 - 2 11 22 22 22 22 22
+1 1 5 10 13 22 22 22 22
+- 2 2 9 10 12 22 22 22
+0 1 7 8 0 13 0 - 21
+- 6 6 0 - 0 - 0 20
+5 0 2 - 0 14 0 17 19
+0 - 0 2 3 15 16 - 17
+1 0 - 2 3 3 17 5 18
+2 - 0 1 3 4 - 18 18
+
+[reason]
+- i1 wx is is is is is is
+i1 - i1 p3 is is is is is
+wx wx wx im wv is is is is
+- ix ix ie im pk is is is
+ac wx wx p3 i1 wv i1 - ie
+- ix im i1 - i1 - ac p3
+wx i1 i1 - i1 ur i1 im wx
+i1 - i1 i1 im p3 ie - im
+wx i1 - ix ix im im cb im
+ix - ac wx im wx - ix ix

--- a/project/assets/main/nurikabe/official/generated/37.txt.info
+++ b/project/assets/main/nurikabe/official/generated/37.txt.info
@@ -1,7 +1,7 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
-difficulty 12.70
+difficulty 14.06
 width 13
 height 10
 author poobslag v02
@@ -20,27 +20,27 @@ author poobslag v02
  .################## . . . .
 
 [order]
-10 12 10 10 0 10 29 29 36 34 44 42 43 56
-12 - 11 0 - 0 30 - 0 - 34 40 41 -
-15 12 10 10 0 28 26 31 32 33 34 - 27 27
-- 12 11 10 11 14 25 24 28 34 43 39 43 27
-15 12 2 12 13 8 4 24 3 35 58 57 56 45
-15 0 - 0 7 2 1 2 23 38 58 46 56 55
-5 - 0 - 0 - 0 - 0 22 37 46 54 47
-16 4 1 2 5 0 - 0 - 20 21 - 47 47
-16 12 - 4 5 7 2 1 18 19 50 48 51 53
-16 5 11 7 8 6 8 18 18 18 49 51 52 53
-16 10 10 10 8 9 17 17 18 19 50 51 52 53
+22 24 22 22 0 22 32 32 39 37 46 44 45 60
+24 - 23 0 - 0 33 - 0 - 37 44 42 -
+27 24 22 22 0 31 29 34 35 36 37 - 30 30
+- 10 23 11 23 26 18 17 22 37 45 45 45 30
+27 10 2 24 25 8 4 17 3 38 43 50 50 47
+27 0 - 0 7 2 1 2 16 41 50 48 49 52
+5 - 0 - 0 - 0 - 0 15 40 48 60 51
+19 4 1 2 5 0 - 0 - 13 14 - 52 52
+19 19 - 4 5 7 2 1 11 12 56 53 54 52
+19 5 20 7 8 6 8 11 11 11 55 57 58 59
+28 21 20 10 8 9 10 10 11 22 56 57 58 59
 
 [reason]
-ur im ur ur i1 ur uL uL wx im ix ix ic im
-im - p3 i1 - i1 p3 - ac - im ix id -
+ur im ur ur i1 ur uL uL wx im ix ik ic im
+im - p3 i1 - i1 p3 - ac - im ix Bg -
 is im ur ur i1 ur pk im p3 ie im - iB ix
-- im p3 ur p3 im wx im iC im ic Bg ic ik
-is im ix im p3 ix wx ix ci p3 is p3 im ix
-iB ac - ac wx ix wx ix wx ix is ik im ie
-ix - ac - ac - ac - ac ix Bw iB wx ik
+- ic p3 ci p3 im wx im iC im ic ic ic ik
+is ic ix im p3 ix wx ix ci p3 Bi is iB ix
+iB ac - ac wx ix wx ix wx ix is ik iC ix
+ix - ac - ac - ac - ac ix Bw iB im ik
 ix wx wx ix ix ac - ac - ix id - iB ik
-ix im - id ix wx ix wx im wx p3 ix im ie
-ix ci p3 wx ix ci ix ix ix im ur im wx ie
-ix ur ur ur im wx wx wx im wx p3 ie ie ie
+ik iB - id ix wx ix wx im wx p3 ix id ik
+ik ci ix wx ix ci ix ix ix im ci im wx ie
+ix wx im ic im wx ic ic im ur p3 ie ie ie

--- a/project/assets/main/nurikabe/official/generated/370.txt.info
+++ b/project/assets/main/nurikabe/official/generated/370.txt.info
@@ -1,1 +1,88 @@
-{"cells":400,"difficulty":4.08395567870423,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.75
+width 15
+height 24
+author 
+
+[solution]
+ . 2## . 4#### 9 . . . . . . . .
+###### .## 3####################
+ 2 .## .## . .## 8 . . . . . .##
+############## 2############ .##
+## 1## .## 1## .## 1## 1## 1####
+ .#### . 3########## 1######## .
+ .## .###### . . . .## . . 3## .
+ 3## .## . .## 5############## .
+#### .## 3######## 2 .## 1## . .
+## . .#### 4 . . .######## . .10
+## .#### .########## .## . .####
+## .## . .## . . . . .######## 1
+## .## .#### .########## . .####
+## 9## .## . .## .## . 3## . .##
+ .#### .##10#### .#### .#### 5##
+ .## . .#### . . .## 1#### 1## 1
+ .## .#### . .########## 3######
+ 4##10## 9 .## 3 . .## . .## .##
+## 6## 5#################### .##
+## .## . . . .## . . . .## 4 .##
+## .##########11 .#### . .######
+## .## 3## 4 .#### 2#### . .## .
+## .## . .## . .## .## 1## .## 4
+## .########################## .
+######11 . . . . . . . . . .## .
+
+[order]
+59 - 4 2 - 0 1 - 16 16 18 18 22 22 25 73
+6 58 5 6 0 - 1 14 2 17 17 20 20 24 72 26
+- 57 6 6 6 2 11 0 - 4 18 18 22 71 71 74
+56 0 56 6 7 0 11 - 0 0 1 0 70 0 75 73
+0 - 0 8 0 - 0 14 0 - 0 - 0 - 0 76
+55 0 10 9 - 0 60 14 63 0 - 0 67 0 76 77
+55 53 54 10 10 55 61 62 68 67 2 65 66 - 67 78
+- 53 52 53 39 55 55 - 69 66 64 64 0 67 79 78
+36 36 52 38 - 0 56 63 66 - 65 0 - 0 80 81
+34 35 37 51 0 - 42 95 95 66 66 85 0 82 82 -
+29 33 34 39 50 41 93 93 95 96 86 84 84 82 1 0
+29 27 31 33 40 49 91 95 95 96 86 85 15 83 0 -
+7 27 25 30 31 42 48 90 89 97 13 84 84 14 4 0
+6 - 25 24 29 30 43 47 89 46 85 - 11 6 2 1
+6 3 11 24 15 - 29 44 45 87 0 12 11 0 - 0
+2 4 2 14 22 22 27 30 32 0 - 0 0 - 0 -
+2 1 2 1 16 20 24 25 31 28 0 85 - 0 1 0
+- 0 - 0 - 17 18 - 27 33 33 86 87 88 65 64
+0 - 0 - 0 11 20 25 26 29 34 88 88 98 89 99
+1 2 1 2 6 20 20 20 25 27 30 35 36 - 100 99
+4 2 4 4 18 7 20 - 22 24 29 89 89 90 93 101
+4 6 11 - 0 - 18 20 24 - 90 0 91 91 97 102
+11 14 16 14 17 17 22 25 25 91 0 - 0 96 92 -
+16 17 15 16 17 21 24 23 27 91 92 0 95 94 101 103
+18 17 19 - 20 20 22 25 25 29 93 93 93 100 100 103
+
+[reason]
+ix - id ix - ac wx - ix ix ix ix ix ix ix ix
+ci im wx ix ac - wx wx cb wx wx wx wx wx wx ci
+- p3 im ix im ix ix ac - ix ix ix ix ix ix wx
+wx i1 wx im wx i1 im - ac i1 wx i1 wx i1 ix ci
+i1 - i1 p3 i1 - i1 ix i1 - i1 - i1 - i1 wx
+ix i1 im ie - i1 wx im wx i1 - i1 im i1 wx p3
+ix wx p3 im im im p3 ie ie p3 i1 p3 ie - im ie
+- wx ix wx ix ix im - im im ur ur i1 im wx ie
+wx wx ix cb - ac wx wx im - p3 i1 - i1 p3 ie
+wx ix ix wx ac - ix ix ix im im wx i1 ix ix -
+wx ix wx wx ix ci wx wx im wx p3 im ix ix wx i1
+wx ix wx ix ix wx ix ix ix ix p3 wx ci wx i1 -
+wx ix wx ix wx wx ix wx im wx ci im ix ix wx i1
+im - wx ix wx ix ix wx ix ci ix - id ix ix wx
+ix ci wx ix cb - id wx ix wx i1 p3 wx i1 - i1
+ix wx ix ix wx id ix ix p3 i1 - i1 i1 - i1 -
+ix wx ix wx wx ix ix id wx ci i1 wx - i1 wx i1
+- ac - ac - ix id - ix ix im p3 ix im p3 ur
+ac - ac - ac wx im wx wx wx wx im im wx ie wx
+wx ix wx ix ix ix ix im ix ix ix ix id - ix wx
+wx ix wx id wx cb im - ix id wx ix ix id wx wx
+wx ix id - ac - ix id id - wx i1 ix ix im p3
+wx ix id ix ix im ix ix im ix i1 - i1 p3 ci -
+wx ix ci id im wx wx ci wx im wx i1 wx ci wx ix
+wx im wx - ix ix ix ix ix ix ix ix ix ix im ix

--- a/project/assets/main/nurikabe/official/generated/371.txt.info
+++ b/project/assets/main/nurikabe/official/generated/371.txt.info
@@ -1,1 +1,52 @@
-{"cells":208,"difficulty":2.4060419373468,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 2.41
+width 15
+height 12
+author 
+
+[solution]
+ . .## 3 . .#### 2 .#### 3 . .##
+ .##########11###### 5##########
+ .## . . .## . . .## . . . .## .
+ 5## 4########## .############ .
+## 7#### 8 . .## . . . . . .## .
+## . . .#### .################ .
+###### . .## . .## .## .## .## 5
+ 7## 1## .## . .## .## .## .####
+ .################ .## .## . 4##
+ . .## 3 . .## .## .## . 5#### 4
+ .## 5######## .## . 6#### 3## .
+ .## . . . .## .######## . .## .
+ .############ . . . 7######## .
+
+[order]
+11 11 11 - 13 14 14 15 - 21 21 22 - 43 43 43
+2 9 12 8 13 14 - 15 20 16 - 22 42 42 43 44
+2 1 7 13 13 13 16 19 19 23 23 40 40 43 43 45
+- 0 - 6 13 14 18 18 25 24 39 39 42 41 44 46
+0 - 0 6 - 16 16 26 25 38 38 40 40 43 43 16
+1 2 4 4 6 9 27 26 37 37 38 33 35 11 13 7
+3 3 0 7 7 28 27 36 34 37 33 33 5 11 6 -
+- 0 - 0 29 8 32 36 36 33 31 33 9 4 1 1
+4 9 0 11 29 25 31 29 31 29 31 7 3 2 - 0
+11 10 0 - 13 30 29 29 28 29 6 4 - 0 0 -
+16 13 - 0 23 23 28 27 28 7 - 6 0 - 3 2
+16 18 16 21 21 25 25 27 11 8 0 6 6 4 3 4
+19 17 20 20 23 23 26 13 9 9 - 7 5 5 4 4
+
+[reason]
+ix ix im - ix ix im wx - ix im wx - ix ix im
+ix wx wx cb im wx - wx wx ci - wx wx wx im wx
+ix wx ix ix ix im ix ix ix wx ix ix ix ix im p3
+- ac - wx im wx wx wx ix wx wx wx wx ci wx ie
+ac - ac wx - ix ix wx ix ix ix ix ix ix im ix
+wx ix ix ix id wx ix wx wx im wx im wx im wx ix
+wx wx i1 ix ix wx ix is ci ix im ix ci ix wx -
+- i1 - i1 ix ci p3 is iB ix wx ix wx ix wx wx
+ix wx i1 wx im ci wx im wx ix wx ix id ix - ac
+ix p3 ac - ix p3 im ix wx ix id ix - ac ac -
+ix id - ac wx wx wx ix wx ix - id ac - wx ix
+ix wx ix ix ix ix im ix wx wx ac im ix ix wx ix
+ix ci wx wx wx wx wx ix ix ix - wx wx wx im ix

--- a/project/assets/main/nurikabe/official/generated/372.txt.info
+++ b/project/assets/main/nurikabe/official/generated/372.txt.info
@@ -1,1 +1,46 @@
-{"cells":88,"difficulty":2.38667775724877,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 2.39
+width 7
+height 10
+author 
+
+[solution]
+ . . .10## 1## 2
+ .############ .
+ .## . 6## . .##
+ .## .## 2## 6##
+ .## .## .## .##
+ .## .###### .##
+ .## .## .## .##
+######## . 3####
+## . . 3###### .
+########## . . .
+ . . . 4## 7 . .
+
+[order]
+7 7 4 - 0 - 0 -
+7 6 6 0 1 0 0 4
+7 8 4 - 0 2 3 4
+11 8 11 0 - 0 - 5
+11 12 11 4 4 4 6 5
+13 12 13 11 4 7 6 7
+13 13 13 13 9 8 8 7
+13 14 13 10 15 - 8 11
+15 15 12 - 11 16 18 19
+16 15 13 0 1 17 21 20
+16 15 4 - 0 - 21 21
+
+[reason]
+ix ix ix - i1 - i1 -
+ix wx wx ac wx i1 ci ix
+ix wx ix - ac p3 ie im
+ix wx ix ac - ac - wx
+ix wx ix im ix im ix wx
+ix wx ix wx im wx ix wx
+ix im ix im p3 im ix wx
+im wx im cb ie - im wx
+im ix ix - cb im wx p3
+wx im id ac wx p3 is ie
+ix ix ix - ac - is is

--- a/project/assets/main/nurikabe/official/generated/373.txt.info
+++ b/project/assets/main/nurikabe/official/generated/373.txt.info
@@ -1,1 +1,34 @@
-{"cells":35,"difficulty":5.3389898937613,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.34
+width 4
+height 6
+author 
+
+[solution]
+## . . . .
+######## .
+## . .## .
+#### .## .
+ .## .## 8
+ 3## . 6##
+ .########
+
+[order]
+12 19 17 17 17
+20 15 18 16 10
+12 19 14 9 6
+21 13 8 5 2
+11 7 4 0 -
+- 3 2 - 0
+22 3 1 1 1
+
+[reason]
+ur ix ix ix ix
+wx ci wx wx ix
+ur ix ix wx ix
+wx ic ix wx ix
+ix ic ix ac -
+- id ix - ac
+ix wx wx wx wx

--- a/project/assets/main/nurikabe/official/generated/374.txt.info
+++ b/project/assets/main/nurikabe/official/generated/374.txt.info
@@ -1,1 +1,31 @@
-{"cells":36,"difficulty":10.1977155486561,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 10.82
+width 5
+height 5
+author 
+
+[solution]
+#### . 2## .
+ .######## .
+ 4## 3 .## .
+ .## .## 5 .
+ .##########
+#### 1## 2 .
+
+[order]
+9 9 13 - 12 17
+10 9 13 8 16 15
+- 0 - 14 14 15
+9 5 6 7 - 15
+4 3 0 1 0 2
+11 0 - 0 - 2
+
+[reason]
+uL uL ix - Bj ix
+p3 uL im ci wx ix
+- ac - ix im ix
+ul wv p3 id - ix
+pk Bh i1 wx ac im
+im i1 - i1 - ix

--- a/project/assets/main/nurikabe/official/generated/375.txt.info
+++ b/project/assets/main/nurikabe/official/generated/375.txt.info
@@ -1,1 +1,46 @@
-{"cells":88,"difficulty":4.97818013063844,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 4.98
+width 7
+height 10
+author 
+
+[solution]
+ . 2###### 5 . .
+###### . 4#### .
+ .## . .## 5## .
+ .######## .####
+ .## . .## . .##
+ .## 3## 2## .##
+ .###### .######
+ .## 2 .#### . .
+ .######## . . .
+ .## 2 .##11 . .
+ .10###### . . .
+
+[order]
+24 - 4 1 0 - 2 2
+6 22 4 2 - 0 1 2
+23 20 21 6 0 - 2 2
+19 22 7 19 8 4 3 2
+17 18 8 19 5 9 11 13
+17 7 - 0 - 10 14 12
+6 16 0 4 11 6 14 15
+6 3 - 4 4 25 26 27
+2 4 0 2 16 26 27 27
+2 0 - 2 2 - 27 27
+2 - 0 1 4 27 27 27
+
+[reason]
+ix - wx wx ac - ix ix
+ci wx wx ix - ac wx ix
+p3 ci ix ix ac - im ix
+ix wx ci im wx ix wx im
+ix id ix ix cb ix ix wx
+ix cb - ac - id ix ci
+ix ic ac im ix ci im wx
+ix cb - ix im wv p3 is
+ix wx ac im ic p3 is is
+ix ac - ix im - is is
+ix - ac wx wx is is is

--- a/project/assets/main/nurikabe/official/generated/376.txt.info
+++ b/project/assets/main/nurikabe/official/generated/376.txt.info
@@ -1,1 +1,52 @@
-{"cells":91,"difficulty":15.9872966340875,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 15.13
+width 6
+height 12
+author 
+
+[solution]
+##############
+## . . . . .##
+## 6##########
+#### 1## . . .
+ . 6######## .
+ .## 3 . .## .
+ .########## .
+ .## .## 1## .
+ .## .###### 8
+#### .## .####
+## . .## . . 4
+## . 7########
+###### . . . 4
+
+[order]
+7 7 7 9 9 12 13
+4 5 8 8 10 29 29
+4 - 0 9 28 11 30
+1 0 - 0 27 29 32
+2 - 0 1 26 31 29
+2 0 - 26 26 26 29
+2 4 24 25 0 28 10
+5 15 24 0 - 0 10
+14 6 24 13 0 9 -
+15 16 19 5 8 1 0
+22 23 17 7 2 2 -
+20 21 - 3 4 1 0
+18 6 5 5 2 2 -
+
+[reason]
+wx wx wx wx wx wx ur
+wx ix ix ix ix ix im
+wx - i1 wx id ci wx
+wx i1 - i1 p3 ie ix
+ix - i1 wx im wx ix
+ix ac - ix ix im ix
+ix wx im wx i1 wx ix
+ix im ix i1 - i1 ix
+Bi ci ix wb i1 wx -
+im wb ix ci ix wx ac
+wx p3 ix wx ix ix -
+Bh p3 - ci wx wx ac
+Bh wx im ix ix ix -

--- a/project/assets/main/nurikabe/official/generated/377.txt.info
+++ b/project/assets/main/nurikabe/official/generated/377.txt.info
@@ -1,1 +1,40 @@
-{"cells":90,"difficulty":1.37447680959285,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 1.37
+width 9
+height 8
+author 
+
+[solution]
+####################
+## . . .## . .## 1##
+## . 6###### . .## .
+## .## . 3#### 5## .
+###### .## . .#### 3
+## . 2###### 3## 4##
+###### 4## 2#### .##
+## . . .## .## . .##
+####################
+
+[order]
+20 19 14 14 11 7 8 7 0 6
+19 19 18 12 9 9 6 0 - 0
+17 18 - 6 11 5 4 4 0 4
+17 13 12 11 - 4 3 - 3 2
+14 2 9 7 4 4 2 3 0 -
+11 11 - 0 6 0 - 0 - 0
+16 11 0 - 0 - 0 6 2 1
+14 14 14 2 2 2 2 7 9 3
+15 14 12 12 9 2 9 10 10 11
+
+[reason]
+wx im wx wx wx ci wx wx i1 wx
+im ix ie p3 im ix ix i1 - i1
+wx ie - cb wx wx ix ix i1 ix
+wx p3 im ie - im id - id ix
+wx ci id p3 im ix ix id ac -
+im ix - ac wx ac - ac - ac
+wx im ac - ac - ac wx ix wx
+im ix ix ix im ix im p3 ix wx
+wx im wx wx wx im wx im im wx

--- a/project/assets/main/nurikabe/official/generated/378.txt.info
+++ b/project/assets/main/nurikabe/official/generated/378.txt.info
@@ -1,1 +1,58 @@
-{"cells":195,"difficulty":3.06168101883749,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.93
+width 12
+height 14
+author 
+
+[solution]
+ . . . . . . 8## 2## 3 . .
+ .############## .########
+## 1## . . 4## 3## 9 . .##
+###### .#### . .###### .##
+ 2## 1## 4###### 5 .## .##
+ .###### .## . 3## .## .##
+## 2## . .## .#### .## .##
+## .##########10## .## .##
+#### 4## 2## . .###### .##
+## . .## .## .## 3## 4####
+## .###### . .## .## .## 7
+###### . . .#### .## .## .
+## .#### .#### 3#### .## .
+## . . 4## 1## . .###### .
+#################### . . .
+
+[order]
+13 13 9 9 5 5 - 0 - 0 - 5 5
+13 0 12 7 6 2 3 1 2 1 3 4 5
+0 - 0 7 6 - 0 - 0 - 3 9 12
+14 0 0 8 3 5 5 2 3 2 6 13 12
+- 0 - 0 - 6 3 0 - 5 14 13 14
+16 15 0 9 9 5 2 - 0 16 14 16 14
+16 - 13 13 10 5 6 0 9 16 18 16 18
+16 18 18 11 12 12 6 - 18 19 17 19 18
+19 18 - 0 - 25 23 19 9 19 19 19 19
+37 38 19 26 26 13 26 22 - 0 - 19 20
+35 36 39 33 26 31 26 27 23 20 22 21 -
+35 35 41 40 31 31 29 24 28 25 22 23 22
+35 36 39 32 42 0 33 - 28 25 26 23 25
+37 38 37 - 0 - 0 33 30 29 26 27 25
+35 37 37 37 37 0 34 31 31 28 28 28 28
+
+[reason]
+ix ix ix ix ix ix - ac - ac - ix ix
+ix i1 wx wx wx cb wx wx ix wx wx wx im
+i1 - i1 ix ix - ac - ac - ix ix wx
+wx i1 i1 ix cb im ix ix wx cb wx ix wx
+- i1 - i1 - wx wx ac - ix wx ix wx
+ix wx i1 wx ix cb ix - ac ix wx ix wx
+im - im ix ix ci ix ac wx ix wx ix wx
+ci ix im ci id wx im - wx ix ci ix wx
+wx im - ac - id ix ix cb im im ix im
+uL p3 ix im ix ci ix id - ac - im wx
+ur p3 im wx im ix ix wx ix wx ix wx -
+ur ur wx ix ix ix wx ci ix wx ix wx ix
+ur p3 im cb ix i1 wx - im ci ix wx ix
+uL p3 ul - i1 - i1 ie p3 wx im wx ix
+ur uL uL uL uL i1 wx wx wx im ix ix ix

--- a/project/assets/main/nurikabe/official/generated/379.txt.info
+++ b/project/assets/main/nurikabe/official/generated/379.txt.info
@@ -1,1 +1,55 @@
-{"cells":168,"difficulty":2.15251772280487,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 2.15
+width 11
+height 13
+author 
+
+[solution]
+#### 7 . . . . . .## 2 .
+## 3####################
+## . .## 7 . . . . . .##
+###### 2################
+ 2 .## .## 2 .## 5 . .##
+######## 4#### 3#### .##
+## . .## . .## . .## .##
+## 3###### .############
+#### 4 .#### 4 . .## .##
+## .## . .## .###### 2##
+## .########## 1## .## 1
+## 3## . . .###### 2####
+ 2## 5 .###### .###### .
+ .######## 4 . .## 4 . .
+
+[order]
+1 0 - 2 9 9 11 11 19 19 - 22
+1 - 0 8 3 10 10 13 12 20 21 22
+1 2 7 0 - 4 11 11 19 19 23 23
+4 4 3 - 0 7 2 9 13 22 22 24
+- 5 2 4 0 - 8 0 - 19 29 32
+6 6 8 4 - 0 8 - 0 28 34 32
+14 15 16 16 7 19 22 9 26 26 34 34
+14 - 0 17 18 23 20 25 23 32 34 35
+13 0 - 4 25 23 - 31 31 2 35 1
+4 11 3 26 29 29 30 0 31 36 - 0
+1 2 10 28 27 29 0 - 0 37 0 -
+0 - 0 9 29 29 29 0 34 - 38 0
+- 0 - 7 8 29 30 31 33 0 39 40
+2 1 4 4 8 - 32 32 33 - 34 41
+
+[reason]
+wx ac - ix ix ix ix ix ix im - ix
+wx - ac wx cb wx wx wx ci wx wx im
+wx ix ix ac - ix ix ix ix ix ix im
+wx wx ci - ac wx ci wx wx wx ci wx
+- p3 ci ix ac - ix ac - ix ix wx
+im im wx im - ac im - ac wx ix wx
+wx p3 ix im ix ix wx ix ix im ix im
+wx - ac wx wx ix ci wx ci wx im wx
+wx ac - ix wx im - ix ix ci p3 wx
+wx ix ci ix ix im p3 i1 im wx - i1
+wx ix wx wx ci im i1 - i1 p3 i1 -
+ac - ac ix ix ix im i1 wx - im i1
+- ac - ix wx im wx p3 im ac wx p3
+ix wx wx wx wx - ix ix im - ix ie

--- a/project/assets/main/nurikabe/official/generated/38.txt.info
+++ b/project/assets/main/nurikabe/official/generated/38.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/380.txt.info
+++ b/project/assets/main/nurikabe/official/generated/380.txt.info
@@ -1,1 +1,64 @@
-{"cells":153,"difficulty":1.1282224740159,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 1.13
+width 8
+height 16
+author 
+
+[solution]
+## 1########## . .
+#### . 2## .#### .
+ .######## . .## .
+ 2## . . 3## .## .
+############ 5## .
+## 1## . . 3#### .
+ .########## .## 8
+ .## . . .## 2####
+ .###### . 5## . .
+ .## .########## 3
+ 5## .## . 3## 3##
+#### 3## .## . .##
+## .##############
+## .## 1## .## .##
+## . 4## . 3## .##
+############ 4 .##
+ . 2## . . 3######
+
+[order]
+0 - 0 24 23 22 17 17 17
+1 0 23 - 20 22 18 16 14
+23 22 22 14 21 19 14 13 10
+- 22 22 22 - 13 11 9 9
+21 0 21 18 11 0 - 8 8
+0 - 0 18 7 - 0 7 7
+19 0 18 13 17 5 5 2 -
+16 18 18 18 16 0 - 3 5
+16 15 14 15 2 - 0 7 2
+11 14 14 14 12 0 11 0 -
+- 9 14 13 13 - 0 - 0
+8 7 - 13 12 11 11 2 1
+7 7 7 0 5 4 3 7 5
+6 7 0 - 0 4 4 7 7
+6 5 - 0 3 - 0 7 5
+5 2 3 2 1 0 - 2 5
+5 - 2 2 2 - 0 1 5
+
+[reason]
+i1 - i1 wx wx im im ix ix
+wx i1 p3 - ci ix wx wx ix
+p3 ci im cb id ix ix wx ix
+- im ix ix - id ix wx ix
+wx i1 wx im id ac - wx ix
+i1 - i1 ix ix - ac wx ix
+ix i1 im ci wx im ix ci -
+ix im ix ix ix ac - ci id
+ix wx im wx ix - ac ix ix
+ix im ix im wx ac wx ac -
+- wx ix wx ix - ac - ac
+wx im - wx p3 im ix ix wx
+im ix im i1 wx im ci im wx
+wx ix i1 - i1 ix im ix im
+wx ix - i1 p3 - ac ix wx
+im cb wx im wx ac - ix wx
+ix - im ix ix - ac wx wx

--- a/project/assets/main/nurikabe/official/generated/381.txt.info
+++ b/project/assets/main/nurikabe/official/generated/381.txt.info
@@ -1,1 +1,28 @@
-{"cells":25,"difficulty":2.53456442242847,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 2.53
+width 4
+height 4
+author 
+
+[solution]
+ . . . .##
+ 5########
+## 4 . .##
+#### .####
+ 1###### 1
+
+[order]
+2 2 2 5 5
+- 0 4 3 6
+0 - 2 8 7
+0 1 8 9 0
+- 0 7 0 -
+
+[reason]
+ix ix ix ix im
+- ac wx ci wx
+ac - ix p3 wv
+i1 wx p3 im i1
+- i1 wv i1 -

--- a/project/assets/main/nurikabe/official/generated/382.txt.info
+++ b/project/assets/main/nurikabe/official/generated/382.txt.info
@@ -1,1 +1,52 @@
-{"cells":117,"difficulty":13.8416215431026,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 13.73
+width 8
+height 12
+author 
+
+[solution]
+########## 4 . . .
+## 1## .11########
+#### . .## 3 . .##
+ .## . .##########
+ .## . .## 4 . .##
+ .## . .#### .## .
+ .## .## .###### .
+ .###### 2## .## 3
+ 6## 1###### 2####
+###### . 5#### 3 .
+## . . .## . 2## .
+##################
+ . . . . 9 . . . .
+
+[order]
+9 0 4 1 0 - 2 2 6
+0 - 0 2 - 0 1 4 3
+42 0 50 2 0 - 2 11 10
+48 47 50 41 4 0 12 3 10
+45 49 50 50 26 - 25 24 23
+43 44 47 50 34 26 22 7 23
+40 46 37 4 35 27 20 21 6
+40 28 0 36 - 2 20 5 -
+- 0 - 0 0 19 - 0 4
+39 28 0 19 - 1 0 - 2
+33 33 29 14 17 17 - 0 6
+34 30 32 28 18 2 16 8 6
+38 38 38 31 - 15 15 13 38
+
+[reason]
+wb i1 wx wx ac - ix ix ix
+i1 - i1 ix - ac wx wx ci
+Bh i1 is ix ac - ix p3 ur
+p3 ci is Bi wx ac im ci ur
+Bi im is is im - ie p3 im
+Bi cb ie is iC im p3 ci ix
+ix id p3 ci p3 wx im wx ix
+ix ic i1 im - ci ix wx -
+- i1 - i1 ac wx - ac id
+wx ic i1 ix - wx ac - ix
+im ix ix ik im ix - ac ix
+wb ci wv ic wx ci id wx im
+is is is ix - ul ul pk is

--- a/project/assets/main/nurikabe/official/generated/383.txt.info
+++ b/project/assets/main/nurikabe/official/generated/383.txt.info
@@ -1,1 +1,58 @@
-{"cells":210,"difficulty":16.9530025969101,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 16.95
+width 13
+height 14
+author 
+
+[solution]
+###### 1###### . . . . . . .
+ . .###### .############ . .
+ .## . .## 2## . .## 1####10
+ .## .## 1#### .###### .####
+ .## 4###### . .## .## . 3##
+ .###### 1## 6#### .###### .
+ .## . 2###### .## .## 1## .
+ .###### .## . .## . 5#### 3
+ .## .## .## 4######## .####
+ .## .## 3#### . . 3## . .##
+11## 3#### .######## 1## .##
+###### .## .## . 2###### 5##
+ . . . .## .###### . . .####
+ .######## .## . . .###### .
+ 7## 8 . . .## . . 9## 4 . .
+
+[order]
+23 13 0 - 0 13 19 63 64 64 26 26 68 69
+18 17 16 0 13 14 2 62 62 65 0 66 67 65
+23 17 15 14 0 - 15 61 61 0 - 0 60 -
+23 17 16 0 - 0 59 60 60 59 0 59 48 48
+21 16 - 16 0 45 57 58 56 59 57 49 - 47
+20 22 16 0 - 0 - 55 57 55 28 0 47 47
+23 23 24 - 0 45 51 55 53 55 0 - 0 47
+23 23 2 25 44 42 50 52 54 46 - 0 46 -
+12 23 24 25 41 43 - 6 47 2 45 45 44 44
+5 11 11 7 - 40 49 49 3 - 0 45 43 44
+- 0 - 25 40 40 40 32 5 0 - 0 43 42
+3 4 6 30 8 40 37 37 - 36 0 39 - 42
+2 5 5 7 31 40 35 37 29 36 36 39 39 41
+2 1 6 6 9 33 34 27 39 36 1 37 40 41
+- 0 - 7 7 10 39 39 39 - 0 - 38 41
+
+[reason]
+uL ur i1 - i1 ur ic p3 ie ie ik ik ie ix
+ie p3 uL i1 ur p3 ci im im wx i1 wx p3 ix
+ul im ie p3 i1 - im ix p3 i1 - i1 wx -
+ul im ul i1 - i1 wx ix wx im i1 ix wx wx
+ik uL - uL i1 wx ix p3 ci ix wx ix - im
+pk wb uL ac - ac - im wx ix Bw i1 im ix
+ul uL p3 - ac wx id ix ci ix i1 - i1 ix
+ul uL ci im ix ci ix ix wx ix - i1 wx -
+ix uL p3 im ix id - ci wx cb im ix wx wx
+ix iB ix cb - im im ix ix - i1 ix ix wx
+- ac - im im ix im Bw id i1 - i1 ix wx
+id wx id Bi ci ix im ix - iB i1 iB - wx
+ix ix ix ix im ix Bh im Bj ik ik is iB im
+ix wx wx wx wx Bi iB ik is ix wx wx wx ix
+- ac - ix ix ix iB is is - ac - ix ix

--- a/project/assets/main/nurikabe/official/generated/384.txt.info
+++ b/project/assets/main/nurikabe/official/generated/384.txt.info
@@ -1,1 +1,40 @@
-{"cells":99,"difficulty":4.01622242666713,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 6.21
+width 10
+height 8
+author 
+
+[solution]
+ . . 8 . . . .########
+ .############ 3 . .##
+#### 3 .## 2 .########
+## 1## .######## .## 1
+ .###### 3 . .## 2####
+ 2## .############ .##
+## 7 . . . . .## . .##
+############## 6 . .##
+ 6 . . . . .##########
+
+[order]
+8 8 - 9 9 12 12 12 13 23 29
+7 6 0 6 11 10 12 - 21 24 25
+3 0 - 2 3 - 20 20 25 22 0
+0 - 0 11 11 19 11 21 26 0 -
+2 0 12 11 - 17 20 20 - 27 0
+- 0 13 14 16 16 17 21 27 32 32
+0 - 2 15 15 17 17 17 28 32 31
+1 0 3 3 16 5 17 - 19 30 31
+- 2 2 4 4 17 17 18 18 20 31
+
+[reason]
+ie ie - ix ix ix ix im wx wx wx
+p3 ic ac ic wx cb im - ix pk im
+wx i1 - ix id - ix im im ci i1
+i1 - i1 ix im id ci wx p3 i1 -
+ix i1 wx im - ix ix im - im i1
+- ac p3 wx wx wx im wx im ix im
+ac - ix ix ix ix ix im p3 ix wx
+wx cb wx wx wx ci im - ix Bi wx
+- ix ix ix ix ix im wx wx wx wx

--- a/project/assets/main/nurikabe/official/generated/385.txt.info
+++ b/project/assets/main/nurikabe/official/generated/385.txt.info
@@ -1,1 +1,40 @@
-{"cells":135,"difficulty":5.0523423387422,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.35
+width 14
+height 8
+author 
+
+[solution]
+######## . . . . . . .###### 1
+## . .############## 8## . 2##
+## .#### . . . . . 6##########
+## 4## 3############ . .## 1##
+#### . .## .## . 2## 3########
+ .######## 2###### 3## 3 . .##
+ 4## 3## 8## 1## . .##########
+ .## .## .############ 3## 1##
+ .## .## . . . . . .## . .####
+
+[order]
+23 27 23 11 11 11 9 9 5 5 4 4 1 0 -
+27 26 22 12 11 10 10 6 6 0 - 2 2 - 0
+27 27 21 11 11 11 9 9 2 - 0 2 2 0 1
+27 - 0 - 11 2 10 2 4 1 2 2 0 - 0
+27 20 20 13 2 2 2 6 - 0 - 0 4 0 23
+28 23 14 19 0 - 0 6 0 - 0 - 2 24 23
+- 0 - 0 - 0 - 0 7 2 1 0 25 0 23
+29 30 15 16 2 1 0 23 3 8 33 - 0 - 0
+31 17 31 31 17 32 32 32 32 32 32 34 34 0 18
+
+[reason]
+ur uL ur im ix ix ix ix ix ix ix wx wx i1 -
+uL ie p3 wx im wx wx wx wx ac - im ix - i1
+uL ul wx im ix ix ix ix ix - ac im im i1 wx
+uL - ac - im im wx ci wx wx ix ix i1 - i1
+uL im ix ix im ix im ix - ac - ac wx i1 ur
+p3 wb ci wv ac - i1 im ac - ac - ix p3 ur
+- ac - ac - i1 - i1 p3 ix wx ac im i1 ur
+ix id ix id ix wx i1 wb ci im wx - i1 - i1
+ix ci ix im ix ix ix ix ix ix im ix ix i1 wb

--- a/project/assets/main/nurikabe/official/generated/386.txt.info
+++ b/project/assets/main/nurikabe/official/generated/386.txt.info
@@ -1,1 +1,76 @@
-{"cells":231,"difficulty":11.1017154092362,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 11.10
+width 10
+height 20
+author 
+
+[solution]
+######## . . 3## 2## 1
+## . . 6######## .####
+## .###### . 6###### .
+## .## . . .## . 3## 2
+## .## .###### .## 6##
+########## . 3#### .##
+ 1## 4 .## .## 5## .##
+#### .## 3#### .## .##
+ 2## .## .## . .## .##
+ .###### .## .#### .##
+## 2 .########## 6####
+###### 6 .## . . . .##
+ .## 2## .## .########
+ 7## .## .###### .16##
+ .###### . .## . .## 5
+ .## . 2###### . .## .
+ .###### 1## . . .## .
+ . .## 2#### . . .## .
+###### .## . . . .## .
+ 2 .##################
+###### . . . . . . 8 .
+
+[order]
+17 17 9 8 8 3 - 0 - 0 -
+17 16 16 - 4 7 0 1 3 1 0
+17 18 15 15 10 8 - 3 3 1 2
+19 18 19 13 13 11 7 5 - 0 -
+19 20 16 20 12 12 6 8 0 - 0
+0 20 21 20 21 7 - 0 10 3 1
+- 0 - 22 13 23 0 - 4 11 5
+0 1 24 23 - 23 24 5 12 11 12
+- 24 24 24 24 30 29 26 12 13 12
+26 3 24 25 31 25 31 28 13 13 13
+26 - 51 50 31 32 31 32 - 13 14
+27 52 0 - 42 42 40 40 33 37 38
+58 57 - 0 42 41 43 39 34 35 1
+- 3 56 43 42 53 43 44 36 - 0
+49 59 3 55 54 59 59 60 45 0 -
+61 59 59 - 0 55 61 84 78 46 3
+61 63 1 0 - 0 62 84 84 79 47
+64 66 66 - 0 68 84 84 84 83 80
+65 48 3 67 67 69 76 84 84 81 82
+- 69 68 67 68 75 75 84 84 77 74
+70 48 71 72 73 73 74 74 74 - 85
+
+[reason]
+wx wx wx im ix ix - ac - i1 -
+wx ix ix - ci wx ac wx ix wx i1
+wx ix wx wx wx ix - cb im wx p3
+wx ix wx ix ix ix id ix - ac -
+wx ix ci ix wx wx ci ix ac - ac
+i1 im wx im wx ix - ac wx ix wx
+- i1 - p3 ci ix ac - cb ix wx
+i1 wx ix id - im wx ix wx ix wx
+- im ix im ix wx ix ix wx ix wx
+ix ci im wx ix ci ix wx im ix im
+im - p3 Bw im wx im wx - im wx
+wx im ac - ix iB ix ix ix pk wx
+p3 im - ac ik ci ix wx cb ic wx
+- ci p3 wx ik wx im wx ix - ac
+ix wx ci id ix ix im p3 ix ac -
+ix im ix - i1 wx wx is Bi wx ix
+ix wx wx i1 - i1 p3 is is wx ix
+ix ix im - i1 wb is is is im ix
+id iC ci ix im p3 ie is is ci p3
+- p3 iC im wb id cb iB iB Bj uL
+im iC wx p3 ie ie ul ul ul - ix

--- a/project/assets/main/nurikabe/official/generated/387.txt.info
+++ b/project/assets/main/nurikabe/official/generated/387.txt.info
@@ -1,1 +1,28 @@
-{"cells":35,"difficulty":0.0,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.00
+width 6
+height 4
+author 
+
+[solution]
+###### . 2## .
+## . 4###### 2
+## .## 2## 2##
+## .## .## .##
+##############
+
+[order]
+8 5 4 4 - 2 2
+8 7 - 0 3 0 -
+8 9 0 - 0 - 0
+9 9 2 2 2 2 1
+10 9 6 2 5 2 4
+
+[reason]
+wx wx im ix - im ix
+wx ix - ac wx ac -
+wx ix ac - ac - ac
+im ix im ix im ix wx
+wx im wx im wx im wx

--- a/project/assets/main/nurikabe/official/generated/388.txt.info
+++ b/project/assets/main/nurikabe/official/generated/388.txt.info
@@ -1,1 +1,40 @@
-{"cells":63,"difficulty":6.21898485476869,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 6.22
+width 6
+height 8
+author 
+
+[solution]
+ .############
+ .## .## . .##
+ .## 2## . .##
+ .#### 7 .####
+ .## .## .## .
+ .## .###### .
+ 7## 3## 1## .
+## 1## 1#### .
+########## 6 .
+
+[order]
+7 7 8 9 20 18 13
+7 4 8 8 17 19 16
+6 6 - 0 12 15 14
+5 5 0 - 6 11 10
+4 4 4 4 5 5 10
+4 1 4 1 0 8 4
+- 0 - 0 - 0 4
+0 - 0 - 0 3 4
+1 0 1 2 2 - 4
+
+[reason]
+ix im im wx im ci ur
+ix ci ix im Bi p3 wx
+ix wx - ac ix p3 Bh
+ix wx ac - ie wx im
+ix im ix im p3 ci ix
+ix wx ix wx i1 wx ix
+- i1 - i1 - i1 ix
+i1 - i1 - i1 wx ix
+wx i1 wx wx wx - ix

--- a/project/assets/main/nurikabe/official/generated/389.txt.info
+++ b/project/assets/main/nurikabe/official/generated/389.txt.info
@@ -1,1 +1,46 @@
-{"cells":77,"difficulty":1.96850823075979,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 1.97
+width 6
+height 10
+author 
+
+[solution]
+##############
+## 6 . . . .##
+ 5######## .##
+ . . . .######
+######## 2 .##
+ .## .########
+ 2## 2## . 2##
+## 8## 1######
+## .###### .##
+## . . . . .##
+##############
+
+[order]
+1 1 1 6 8 8 11
+0 - 2 7 7 9 11
+- 0 6 5 8 12 10
+2 3 4 7 7 12 13
+2 3 2 6 - 15 14
+2 1 2 2 16 8 14
+- 0 - 0 17 - 18
+0 - 0 - 0 12 13
+1 2 1 0 8 12 11
+6 2 7 7 9 9 11
+6 6 6 8 8 11 11
+
+[reason]
+wx wx wx wx wx wx wx
+ac - ix ix ix ix wx
+- ac wx ci wx ix ci
+ix ix ix ix im im wx
+im wx im wx - p3 ur
+ix wx ix im im ci ur
+- ac - i1 p3 - im
+ac - i1 - i1 im wx
+wx ix wx i1 wx ix wx
+wx ix ix ix ix ix wx
+wx wx wx wx wx wx wx

--- a/project/assets/main/nurikabe/official/generated/39.txt.info
+++ b/project/assets/main/nurikabe/official/generated/39.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.85

--- a/project/assets/main/nurikabe/official/generated/390.txt.info
+++ b/project/assets/main/nurikabe/official/generated/390.txt.info
@@ -1,1 +1,34 @@
-{"cells":70,"difficulty":5.45987932143316,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.46
+width 9
+height 6
+author 
+
+[solution]
+ 2 .######## . . . 4
+###### . .##########
+ 5 . .## .## . . 3##
+#### .## .######## .
+ 2## .## 5## . .## .
+ .############ .## .
+#### . . . 4## 4## 4
+
+[order]
+- 2 2 15 19 10 10 7 7 -
+0 0 4 16 20 11 8 9 0 6
+- 2 2 21 22 10 10 7 - 5
+0 1 22 14 13 11 5 7 3 5
+- 17 18 23 - 9 9 2 4 2
+16 2 12 17 2 10 1 2 1 2
+15 15 16 11 11 - 0 - 0 -
+
+[reason]
+- ix im ur wx im ix ix ix -
+ac ci wx p3 p3 wx ci wx cb wx
+- ix ix id ie im ix ix - im
+ac wx ix cb ix wx ci wx ci ix
+- im p3 im - im ix ix wx ix
+p3 ci ci im cb wx wx ix wx ix
+ur ur p3 ix ix - ac - ac -

--- a/project/assets/main/nurikabe/official/generated/391.txt.info
+++ b/project/assets/main/nurikabe/official/generated/391.txt.info
@@ -1,1 +1,40 @@
-{"cells":144,"difficulty":1.26702121328081,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 1.27
+width 15
+height 8
+author 
+
+[solution]
+ .## 5 . . . .## 3 . .#### 1####
+ .###################### 1#### .
+ .## . .## . . . .## .#### 3## .
+ .## .#### 5######## 2## . .## .
+ .## 4## .## 4 . . .########## .
+ 6#### . .############ 3 .## . .
+## 1## 4#### . . . . .## .#### 7
+######## 8 . .############## 1##
+ . . . 4######## 1## 3 . .######
+
+[order]
+18 9 - 18 18 22 22 22 - 25 27 1 0 - 0 39
+8 17 17 16 19 19 22 23 24 28 26 3 - 0 1 39
+6 7 15 18 18 14 22 23 29 29 30 31 0 - 36 39
+6 5 6 14 13 - 0 25 24 29 - 31 32 35 36 39
+3 4 - 4 13 0 - 13 29 29 29 33 34 36 38 39
+- 0 4 3 6 12 12 14 14 29 16 - 35 36 37 3
+0 - 0 - 0 7 11 13 15 15 33 33 34 35 0 -
+1 0 1 0 - 3 8 10 0 1 17 21 19 0 - 0
+3 3 3 - 0 1 4 0 - 0 - 18 20 2 0 1
+
+[reason]
+ix ci - ix ix ix ix im - ix p3 wx i1 - i1 im
+ix wx id ci wx cb im wx wx im ci i1 - i1 wx ix
+ix wx ix ix im ix ix ix ix im p3 im ac - im ix
+ix wx ix wx im - ac wx ci im - im p3 ie im ix
+ix id - id ix ac - ix ix ix im wx wx im wx ix
+- i1 wx ix ix wx id wx wx im ci - ix im p3 ix
+i1 - i1 - ac wx ix ix ix ix ix im p3 wx i1 -
+wx i1 wx ac - ix ix wx i1 wx wx im ci i1 - i1
+ix ix ix - ac wx wx i1 - i1 - ix p3 wx i1 wx

--- a/project/assets/main/nurikabe/official/generated/392.txt.info
+++ b/project/assets/main/nurikabe/official/generated/392.txt.info
@@ -1,1 +1,70 @@
-{"cells":285,"difficulty":9.38972479575652,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 9.39
+width 14
+height 18
+author 
+
+[solution]
+ .######## . . 3##############
+ .## . .######## 3## 4 . . .##
+ .## 3#### 5 .## . .##########
+ 4#### 4 .## .###### 5 .## . 2
+#### 1## .## .## 1## . .######
+ . 2#### .## .###### .#### . 3
+#### .########## 6 .## 6#### .
+ .## 2## . . . 6## .## .## 4##
+ .######## .###### .## .## .##
+ .## . .## .## 1## .## .## .##
+ .#### 3########## .## .## .##
+ 6 .#### 6 . . .###### .######
+###### . .######## . 5## 5## 1
+ 6## 1###### 7 .## . .## .####
+ .#### 3 . .## .#### .## . .##
+ .## 4######## .## 1###### .##
+ .## .## 3 .## .#### 2## 2####
+ .## . .## .## . .## .## .## 1
+ .############################
+
+[order]
+24 18 20 17 8 8 2 - 0 1 10 10 12 12 18
+14 16 15 19 18 3 7 0 - 0 - 11 11 19 18
+14 14 - 0 4 - 5 7 2 8 0 10 20 2 23
+- 1 0 - 2 4 8 26 0 8 - 25 24 24 -
+23 0 - 0 5 10 13 0 - 0 31 31 26 1 0
+23 - 0 7 11 6 27 18 0 31 31 31 32 33 -
+2 20 19 18 11 28 27 0 - 2 4 - 36 2 34
+21 20 - 20 21 78 2 - 0 36 36 38 36 - 34
+22 24 20 51 79 78 79 0 38 37 39 38 39 38 35
+26 52 53 80 79 74 0 - 0 40 39 40 39 40 39
+29 56 81 - 0 73 73 0 40 40 40 40 41 30 29
+- 55 54 0 - 49 72 65 64 40 41 42 29 29 0
+0 1 0 55 56 59 29 67 63 60 - 0 - 0 -
+- 0 - 0 57 5 - 59 61 62 48 43 29 43 0
+2 1 0 - 2 58 58 67 50 0 47 45 44 22 29
+2 4 - 0 4 58 66 67 0 - 0 46 20 21 18
+5 7 5 7 - 70 69 67 69 0 - 0 - 20 0
+8 10 8 76 71 68 67 68 19 2 2 2 19 0 -
+11 9 77 11 75 29 29 29 18 18 2 18 18 1 0
+
+[reason]
+ix ur im ci im ix ix - ac wx wx wx wx wx ur
+ik id ix p3 ur ci id ac - ac - ix ix p3 ur
+ix iB - ac id - ix id ix ix ac wx im ci wx
+- wx i1 - ix id ix wx i1 im - p3 im ix -
+im i1 - i1 ix wx ix i1 - i1 is is wx wx ac
+ix - i1 wx ix ci ix ur i1 iB is iB wx p3 -
+ci im p3 ur im wx im ac - ix id - wx cb ix
+p3 im - im p3 ul ix - ac ix wx ix cb - im
+ie wx im Bw im ul im i1 wx ix wx ix wx ix wx
+ie Bj p3 p3 im p3 i1 - i1 ix wx ix wx ix wx
+ul im im - ac im im i1 im ix im ix im p3 uL
+- p3 uL ac - ix ie p3 wx im wx ix uL uL i1
+ac wx i1 p3 ie wx uL uL im ix - ac - i1 -
+- i1 - i1 wx ci - ix ci p3 ie wx ul wx i1
+ix wx i1 - ix ix im ul uL i1 p3 im ix ie uL
+ix id - ac id im iC ul i1 - i1 wx im p3 ur
+ix id ix id - p3 im ul im i1 - ac - im i1
+ix id ix p3 im p3 uL p3 p3 im ix im p3 i1 -
+ix ci im ci wb uL uL uL ur ur im ur ur wx i1

--- a/project/assets/main/nurikabe/official/generated/393.txt.info
+++ b/project/assets/main/nurikabe/official/generated/393.txt.info
@@ -1,1 +1,31 @@
-{"cells":54,"difficulty":0.18035312091782,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.18
+width 8
+height 5
+author 
+
+[solution]
+ . . .## .#### 6 .
+ 4###### .## 2## .
+#### .## .## .## .
+## 3 .## 4###### .
+ 7########## 1## .
+ . . . . . .######
+
+[order]
+6 6 6 6 13 1 0 - 2
+- 5 4 7 13 10 - 0 2
+1 1 4 4 13 2 9 3 2
+0 - 2 3 - 12 0 8 4
+- 0 3 3 5 0 - 0 11
+2 2 2 4 4 6 0 7 11
+
+[reason]
+ix ix ix im ix wx ac - ix
+- wx im wx ix im - ac ix
+wx wx ix im ix ci p3 wx ix
+ac - ix id - wx i1 ic ix
+- ac wx wx id i1 - i1 ix
+ix ix ix ix ix ix i1 wx im

--- a/project/assets/main/nurikabe/official/generated/394.txt.info
+++ b/project/assets/main/nurikabe/official/generated/394.txt.info
@@ -1,1 +1,46 @@
-{"cells":165,"difficulty":11.54506130318,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 11.56
+width 14
+height 10
+author 
+
+[solution]
+################## 7 . .## 1##
+## .## . 2## . . 3#### .######
+## . 3#### 8###### 6## . . .##
+######## . . . .## .##########
+## 2 .###### . .## .##12 . . .
+ .#### 3 .## .#### .## . . . .
+ 4## 2## .#### 6## .#### . . .
+ .## .###### . .## .## 5#### .
+ .#### 2## . .######## .## 1##
+## 1## .## .## 1## . . .######
+########################## 1##
+
+[order]
+11 11 16 2 14 11 4 1 0 - 2 2 0 - 0
+11 12 15 15 - 0 12 2 - 0 1 2 4 0 1
+17 18 - 15 0 - 3 13 0 - 4 5 7 44 44
+11 18 19 22 23 4 25 31 30 5 6 6 43 8 45
+20 - 21 21 24 24 32 26 30 34 36 - 46 46 38
+20 20 0 - 22 29 32 26 34 37 46 46 46 46 46
+- 0 - 0 28 25 32 - 27 48 47 41 46 46 46
+10 2 2 2 27 33 27 34 35 48 48 - 41 0 46
+20 0 2 - 13 13 34 0 36 48 49 50 0 - 0
+0 - 0 12 4 12 0 - 0 40 50 42 41 0 3
+9 0 11 11 11 11 11 0 36 39 41 41 2 - 2
+
+[reason]
+ur ur wx ci wx ur wx wx ac - ix ix i1 - i1
+ur p3 im ix - ac p3 ix - ac wx ix wx i1 wx
+wx ie - im ac - ci im ac - wx ix ix ix im
+ur cb im wx p3 ix ix p3 ic ix wx id Bg ci wx
+iB - ix im wx wx ix ik ic ix id - is is ik
+is iB ac - ix im ix iB wx ix iB is is is is
+- ac - ac p3 ci im - uL ix wx uL is is is
+pk im ix im uL wx ul ix im ix im - uL i1 is
+is i1 im - im ie ie i1 wx im wx ix i1 - i1
+i1 - i1 p3 ci p3 i1 - i1 p3 ie p3 uL i1 wx
+wb i1 ur ur ur ur ur i1 wx ur uL uL i1 - i1

--- a/project/assets/main/nurikabe/official/generated/395.txt.info
+++ b/project/assets/main/nurikabe/official/generated/395.txt.info
@@ -1,1 +1,40 @@
-{"cells":144,"difficulty":12.862936488076,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 12.83
+width 15
+height 8
+author 
+
+[solution]
+ .###### 3 . .## . . . . . . . .
+ .## .########## . . . . . . . .
+ .## .## .## .## . . . . . . . .
+ .## .## .## .######## . . . . .
+ 5## 4## .## .## . 2##########30
+###### . .## 4###### .## . .####
+## . . .###### .## . .## . . . 6
+## 9###### 4 . .## .############
+#### 3 . .######## 5## . . . . 5
+
+[order]
+22 16 24 25 - 27 27 27 46 46 46 46 46 46 46 46
+15 20 24 19 22 26 27 29 46 46 46 46 46 46 46 46
+13 14 18 22 22 22 28 31 34 46 46 46 46 46 46 46
+5 12 13 17 22 21 30 31 33 33 40 41 46 46 46 36
+- 0 - 12 15 20 20 31 32 - 33 40 43 45 35 -
+4 4 3 11 13 14 - 18 19 20 39 23 44 42 1 0
+1 2 5 5 10 14 10 18 18 18 22 37 38 2 2 -
+1 - 0 7 3 - 15 15 17 18 6 5 4 4 1 0
+1 0 - 2 8 8 9 17 17 - 5 5 5 2 2 -
+
+[reason]
+ix ci im wx - ix ix im is is is is is is is is
+ix wx ix ci im wx im wb is is is is is is is is
+ix wx ix im ix im p3 im p3 is is is is is is is
+ix wx ix wx ix wx Bi im im im wb p3 is is is ix
+- ac - id ix wx ix im p3 - im iC ci im Bw -
+wx wx cb ix ix id - im wx id ix ci p3 Bi wx ac
+wx ix ix ix wx wx cb ix im ix ix Bj p3 ix ix -
+wx - ac wx ci - ix ix cb ix wx im wx wx wx ac
+wx ac - ix ix im wx wx wx - im ix ix ix ix -

--- a/project/assets/main/nurikabe/official/generated/396.txt.info
+++ b/project/assets/main/nurikabe/official/generated/396.txt.info
@@ -1,1 +1,40 @@
-{"cells":72,"difficulty":5.12555777396565,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.13
+width 7
+height 8
+author 
+
+[solution]
+ .########## 2 .
+ .## .## 1######
+ .## .#### 3 . .
+ .## 4 .########
+ . 6###### 6 .##
+#### 3 . .## .##
+## 2######## .##
+## .## 2## . .##
+###### .########
+
+[order]
+14 6 13 11 0 11 - 14
+5 13 13 0 - 0 4 10
+2 4 13 11 0 - 2 10
+2 0 - 12 11 0 9 5
+2 - 0 1 5 - 7 11
+1 0 - 2 5 5 14 11
+4 - 0 4 3 15 14 15
+2 5 5 - 19 19 16 15
+7 5 8 20 7 17 18 18
+
+[reason]
+ix ci im ic i1 ic - ix
+ix im ix i1 - i1 id im
+ix wx ix ic i1 - ix ix
+ix ac - p3 ic ac id ci
+ix - ac wx im - ix ic
+wx ac - ix ix im ix ic
+wx - ac id ci wx ix wx
+ci ix im - im ix ix wx
+wx im wx ix ci ci wx wx

--- a/project/assets/main/nurikabe/official/generated/397.txt.info
+++ b/project/assets/main/nurikabe/official/generated/397.txt.info
@@ -1,1 +1,61 @@
-{"cells":480,"difficulty":17.0919460276611,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 17.09
+width 29
+height 15
+author 
+
+[solution]
+ . . . .17## 2###### . . . . . 6#################### 4 . . .
+ . .######## .## .################ . . . .## .## .##########
+ . .## . 2###### . .## . .## . .######## 5## .## .## .## . 2
+ . .###### . . 3## . 5## 4## 3#### . . .#### .## .## .######
+ . .## .################ .#### .###### 4## 5 .## .## .## . .
+ . .## .## . . . . . 6#### 1## . . .#### .###### .## . 5## 3
+ .#### . .############ . 8######## . .## .## .## .##########
+ .## 1## 5## . . . . . .## . . 3#### .## .## .## .## .## . 2
+################################ .## .## .## 3## 8## .######
+## . . . . . 6## . 4## . . . .## .## 9## 5#### .#### 3## . 2
+############## . .## . .#### 7## . 4## .## .## .## .########
+## .## . . 4############## .########## .## .## .## 2## . . .
+## .#### .## . .## . . .## .## . . 3## .## 3## . .######## .
+## . . 5###### 3###### 4## . .######## 4######## . 7## 2## 5
+########## .#### .## .###### . . . . 9## . . . 4###### .####
+ . . . 4## . 3## 2## . . 4###################### . . 3#### 1
+
+[order]
+151 133 133 2 - 0 - 125 9 116 116 93 93 90 90 - 85 83 83 81 81 79 78 32 32 81 - 32 31 82
+151 151 131 130 0 1 127 2 122 121 94 115 91 92 88 88 84 84 82 82 78 77 78 74 75 32 56 30 5 28
+151 151 130 130 - 126 127 124 123 120 116 116 8 89 88 87 85 71 83 69 - 77 73 76 73 54 56 29 29 -
+151 151 133 127 128 128 125 - 119 117 - 0 - 0 - 86 84 84 70 68 57 69 73 72 73 55 53 25 3 4
+151 151 129 131 130 122 125 120 118 117 0 115 114 0 86 86 85 72 67 - 0 - 70 72 53 52 24 5 5 2
+137 136 132 128 127 127 121 119 119 95 - 93 0 - 0 86 73 66 63 54 56 55 51 52 51 50 7 - 0 -
+134 135 0 128 125 125 106 120 99 99 93 92 - 0 88 77 65 64 62 55 53 48 51 50 48 39 22 6 1 0
+138 0 - 0 - 121 121 105 100 97 97 95 90 90 78 - 60 61 51 52 48 50 46 47 17 22 22 2 2 -
+142 133 0 128 111 125 109 104 103 99 96 96 92 79 61 49 60 50 2 20 48 45 - 0 - 16 19 16 1 0
+141 141 130 127 127 110 - 105 103 - 95 93 80 62 59 59 48 0 - 0 - 47 44 48 45 21 - 15 15 -
+142 131 140 128 112 108 107 107 102 100 100 97 63 58 - 4 2 - 0 53 43 47 47 43 11 38 12 18 2 14
+142 143 144 139 109 - 103 103 101 100 98 99 54 58 55 48 47 0 52 45 46 40 41 10 10 - 37 37 13 36
+149 145 147 113 145 105 105 62 100 100 100 57 57 53 48 48 46 - 43 41 2 - 10 10 10 0 9 33 35 2
+149 148 147 - 145 60 61 - 56 57 56 - 52 51 51 48 47 45 0 - 40 39 11 10 10 - 0 - 0 -
+148 149 146 0 26 60 57 1 56 2 56 51 52 50 49 48 46 43 - 0 40 38 38 - 2 23 34 34 1 0
+150 147 27 - 59 58 - 0 - 55 53 53 - 50 50 47 45 42 42 41 39 39 37 36 36 36 - 34 0 -
+
+[reason]
+is ix ix ix - ac - wx ur im ix ix ix ix ix - wx wx wx ic ic wx im uL uL ic - ul pk ix
+is is wx im ac wx ix ci p3 wx ci wx cb wx wx wx im ix ix ix ix ci ix ci p3 uL im wb ci Bj
+is is im ix - ci im im ie ix im ix ix im ix p3 wx ci wx id - wx ix im ix ci ix im ix -
+is is wx ci im ix ix - id ix - ac - ac - im im ix ix ix wx wx ix wx ix wx ix wx ci id
+is is ci p3 wx ci wx id wx wx ac wx pk i1 im ix wx wx wx - ac - ix wx ix wx Bi im ix ix
+ul p3 im ix im ix ix ix ix ix - id i1 - i1 ix ix ix wx ci ix wx im wx ix wx ix - ac -
+ik wb i1 ix ix wx ci wx wx wx id ix - i1 wx wx wx ix ix wx ix ci ix wx ix wx im wx wx ac
+ik i1 - i1 - im ix ix ix ix ix ix im ix ix - im wx ix id ix id ix id ix im ix im ix -
+wb wx i1 wx cb wx wx wx wx id wx wx wx wx wx ci ix wx ix Bw ix cb - ac - cb ix wx wx ac
+im ix ix ix ix ix - id ix - id ix ix ix ix wx ix ac - ac - im ci ix wx Bj - im ix -
+ur ci wx wx wx wx im ix p3 im ix ix wx im - id ix - ac ix ci ix im ix wx ix ci ur ci ic
+ur p3 id ix ix - ci wx wx im ci wx ci ix wx im id ac wx ix id ix id ik iB - im ix ik ix
+im ie wx cb ix im ix ix im ix ix ix wx ix im ix ix - id ix cb - iB ik ik ac ur Bg wx ix
+im ix ix - im im wx - im wx im - id ix ix im id id ac - im id wx iB ix - ac - ac -
+ci im wx ac Bw ix wx wx ix ci ix cb wx wx ix ix ix ix - ac ix ix ix - cb Bg im ix wx i1
+ix ix ix - id ix - ac - id ix ix - wx wx wx wx wx wx wx wx wx wx im ix ix - im i1 -

--- a/project/assets/main/nurikabe/official/generated/398.txt.info
+++ b/project/assets/main/nurikabe/official/generated/398.txt.info
@@ -1,1 +1,37 @@
-{"cells":88,"difficulty":6.64070220273154,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 6.64
+width 10
+height 7
+author 
+
+[solution]
+ 1## 1## 6 . . . . .##
+######################
+ 2## 1## 5 . . . .## .
+ .#### 4############ .
+## 3## .##19 . . . . .
+## .## . .## . . . . .
+## .############ . . .
+###### 4 . . .## . . .
+
+[order]
+- 0 - 0 - 2 5 8 14 14 14
+0 1 0 1 0 4 7 13 12 14 15
+- 0 - 0 - 2 5 11 14 14 16
+2 2 0 - 0 4 9 10 14 18 17
+2 - 4 2 4 - 9 24 24 24 19
+3 5 7 5 8 8 20 24 24 24 24
+7 8 6 7 8 21 12 23 24 24 24
+9 8 10 - 11 11 22 22 24 24 24
+
+[reason]
+- i1 - ac - ix ix ix ix ix im
+i1 wx i1 wx ac id id id ci im wx
+- ac - ac - ix ix ix ix im p3
+ix im ac - ac id wx wx im wb ie
+im - id ix id - ix is is is ie
+wx ix id ix ix im Bi is is is is
+wx ix ci id im wx ci wv is is is
+wx im wx - ix ix ix im is is is

--- a/project/assets/main/nurikabe/official/generated/399.txt.info
+++ b/project/assets/main/nurikabe/official/generated/399.txt.info
@@ -1,1 +1,67 @@
-{"cells":180,"difficulty":1.8555768012205,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 1.86
+width 9
+height 17
+author 
+
+[solution]
+11## 2############ .
+ .## .## . . . 4## 2
+ .############## 2##
+ .## . . . . 7## .##
+ .## .######## 5####
+ .## .## . . . .## 8
+ .################ .
+ . . .## . . . . . .
+ .##################
+#### . . . . . . . 8
+## 1################
+###### . . . . . 6##
+## .############## .
+## . .## . . . .## .
+#### . .###### .## .
+## 1## 6## .## .## .
+########## .## 7## .
+ . . . 4## . 4#### 6
+
+[order]
+- 0 - 10 7 7 3 3 1 2
+2 1 12 2 9 5 5 - 0 -
+2 14 12 14 7 7 3 0 - 0
+16 24 22 16 16 5 - 0 2 1
+27 24 27 20 14 14 0 - 2 3
+27 27 27 18 18 12 12 3 2 -
+28 28 27 20 16 17 10 10 4 5
+29 30 21 18 18 16 16 9 9 5
+32 31 19 20 17 17 14 14 8 7
+26 0 22 18 18 16 16 12 12 -
+0 - 0 18 17 17 14 14 9 11
+24 0 18 18 18 16 16 12 - 10
+25 23 22 18 15 17 13 12 6 10
+25 24 20 18 18 14 14 7 9 5
+23 0 20 7 16 5 6 7 3 5
+0 - 0 - 5 5 5 2 3 2
+22 0 20 0 4 5 0 - 0 2
+22 22 5 - 3 2 - 0 1 -
+
+[reason]
+- ac - wx wx wx wx wx wx ix
+ix wx ix ci ix ix ix - ac -
+ix wx im wx wx wx wx ac - ac
+ix wx ix ix ix ix - ac ix wx
+ix wx ix wx wx wx ac - im wx
+ix im ix im ix ix ix ix cb -
+ix wx im wx ci wx wx wx wx ix
+ix ie p3 im ix ix ix ix ix ix
+p3 wx ci wx wx wx wx wx wx id
+wx i1 ix ix ix ix ix ix ix -
+i1 - i1 im wx wx wx wx cb wx
+wx i1 im ix ix ix ix ix - im
+im p3 wx im ci wx wx wx ci ix
+im ix ix im ix ix ix ix wx ix
+wx i1 ix ix wx im wx ix wx ix
+i1 - i1 - im ix im ix wx ix
+im i1 wx ac wx ix ac - cb ix
+ix ix ix - id ix - ac wx -

--- a/project/assets/main/nurikabe/official/generated/4.txt.info
+++ b/project/assets/main/nurikabe/official/generated/4.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.48

--- a/project/assets/main/nurikabe/official/generated/40.txt.info
+++ b/project/assets/main/nurikabe/official/generated/40.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.90

--- a/project/assets/main/nurikabe/official/generated/400.txt.info
+++ b/project/assets/main/nurikabe/official/generated/400.txt.info
@@ -1,1 +1,37 @@
-{"cells":96,"difficulty":8.41898044457207,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 8.42
+width 11
+height 7
+author 
+
+[solution]
+########## . .## . . . .
+## 3## 4#### 3######## 5
+## .## .## 3#### . 5####
+## .## .## . .## .## 3 .
+###### .######## .#### .
+## .###### 4 .## .## 2##
+## . 3## 1## .###### .##
+############ .## 1######
+
+[order]
+30 30 34 33 9 9 9 7 7 4 4 4
+30 - 0 - 10 0 - 8 5 6 3 -
+30 30 20 14 14 - 0 10 7 - 0 2
+18 19 31 32 26 15 25 24 11 0 - 1
+18 18 30 31 18 16 26 24 23 6 0 4
+18 19 32 30 0 - 17 22 21 20 - 4
+30 31 - 0 - 0 12 27 0 6 19 5
+18 30 30 29 0 13 28 0 - 0 18 18
+
+[reason]
+uL uL wb im im ix ix im ix ix ix ix
+uL - ac - wx ac - wx ci wx wx -
+uL ul cb ix iB - ac wx ix - ac id
+ur p3 im ie im ix p3 im ix ac - ix
+ur ur uL p3 ur id im im ie wx ac ix
+ur p3 im uL i1 - ix id p3 im - im
+uL p3 - i1 - i1 pk wx i1 ci p3 wx
+ur uL uL wx i1 wx ix i1 - i1 ur ur

--- a/project/assets/main/nurikabe/official/generated/401.txt.info
+++ b/project/assets/main/nurikabe/official/generated/401.txt.info
@@ -1,1 +1,40 @@
-{"cells":90,"difficulty":5.69254742712162,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.69
+width 9
+height 8
+author 
+
+[solution]
+#### 5 . . .## 3## 4
+## 2###### .## .## .
+## .## .###### .## .
+###### 2## . .#### .
+ 4## 7#### 3## 1####
+ .## .## 5###### 3##
+ .## .## . . .## .##
+ .## .###### .## .##
+#### . . .##########
+
+[order]
+1 0 - 2 6 22 24 - 0 -
+1 - 0 5 21 25 23 25 1 2
+1 2 2 5 2 25 5 25 25 2
+4 2 0 - 4 2 26 0 3 26
+- 0 - 0 0 - 0 - 0 26
+5 6 2 4 - 0 13 0 - 16
+7 9 7 9 5 19 17 16 15 16
+10 8 10 29 20 18 14 13 14 13
+10 11 30 12 28 27 13 13 13 13
+
+[reason]
+wx ac - ix ix ix id - ac -
+wx - ac im ic ix ci ix wx ix
+wx ix im ix ci im ci ix im ix
+wx im ac - id ix ix i1 ci ix
+- ac - ac ac - i1 - i1 im
+ix id ix id - ac wb i1 - im
+ix id ix id ix ie p3 im ie im
+ix ci ix wx im cb p3 ur p3 ur
+im wx ix ik p3 wx ur ur ur ur

--- a/project/assets/main/nurikabe/official/generated/402.txt.info
+++ b/project/assets/main/nurikabe/official/generated/402.txt.info
@@ -1,1 +1,43 @@
-{"cells":80,"difficulty":2.65375366085871,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 2.65
+width 7
+height 9
+author 
+
+[solution]
+ . . . . . . .##
+11######## . .##
+#### 2 .## .####
+ . 8########## .
+ .## 4 . . .## 2
+ .##############
+ .## 4 .## 1## 2
+ .#### . .#### .
+ .## 1#### .####
+ .###### 4 . .##
+
+[order]
+5 5 5 8 8 10 19 22
+- 4 7 2 9 17 21 20
+3 0 - 8 8 12 15 13
+2 - 0 1 9 11 2 13
+5 0 - 2 9 11 11 -
+5 7 0 8 10 0 1 0
+8 6 - 7 0 - 0 -
+8 10 0 9 9 0 2 2
+11 0 - 0 9 16 15 2
+11 11 0 17 - 14 18 18
+
+[reason]
+ix ix ix ix ix ix Bi im
+- wx wx ci wx ie p3 ci
+id ac - ix im p3 wb im
+ix - ac wx wx im ci ix
+ix ac - ix ix ix im -
+ix wx ac id wx i1 wx ac
+ix cb - ix i1 - i1 -
+ix wx i1 ix ix i1 im ix
+ix i1 - i1 im p3 wb im
+ix im i1 wx - ix ix im

--- a/project/assets/main/nurikabe/official/generated/403.txt.info
+++ b/project/assets/main/nurikabe/official/generated/403.txt.info
@@ -1,1 +1,49 @@
-{"cells":168,"difficulty":6.67549863672264,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 6.68
+width 13
+height 11
+author 
+
+[solution]
+ . . . . . . . . . . . . . .
+ . . .################## . .
+ .22 .## .## 1## .## .######
+######## .#### 3 .## .## .##
+## . .## . . .###### .## .##
+## .######## .## . . .## 3##
+## .## . 2## 7## .######## .
+## 5###### .#### .## . .## 2
+#### . .## . .## .## 3######
+## 2## .#### 4## .11#### .##
+## .## 4## .######## 4 . .##
+######## 3 .## . . 3########
+
+[order]
+45 45 44 40 40 40 40 40 40 40 40 40 43 45
+45 45 45 41 37 39 0 37 35 37 35 41 42 45
+45 - 38 37 37 0 - 0 35 26 35 33 32 33
+34 34 33 36 37 27 0 - 25 34 32 32 32 32
+31 32 35 35 29 25 25 24 13 27 32 31 32 18
+31 30 30 9 27 24 11 13 12 14 29 31 - 17
+28 29 29 29 - 0 - 9 7 11 15 10 9 17
+28 - 23 24 8 23 6 6 5 6 9 16 16 -
+27 0 25 21 22 7 5 4 5 0 - 7 6 7
+20 - 2 21 5 3 - 4 2 - 0 1 6 5
+5 19 20 - 0 3 3 2 1 0 - 2 2 5
+27 20 1 0 - 2 2 2 2 - 0 1 5 5
+
+[reason]
+is is ik ik ik ik ik ik ik ik ik ik ik is
+is is is ic im wx i1 wx im wx im ic p3 is
+is - p3 im ix i1 - i1 ix ci ix wx im wx
+wx id ci wx ix wx i1 - ix wx ix im ix im
+wx ix ix im ix ix ix wx cb wx ix wx ix wx
+wx ix wx ci wx wx ix id ix ix ix wx - im
+wx ix im ix - ac - id ix wx wx ci ci ix
+wx - ci wx ci ix id wx ix wx ix ix im -
+wx ac ix ix wx ix ix wx ix ac - wx im wx
+im - cb ix wx im - wx ix - ac wx ix wx
+ci pk im - ac ix wx im wx ac - ix ix wx
+wx im wx ac - ix im ix ix - ac wx wx wx

--- a/project/assets/main/nurikabe/official/generated/404.txt.info
+++ b/project/assets/main/nurikabe/official/generated/404.txt.info
@@ -1,1 +1,37 @@
-{"cells":120,"difficulty":5.89561875762121,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.90
+width 14
+height 7
+author 
+
+[solution]
+################## 1##########
+## 7 . .## 3 . .###### 4 . .##
+ .#### . .######## 5 .## .####
+ .## 1## . .## 4 .## .###### 1
+ 3########## 4## .## .## 2 .##
+## 2 .## . . .## .## .########
+######################## 4 .##
+ 5 . . . .## 1## 2 .## . .####
+
+[order]
+3 3 3 7 7 9 9 12 0 - 0 18 18 21 26
+2 - 6 6 7 - 10 17 17 0 17 - 19 25 26
+2 2 0 8 8 9 15 11 2 - 15 17 27 24 0
+2 0 - 0 10 13 0 - 12 13 19 28 27 0 -
+- 0 0 9 12 11 - 0 15 21 29 20 - 28 0
+0 - 2 2 5 13 12 14 22 16 29 29 0 28 29
+1 0 2 3 4 6 0 1 22 2 29 30 - 34 33
+- 2 2 3 4 0 - 0 - 23 23 31 32 35 33
+
+[reason]
+wx wx wx wx wx wx wx wx i1 - i1 wx wx wx wx
+im - ix ix id - ix ix im i1 id - ix pk wx
+ix im i1 ix ix id wx ci cb - ix id ix ic i1
+ix i1 - i1 ix ix ac - ix id ix wx im i1 -
+- ac i1 wx id ci - ac ix wx ix cb - ix i1
+ac - ix im p3 ie ix im ix ci ix im ac im wx
+wx cb im wx im wx i1 wx im ci im Bh - p3 ur
+- ix ix ix ix i1 - i1 - ix im p3 ie im ur

--- a/project/assets/main/nurikabe/official/generated/405.txt.info
+++ b/project/assets/main/nurikabe/official/generated/405.txt.info
@@ -1,1 +1,34 @@
-{"cells":70,"difficulty":2.82530713138212,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 4.91
+width 9
+height 6
+author 
+
+[solution]
+#### 2## . 3## 4## 4
+ .## .## .#### .## .
+ .########## . .## .
+ .## . .## 2###### .
+ 4#### .## .## . 4##
+## 1## 4###### . .##
+######## 2 .########
+
+[order]
+21 18 - 14 12 - 0 - 0 -
+21 15 17 13 15 10 1 3 1 3
+21 20 13 16 15 9 9 3 5 3
+3 19 19 12 4 - 6 8 4 6
+- 0 2 3 10 10 10 11 - 6
+0 - 0 - 0 3 12 25 23 7
+1 0 1 0 - 3 3 24 26 22
+
+[reason]
+im im - id ix - ac - ac -
+ix ci p3 ci ix wx wx ix wx ix
+ix wx ci ic im im ix ix wx ix
+ix im ix ix cb - ci wx ci ix
+- i1 wx ix im ix im p3 - im
+i1 - i1 - ac im wx p3 Bi wx
+wx i1 wx ac - ix im ci im ur

--- a/project/assets/main/nurikabe/official/generated/406.txt.info
+++ b/project/assets/main/nurikabe/official/generated/406.txt.info
@@ -1,1 +1,49 @@
-{"cells":264,"difficulty":20.0,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 20.00
+width 21
+height 11
+author 
+
+[solution]
+ . . . . .################ 3 . .## . . . . .
+ .########## 6 . . . . .############12 . . .
+ 7## . .## .############ 4 . . .## 1## . . .
+#### 3## 3 .## 5 . . . .####################
+## .####################10 . . . . . .## 4 .
+## .## . 2## 4 .## 2 .############## .#### .
+## .###### .## . .#### 2 .## .## .## . .## .
+## .## .## .###### 2######## .## 2##########
+## .## .## .## 2## .## . .## .#### . 2## .##
+## 6## .## .## .###### 3## 5 .## .###### .##
+ .#### .## 5#### .## .########## 2## 3## 3##
+ . 3## 5#### 4 . .## 2## 4 . . .#### . .####
+
+[order]
+18 17 17 25 25 25 33 44 68 68 70 70 81 - 73 82 82 83 32 117 117 117
+13 24 17 23 25 67 - 34 45 69 69 80 77 72 74 75 75 0 - 88 117 117
+- 11 16 23 23 67 31 34 39 48 79 71 - 74 74 76 0 - 0 108 117 109
+23 22 - 0 - 25 26 - 35 40 87 97 0 74 77 77 84 0 99 107 116 116
+9 22 10 14 0 66 89 86 96 36 30 97 - 43 78 78 78 85 105 106 - 115
+9 8 21 21 - 0 - 94 29 - 37 37 42 96 65 98 65 104 100 110 114 113
+7 8 6 2 20 93 93 90 95 0 37 - 41 42 65 65 65 65 102 111 111 112
+7 5 5 5 5 19 92 90 46 - 55 42 38 64 62 64 - 64 101 14 63 14
+3 5 4 5 4 19 5 - 55 54 47 49 56 56 62 61 60 103 - 63 63 14
+2 - 4 2 4 2 91 91 14 50 53 - 0 - 57 60 60 14 0 62 62 61
+2 0 1 2 1 - 0 91 51 2 53 1 27 2 57 28 - 0 - 0 - 61
+2 - 0 - 1 0 - 2 93 52 - 0 - 12 15 58 58 59 2 60 60 61
+
+[reason]
+ib ik ik ix ix im Bh Bh wx wx wx wx wx - ix ix im p3 Bi is is is
+ix wx iB im im im - ix ix ix ix ix im cb iB ur iC i1 - Bi is is
+- cb ix ix im ix Bg iB Bg Bg Bj ci - ix ik p3 i1 - i1 p3 is ik
+wx im - ac - ix id - ix ix ix ix ac iB im im wx i1 wx wv im im
+wx ix ci ur ac Bw Bw Bg wx Bj ci im - ix ix ik ik ix ix id - ie
+wx ix im ix - ac - ix Bj - ix im im wx im wx im wx ik Bg wx ie
+wx ix wx ci wx ix im ik ix ac im - Bi im ix im ix im p3 ix im p3
+wx ix im ix im ik wx iB Bj - im im ci wx ix id - ci Bj ur im ur
+wx ix wx ix wx ix cb - im p3 ci Bi ix im ix wx im ix - im ix ur
+im - wx ix wx ix im ix ur ur im - ac - ix im ix ur ac wx ix wx
+ix ac wx ix wx - ac im p3 ci ix wx Bw cb wx ci - ac - ac - wx
+ix - ac - wx ac - ix ix ic - ac - ix ix ix im wx ix ix im wx

--- a/project/assets/main/nurikabe/official/generated/407.txt.info
+++ b/project/assets/main/nurikabe/official/generated/407.txt.info
@@ -1,1 +1,46 @@
-{"cells":132,"difficulty":3.50521298688873,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.51
+width 11
+height 10
+author 
+
+[solution]
+ . .###### . . .## . 3 .
+ .#### 1## 5 .##########
+ .## .########## 1## . .
+ 5## 2## 3 . .#### .## .
+###### .###### 1## .## .
+## . . .## .###### .## .
+## .###### .## 2## 4## .
+## 6## .## .## .###### .
+#### . .## 4#### 2 .## .
+ .## 4###### 2 .###### .
+ 2#### . . 3###### 1##10
+
+[order]
+22 22 22 0 23 36 36 36 36 33 - 37
+19 21 0 - 0 - 35 34 0 32 29 30
+19 17 17 0 21 21 22 0 - 0 31 28
+- 0 - 0 - 22 22 0 0 28 26 28
+18 18 16 20 20 17 0 - 0 25 27 14
+11 17 19 15 13 17 14 0 24 11 12 11
+8 9 14 12 14 12 4 - 0 - 9 7
+8 - 7 12 10 12 2 3 4 5 6 7
+5 7 5 9 11 - 0 2 - 5 5 2
+5 0 - 2 1 0 - 2 2 0 1 2
+- 3 2 2 2 - 0 1 0 - 0 -
+
+[reason]
+ix ix im i1 wx is is is iB ix - ix
+ix wx i1 - i1 - p3 wv i1 wx ci ic
+ix im ix i1 wx cb im i1 - i1 ix ix
+- ac - ac - ix ix i1 i1 ix ci ix
+wx wx cb ix im im i1 - i1 ix id ix
+wx ix ix p3 ci ix wx i1 wx ix id ix
+wx ix wx im wx ix im - ac - id ix
+wx - id ix ci ix ci p3 im im wx ix
+im wx ix ix wx - ac im - ix im ix
+ix ci - im wx ac - ix im i1 wx ix
+- wx im ix ix - ac wx i1 - i1 -

--- a/project/assets/main/nurikabe/official/generated/408.txt.info
+++ b/project/assets/main/nurikabe/official/generated/408.txt.info
@@ -1,1 +1,43 @@
-{"cells":60,"difficulty":0.0612351116516621,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.06
+width 5
+height 9
+author 
+
+[solution]
+ 2 .########
+###### .## 1
+ . 7## 2####
+ .## 3## 1##
+ .## .######
+ .## .## 1##
+ .#### 3####
+ .## . .## 1
+############
+ 5 . . . .##
+
+[order]
+- 5 5 2 1 0
+4 0 1 2 0 -
+2 - 0 - 0 0
+5 0 - 0 - 0
+5 7 2 1 0 6
+8 3 8 0 - 2
+8 10 8 - 0 0
+13 9 11 10 0 -
+13 14 11 12 13 0
+- 15 15 15 15 15
+
+[reason]
+- ix im im wx i1
+id ci wx ix i1 -
+ix - ac - i1 i1
+ix ac - i1 - i1
+ix wx ix wx i1 wx
+ix ci ix ac - i1
+ix wx im - ac i1
+ix ci p3 ix i1 -
+im wx ci im wx i1
+- ix ix ix ix im

--- a/project/assets/main/nurikabe/official/generated/409.txt.info
+++ b/project/assets/main/nurikabe/official/generated/409.txt.info
@@ -1,1 +1,43 @@
-{"cells":160,"difficulty":9.79862673972966,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 10.87
+width 15
+height 9
+author 
+
+[solution]
+ . . 5###### . . 3## . . 6######
+ .###### . 5######## .###### .##
+ .## . . .## . 2## . .## .## .##
+######################## .## .##
+ . .## . . . . . .## .## .## .##
+ .#### . . .######## .## .## .##
+ .## . .###### . .## .## .## .##
+ .##12#### . 2## .## .## 6## 7##
+ .#### .######## 4## . 6###### .
+ . 8## . . . . 6######## 5 . . .
+
+[order]
+61 53 - 29 27 26 26 26 - 21 20 20 - 17 15 16
+61 60 57 29 28 - 26 23 25 22 23 19 18 15 15 15
+61 59 59 55 36 35 35 - 24 24 15 13 18 14 14 12
+61 49 56 58 54 38 25 34 36 24 12 14 12 11 11 12
+48 62 62 63 66 52 39 39 37 9 12 10 8 10 10 8
+48 47 64 65 66 51 50 9 38 10 8 6 8 7 7 8
+32 47 46 51 50 8 39 39 8 6 4 6 2 6 6 5
+32 32 - 45 40 40 - 6 4 3 4 0 - 0 - 4
+32 46 43 45 41 30 3 0 - 3 2 - 0 1 3 4
+33 - 44 42 31 4 2 - 0 1 1 0 - 2 2 4
+
+[reason]
+ix Bi - wx wx im ix ix - id ix ix - wx im wx
+ix wx wx wx Bi - im cb wx wx ix wx im im ix im
+ix im ix ix ix im ix - im ix p3 ci ix wx ix wx
+im ci ci Bj Bw wx ci Bj wx im im wx ix wx ix wx
+ix ix im p3 is ie ie ie p3 ci ix wx ix wx ix wx
+ix wx wx ix is p3 wb ci id wx ix wx ix wx ix wx
+ik wx ix p3 wb ci im ix ix wx ix wx ix wx ix wx
+ik iB - im im ix - id ix wx ix ac - ac - im
+ik wx ci ix wx Bw id ac - wx ix - ac wx id ix
+ib - id ix ix ix ix - ac wx wx ac - ix ix ix

--- a/project/assets/main/nurikabe/official/generated/41.txt.info
+++ b/project/assets/main/nurikabe/official/generated/41.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.37

--- a/project/assets/main/nurikabe/official/generated/410.txt.info
+++ b/project/assets/main/nurikabe/official/generated/410.txt.info
@@ -1,1 +1,52 @@
-{"cells":104,"difficulty":1.5167450348437,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.34
+width 7
+height 12
+author 
+
+[solution]
+ 2## . 3## 4## 6
+ .## .#### .## .
+###### 2## .## .
+## .## .## .## .
+## . 3######## .
+######## . .## .
+## . . 5## 3####
+## . .###### .##
+######## 1## .##
+## .## .#### .##
+## .## . 3## 4##
+## 3###### 5####
+#### . . . .## 1
+
+[order]
+- 4 2 - 0 - 0 -
+5 0 5 0 1 2 1 2
+5 7 5 - 4 2 4 2
+10 8 5 7 5 5 4 5
+10 11 - 7 10 5 7 5
+13 13 12 11 11 8 6 10
+17 18 15 - 0 - 10 10
+19 16 14 13 0 10 10 6
+9 8 11 0 - 0 5 7
+8 8 5 10 0 1 5 4
+6 7 7 2 - 0 - 4
+6 - 3 4 0 - 0 0
+6 5 5 2 2 2 0 -
+
+[reason]
+- id ix - ac - ac -
+ix ci ix ac wx ix wx ix
+im wx im - id ix wx ix
+wx p3 ci ix im ix wx ix
+wx ie - im wx im wx ix
+wx im wx im ix p3 ci ix
+ci p3 ix - ac - im im
+im Bi p3 wx i1 im ix ci
+wx im wx i1 - i1 ix wx
+im ix ci ix i1 wx ix wx
+wx ix wx ix - ac - wx
+wx - ci wx ac - ac i1
+wx im ix ix ix ix i1 -

--- a/project/assets/main/nurikabe/official/generated/411.txt.info
+++ b/project/assets/main/nurikabe/official/generated/411.txt.info
@@ -1,1 +1,64 @@
-{"cells":153,"difficulty":4.00775560437535,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 4.01
+width 8
+height 16
+author 
+
+[solution]
+ .## . . . . 5## .
+ .############## .
+ .## . . . . 5## 3
+ .################
+ 5## . . . . . .##
+############## .##
+## 2 .## . 6## 8##
+ 5###### .## 2## 9
+ .## . . .## .## .
+ .############## .
+ .## . . 3## 3## .
+ .######## . .## .
+## . 2## 2###### .
+######## .## 2## .
+ 3## . 4#### .## .
+ .## .## 1###### .
+ .## .###### 1####
+
+[order]
+28 16 16 13 11 7 - 6 19
+19 27 14 15 12 10 0 18 5
+19 16 16 13 11 8 - 0 -
+17 18 14 15 12 10 7 4 4
+- 16 16 13 11 8 5 2 4
+1 1 2 12 10 7 1 2 1
+0 - 2 2 8 - 0 - 0
+- 0 2 18 11 0 - 0 -
+2 24 24 21 19 2 2 1 2
+25 29 22 23 20 10 2 4 2
+26 24 24 21 - 0 - 3 5
+30 4 24 10 0 8 4 7 5
+25 25 - 0 - 8 5 35 8
+31 25 2 10 10 2 - 9 36
+- 12 11 - 0 10 10 7 36
+32 33 13 0 - 0 0 36 36
+34 14 34 15 0 0 - 0 36
+
+[reason]
+ix im ix ix ix ix - ci ix
+ix wv ci id id id ac ic ix
+ix im ix ix ix ix - ac -
+ix ic ci id id id id wx wx
+- im ix ix ix ix ix ix wx
+wx wx im wx wx wx wx ix wx
+ac - ix im ix - ac - ac
+- ac im ic ix ac - ac -
+ix im ix ix ix im ix wx ix
+ix wx ci id id wx im wx ix
+ix im ix ix - ac - cb ix
+ix ci im wx ac ix ix id ix
+im ix - ac - im id wx ix
+wx im cb im ix ci - cb ix
+- id ix - i1 im ix ci ix
+ix id ix i1 - i1 i1 im ix
+ix ci ix wx i1 i1 - i1 im

--- a/project/assets/main/nurikabe/official/generated/412.txt.info
+++ b/project/assets/main/nurikabe/official/generated/412.txt.info
@@ -1,1 +1,64 @@
-{"cells":153,"difficulty":0.429205623002895,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.43
+width 8
+height 16
+author 
+
+[solution]
+#### . . 3###### .
+ .######## 3 .## 2
+ .## .## .## .####
+ 3## .## 2#### 1##
+#### .#### 1######
+ . . .## 1#### 1##
+ 7########## .## .
+## 4 . . .## .## .
+############ 3## 3
+## 4 . . .########
+ .########## 2 .##
+ .## . . . .######
+ .## 5######## . .
+ .#### 3 . .#### .
+ . . 7###### 1## 4
+######## .########
+ 1## 4 . .## 3 . .
+
+[order]
+13 14 15 2 - 0 1 21 29
+13 13 3 16 0 - 15 16 -
+13 11 13 2 13 13 14 0 28
+- 11 9 11 - 0 0 - 0
+4 5 9 1 0 - 0 0 27
+2 6 6 2 - 0 2 - 2
+- 0 8 8 2 17 18 2 26
+0 - 2 9 10 10 19 20 26
+1 0 7 9 10 13 - 0 -
+6 - 8 8 11 11 0 13 25
+6 6 7 9 9 11 - 13 13
+6 4 6 8 11 11 11 13 23
+2 4 - 0 9 11 12 14 24
+2 1 0 - 2 11 0 22 11
+2 2 - 0 9 0 - 0 -
+0 1 0 4 9 7 0 13 10
+- 0 - 2 6 8 - 9 21
+
+[reason]
+im wx p3 ix - ac wx wx ix
+ix im ci im ac - ie im -
+ix wx ix ci ix im p3 i1 wx
+- wx ix id - i1 i1 - i1
+id wx ix wx i1 - i1 i1 wx
+ix ix ix i1 - i1 i1 - i1
+- ac wx wx i1 wx p3 i1 ix
+ac - ix ix ix im ie im ix
+wx ac wx wx wx wx - ac -
+im - ix ix ix im ac im wx
+ix im wx wx wx im - ix im
+ix wx ix ix ix ix im im wx
+ix wx - ac wx im wx p3 ix
+ix wx ac - ix ix i1 wx ix
+ix ix - ac im i1 - i1 -
+i1 wx ac wx ix ci i1 wx ci
+- i1 - ix ix id - ix ix

--- a/project/assets/main/nurikabe/official/generated/413.txt.info
+++ b/project/assets/main/nurikabe/official/generated/413.txt.info
@@ -1,1 +1,31 @@
-{"cells":60,"difficulty":2.69794326457082,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.44
+width 9
+height 5
+author 
+
+[solution]
+ . 3 .##############
+###### 7 . . . . .##
+ . 2########## .####
+#### . 2## 1###### 1
+ .########## 1## 1##
+ . . . . . 7########
+
+[order]
+8 - 8 8 9 11 11 13 18 7
+6 0 8 - 10 10 12 17 18 18
+6 - 5 0 9 0 14 15 17 0
+6 5 5 - 0 - 0 2 0 -
+15 14 3 4 1 0 - 0 - 0
+16 5 5 3 3 - 0 1 0 1
+
+[reason]
+is - is iB wx wx wx wx im ur
+im ac iB - ix ix ix ix ix im
+ix - im ac wx i1 ic p3 wx i1
+im im ix - i1 - i1 wx i1 -
+p3 ic ci id wx i1 - i1 - i1
+ie ix ix ix ix - ac wx i1 wx

--- a/project/assets/main/nurikabe/official/generated/414.txt.info
+++ b/project/assets/main/nurikabe/official/generated/414.txt.info
@@ -1,1 +1,40 @@
-{"cells":144,"difficulty":4.52127847423083,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 7.09
+width 15
+height 8
+author 
+
+[solution]
+ .########## .################ .
+ .## . . .## .## . . .## . .## .
+ .## .###### .## 4#### .## .## .
+ .## .## .## .#### 1## 2## 4## .
+ .## .## .## 5## .############ .
+ .## 7## 3###### .## . .## .## .
+ . 8## 6#### .## .## 3#### 2## .
+###### . . . .## .#### . 2#### .
+ . 2############ 6 .######11 . .
+
+[order]
+37 25 38 38 18 18 41 21 21 21 18 18 13 20 11 13
+24 36 35 39 39 39 41 22 21 20 19 7 19 10 12 10
+24 17 35 34 33 40 36 21 - 0 7 7 7 6 9 7
+14 15 16 33 33 33 32 35 0 - 0 - 0 - 5 7
+14 14 2 1 33 2 - 31 33 0 8 6 6 4 6 4
+14 0 - 0 - 32 30 32 30 8 7 5 4 4 2 4
+2 - 0 - 0 26 30 28 30 8 - 2 0 - 3 2
+23 0 1 2 24 24 27 29 30 18 2 2 - 0 1 2
+24 - 23 23 23 26 26 29 - 19 3 1 0 - 2 2
+
+[reason]
+ix ci wx wx ur ur ix uL uL uL ur ur ci im ci ix
+ix wx ix ix ix im ix im ul ie p3 im p3 ix id ix
+ix wx ix wx im wx ix uL - i1 im ix im ix id ix
+ik wx ix im ix im ix wx i1 - i1 - ac - cb ix
+ik iB ix wx ix cb - ci ix i1 im id wx im wx ix
+ix ac - ac - wx im wx ix im ie p3 im ix ci ix
+ix - ac - ac wx ix ci ix im - im ac - wx ix
+ic ac wx ix ix ix ix cb ix wb im ix - ac wx ix
+ix - ic ic ic wx wx wx - p3 wx wx ac - ix ix

--- a/project/assets/main/nurikabe/official/generated/415.txt.info
+++ b/project/assets/main/nurikabe/official/generated/415.txt.info
@@ -1,1 +1,37 @@
-{"cells":48,"difficulty":1.70805085398054,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 2.58
+width 5
+height 7
+author 
+
+[solution]
+ . . . .## .
+ . . 8 .## 2
+############
+ 1## 2 .## 1
+## 1########
+###### . . .
+## .###### .
+## . . 4## 5
+
+[order]
+12 12 12 12 2 11
+12 12 - 9 10 -
+0 1 0 2 1 0
+- 0 - 2 0 -
+0 - 0 2 3 0
+1 2 4 4 2 2
+8 6 5 3 1 2
+8 7 4 - 0 -
+
+[reason]
+is is is is ci ix
+is is - ix id -
+i1 wx ac im wx i1
+- i1 - ix i1 -
+i1 - ac im wx i1
+wx i1 im ix ix ix
+im p3 wx wx wx ix
+im ix ix - ac -

--- a/project/assets/main/nurikabe/official/generated/416.txt.info
+++ b/project/assets/main/nurikabe/official/generated/416.txt.info
@@ -1,1 +1,58 @@
-{"cells":150,"difficulty":1.63258080542971,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 1.63
+width 9
+height 14
+author 
+
+[solution]
+ . 3## 4## 3 .## 3 .
+ .#### .#### .#### .
+#### . .## 2#### 6##
+## 3###### .## . .##
+## .## . 3#### .####
+## .## .#### . .## 6
+######## 3######## .
+ 2 .## . .## . . . .
+####################
+ . .## 5 . . . .## 5
+ 3## 5############ .
+#### . . . .## 3## .
+ .########## . .## .
+ .## .## .######## .
+ 3## 2## 2## 2 .####
+
+[order]
+14 - 0 - 0 - 2 4 - 7
+14 13 1 2 1 0 7 3 0 7
+14 11 11 2 4 - 7 9 - 7
+15 - 7 10 9 9 7 10 11 8
+15 16 13 11 - 9 11 14 13 13
+16 16 12 14 0 16 17 14 16 -
+17 9 19 14 - 19 18 18 16 19
+- 19 19 20 21 22 23 24 24 19
+7 5 11 21 21 26 25 25 22 21
+4 9 0 - 24 24 27 27 27 -
+- 0 - 0 7 6 26 27 28 29
+2 3 2 4 5 9 9 - 30 29
+2 2 2 4 2 9 34 31 33 31
+2 1 2 1 2 1 34 2 32 34
+- 0 - 0 - 0 - 36 35 34
+
+[reason]
+ix - ac - ac - ix id - ix
+ix wx wx ix wx ac ix ci ac ix
+im im ix ix id - im wx - im
+wx - ci wx im ix ci p3 ix wx
+wx ix wx ix - im wx ix wx wx
+im ix ci ix ac wx p3 ix wx -
+wx ci wx im - wx im im wx ix
+- ix im p3 ix im p3 ix ix ix
+id ci wx wx wx wx im im wx id
+ix ix ac - ix ix ix ix im -
+- ac - ac wx ci wx im wx ix
+im wx ix ix ix ix im - id ix
+ix im im wx im im ix ix id ix
+ix wx ix wx ix wx im ci ci ix
+- ac - ac - ac - p3 wx im

--- a/project/assets/main/nurikabe/official/generated/417.txt.info
+++ b/project/assets/main/nurikabe/official/generated/417.txt.info
@@ -1,1 +1,49 @@
-{"cells":156,"difficulty":13.0055079529347,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 13.01
+width 12
+height 11
+author 
+
+[solution]
+ . 2############ 7## 2## .
+#### 4 .## 4 .## .## .## .
+## 3## . .## .## .###### 3
+## .######## .## . .## 1##
+## .## 5 .###### .########
+#### 7## .## 2## .## . . 3
+## . .## .## .############
+## .#### .#### . . .## 2 .
+## .## 2## 1## . . .######
+## .## .###### . . .## 1##
+## .###### 1## . . .####19
+###### . 2#### . . . . . .
+
+[order]
+2 - 0 1 4 10 10 12 - 0 - 3 3
+1 0 - 2 4 - 11 12 13 1 4 2 2
+4 - 0 5 8 8 13 15 13 15 4 0 -
+4 5 7 7 6 10 17 14 17 16 0 - 0
+7 8 0 - 8 18 17 18 39 38 17 0 1
+10 8 - 0 19 9 - 35 39 37 37 24 -
+28 29 10 20 19 31 34 18 39 40 25 2 36
+28 28 30 20 32 0 33 41 41 41 41 - 42
+28 28 23 - 0 - 0 41 41 41 25 0 1
+28 27 21 22 23 0 25 41 41 41 0 - 0
+25 26 25 2 0 - 2 41 41 41 4 0 -
+25 25 2 2 - 0 1 41 41 5 2 2 2
+
+[reason]
+ix - ac wx wx wx wx wx - ac - im ix
+wx ac - ix id - ix cb ix wx ix ci ix
+wx - ac ix ix im ix wx ix wx im i1 -
+wx ix wx id ci wx ix ci ix p3 i1 - i1
+wx ix ac - ix wx im wx ix wx wx i1 wx
+wx im - ac ix cb - im ix im ix ix -
+uL p3 ix wx ix Bj p3 ci im wx iC cb Bg
+uL ul im wx ix i1 iC is is is iB - ix
+uL ul im - i1 - i1 is is is iC i1 wx
+uL ie ci pk im i1 wb is is is i1 - i1
+ur p3 ur im ac - i1 is is is wx i1 -
+ur ur im ix - ac wx is is ix ix ix ix

--- a/project/assets/main/nurikabe/official/generated/418.txt.info
+++ b/project/assets/main/nurikabe/official/generated/418.txt.info
@@ -1,1 +1,40 @@
-{"cells":90,"difficulty":1.64613633237085,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 1.65
+width 9
+height 8
+author 
+
+[solution]
+######## 5 . . . .##
+## . .##############
+## 3## 4 . . .## .##
+ 2############## 2##
+ .## . .## . . .####
+#### 3## . .###### .
+## .#### 6## 2 .## .
+## . 3############ .
+######10 . . . . . .
+
+[order]
+4 4 3 7 - 10 12 12 19 19
+1 2 5 5 8 11 11 18 13 19
+0 - 0 - 10 10 16 16 18 17
+- 0 7 8 9 15 12 16 - 17
+2 2 7 8 8 12 16 16 16 14
+2 5 - 5 10 10 11 7 14 14
+3 5 0 7 - 0 - 12 12 14
+4 2 - 0 4 11 6 12 13 14
+4 1 0 - 2 5 12 12 13 14
+
+[reason]
+wx wx ci wx - ix ix ix ix im
+wx ix ix im wx wx wx wx ci wx
+ac - ac - ix ix ix im ix wx
+- ac wx wx wx wx ci im - wx
+ix im ix ix im ix ix ix im im
+im im - cb ix ix id ci im ix
+ci ix ac wx - ac - ix im ix
+wx ix - ac id wx cb im wx ix
+wx wx ac - ix ix ix ix ix ix

--- a/project/assets/main/nurikabe/official/generated/419.txt.info
+++ b/project/assets/main/nurikabe/official/generated/419.txt.info
@@ -1,1 +1,49 @@
-{"cells":156,"difficulty":1.76106500048411,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 1.76
+width 12
+height 11
+author 
+
+[solution]
+ . . . 7## 2## . 3#### 4 .
+ .######## .## .#### 3## .
+ .## . . 3######## . .## .
+ .########## . .##########
+## 2## . . 4## .## .## . .
+## .## .###### 4## . 3## 3
+######## 1## 2## .########
+ .## .###### .## .## . . 7
+ .## . . . 5#### 3## .####
+ .############ 1#### .## 3
+ . .## .## .###### . .## .
+ . 7## 2## . 4 .######## .
+
+[order]
+22 17 17 - 0 - 10 9 - 1 0 - 2
+22 21 16 15 1 12 2 12 7 1 - 0 2
+22 19 19 15 - 12 13 12 6 6 2 2 2
+22 22 16 18 14 13 13 12 7 3 4 3 2
+22 - 18 17 17 - 10 9 8 5 3 3 2
+23 24 19 19 0 15 0 - 8 7 - 0 -
+25 24 25 0 - 0 - 0 10 6 6 1 0
+32 31 29 28 0 2 2 2 10 6 2 2 -
+33 31 30 27 27 - 2 0 - 9 7 1 0
+33 34 28 25 26 25 0 - 0 12 10 9 -
+36 35 1 25 2 25 21 0 18 18 15 12 10
+37 - 0 - 24 22 - 20 19 16 17 11 15
+
+[reason]
+ix ix ix - ac - id ix - wx ac - ix
+ix wx wx wx wx ix ci ix wx wx - ac ix
+ix im ix ix - im wx im im ix ix im ix
+ix im ci wx wx im ix ix wx ci wx wx im
+im - id ix ix - id ix im p3 im ix ix
+wx ix im ix i1 wx ac - im ix - ac -
+wx im wx i1 - i1 - ac ix wx wx wx ac
+p3 im p3 wx i1 im ix im ix cb ix ix -
+ie im ix ix ix - im i1 - id ix wx ac
+ie wx wx im wx im i1 - i1 wx ix wx -
+ie p3 wx ix ci ix wx i1 im ix ix wx ix
+ix - ac - id ix - p3 wx ci wx ci ix

--- a/project/assets/main/nurikabe/official/generated/42.txt.info
+++ b/project/assets/main/nurikabe/official/generated/42.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.15

--- a/project/assets/main/nurikabe/official/generated/420.txt.info
+++ b/project/assets/main/nurikabe/official/generated/420.txt.info
@@ -1,1 +1,40 @@
-{"cells":99,"difficulty":5.76873928783758,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 5.77
+width 10
+height 8
+author 
+
+[solution]
+############## . . . 4
+## .## 2## .##########
+## .## .## .## . . . .
+## . .#### . .###### 5
+#### .## 1## .## . 2##
+ .## .###### .########
+ .## .## 1## 7## . . 4
+ .## . 9######## .####
+ 4###### 3 . .###### 1
+
+[order]
+17 17 17 21 17 17 9 9 6 6 -
+17 18 21 - 16 18 10 7 8 5 4
+23 22 21 20 19 13 9 9 6 6 2
+23 22 11 15 0 13 13 8 2 0 -
+9 10 9 0 - 0 12 2 2 - 0
+9 7 9 8 0 14 6 3 2 1 1
+6 8 6 0 - 0 - 4 2 2 -
+6 4 2 - 0 1 2 3 6 1 0
+- 4 1 0 - 2 2 2 6 0 -
+
+[reason]
+ur ur ur im ur ur im ix ix ix -
+ur p3 im - ci p3 wx ci wx wx id
+im ie im p3 im ik im ix ix ix ix
+im ix ix wx i1 ik ix wx im ac -
+im wx ix i1 - i1 ix im ix - ac
+ix ci ix wx i1 wx ix wx im wx wx
+ix wx ix ac - ac - id ix ix -
+ix cb ix - ac wx im ci ix wx i1
+- wx wx ac - ix ix im im i1 -

--- a/project/assets/main/nurikabe/official/generated/421.txt.info
+++ b/project/assets/main/nurikabe/official/generated/421.txt.info
@@ -1,1 +1,34 @@
-{"cells":70,"difficulty":1.86900981163337,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 1.87
+width 9
+height 6
+author 
+
+[solution]
+## . . . . 6## 2## 2
+###### .###### .## .
+## .###### .########
+## 2## .## .## . . .
+ .#### 2## .###### .
+ . .#### 5 .## .## .
+ . . . 7###### 2## 6
+
+[order]
+16 16 16 10 10 - 0 - 0 -
+15 13 15 14 9 8 1 2 0 2
+12 13 13 13 8 8 8 2 4 2
+11 - 2 13 4 7 7 7 7 7
+11 11 12 - 0 3 6 5 6 2
+11 11 1 0 - 2 2 5 1 2
+11 2 2 - 0 1 4 - 0 -
+
+[reason]
+im ix ix ix ix - ac - ac -
+wx im wx p3 wx im wx ix ci ix
+wx ix im im im ix wx im wx im
+iB - ci ix wx ix im ix ix ix
+is iB wx - ac ix wx im wx ix
+is is wx ac - ix ci ix wx ix
+is ix ix - ac wx wx - ac -

--- a/project/assets/main/nurikabe/official/generated/422.txt.info
+++ b/project/assets/main/nurikabe/official/generated/422.txt.info
@@ -1,1 +1,37 @@
-{"cells":88,"difficulty":17.6756283495518,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 16.53
+width 10
+height 7
+author 
+
+[solution]
+ . . . . .#### 4 .## .
+###### 7 .## 2## .## 2
+## . 6###### .## .####
+## .## 6 .########## 9
+## .#### . .## . . . .
+## .## 2## .## . . . .
+## .## .## .##########
+############## . . . 4
+
+[order]
+8 8 8 8 21 1 0 - 2 2 5
+9 8 0 - 21 21 - 0 3 4 -
+9 2 - 0 1 2 22 4 5 1 0
+9 10 0 - 2 23 22 23 5 6 -
+11 10 11 0 24 24 26 27 37 29 7
+11 12 14 - 20 25 26 33 37 37 37
+14 15 13 19 15 19 26 34 36 36 31
+16 15 17 18 18 18 28 35 32 30 -
+
+[reason]
+ik ik ik ix is wx ac - ix ci ix
+wx iB ac - is iB - ac ix id -
+wx ix - ac wx ci ix wx ix wx ac
+wx ix ac - ix wx im wx im wx -
+wx ix wx ac ix ix im p3 is Bi ix
+wx ix id - im Bi im ik is is is
+wx ix ci p3 ci p3 im iC im im Bg
+wx im wx ur ur ur wx p3 Bi Bi -

--- a/project/assets/main/nurikabe/official/generated/423.txt.info
+++ b/project/assets/main/nurikabe/official/generated/423.txt.info
@@ -1,1 +1,31 @@
-{"cells":60,"difficulty":0.127891231734458,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.13
+width 9
+height 5
+author 
+
+[solution]
+ . . . . 5##########
+########## 3## . 7##
+## . 2## . .## .## 4
+###### 4###### .## .
+## . . .## . . .## .
+################## .
+
+[order]
+14 14 14 2 - 0 1 1 1 1
+14 2 3 13 0 - 4 2 - 0
+4 4 - 0 12 5 4 5 0 -
+15 4 0 - 6 10 7 5 7 2
+14 14 14 7 10 10 10 8 7 8
+15 14 13 13 11 10 9 9 8 8
+
+[reason]
+ix ix ix ix - ac wx wx wx wx
+im ci cb wx ac - wx ix - ac
+im ix - ac ix ix wx ix ac -
+wx im ac - ci im wx ix wx ix
+im ix ix ix im ix ix ix wx ix
+wx im wx wx wx im wx wx im ix

--- a/project/assets/main/nurikabe/official/generated/424.txt.info
+++ b/project/assets/main/nurikabe/official/generated/424.txt.info
@@ -1,1 +1,67 @@
-{"cells":486,"difficulty":4.91414338247252,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 4.91
+width 26
+height 17
+author 
+
+[solution]
+ . . . . . . . . . .11## . . . . . . . 8##############
+######################################## 7 . . .## 1##
+## . . . 4## 1## . . . 4## . 4## . . . 5###### . .####
+############## 6######## . .#### .###### 9 .#### .## 6
+ . .## . . . . .## . .###### . 9## 4## 4## . .###### .
+ .################## . . . . .#### .## .#### . . .## .
+ .## .## . . . . . 6############ . .## . .###### .## .
+ .## .################ . . . . .########## 3 .## .## .
+ .## . .##12 . . . . . .########## 1## 3#### .###### .
+ .#### . 6################ .## 2 .## . .## 2#### . 4##
+ .## .###### .## . . . .## . 3############ .## . .####
+ 9## 2## 1## 2######## .###### . .## .## 1########## 3
+############## . . .## .## .## 3#### .###### 3 .## . .
+## .## .## .###### 4## .## .#### . . .## .#### .######
+## .## .## 2## . 3#### 8## .## . .###### . .###### . 4
+## .## . .#### .## . .#### 4## .## 1## . .#### 1## . .
+## . 5## . 6######## .## .#### 9###### .#### .########
+############ . . 3## 4## . . 4#### 9 . .## 3 .## 2 .##
+
+[order]
+117 89 86 64 64 61 61 61 29 29 - 21 21 7 7 4 4 2 2 - 0 1 3 3 6 0 23
+90 116 88 85 62 63 0 60 59 28 27 22 8 20 5 6 3 3 1 0 - 2 2 4 0 - 0
+116 116 86 84 - 0 - 0 59 59 27 - 20 19 - 6 4 2 2 - 0 1 3 4 21 0 24
+114 89 115 82 83 76 0 - 59 57 58 26 26 21 17 5 7 3 1 0 - 2 6 20 21 21 -
+113 112 84 84 81 78 75 61 59 59 56 53 22 23 15 - 0 - 0 - 0 7 19 23 21 25 26
+103 111 103 83 79 79 76 74 61 55 54 54 52 52 26 14 9 4 6 2 9 17 26 29 29 30 26
+103 101 103 81 81 78 78 75 72 - 55 53 53 51 51 12 12 12 9 12 15 15 27 27 32 30 32
+100 102 100 97 80 79 76 76 74 71 67 66 52 52 50 49 12 0 14 14 13 - 17 32 32 32 32
+100 99 98 96 0 - 79 75 75 72 70 68 65 19 20 48 0 - 0 - 36 0 35 29 32 33 33
+95 99 94 2 - 0 76 78 73 74 71 69 16 19 0 - 47 0 47 38 15 - 35 36 35 - 33
+94 94 94 94 0 76 76 75 75 72 70 19 18 15 - 0 15 46 39 48 0 36 17 37 38 34 34
+- 0 - 0 - 0 - 73 74 71 17 15 17 11 14 15 15 15 47 0 - 0 38 39 39 40 -
+93 92 93 92 0 84 75 75 72 15 14 15 11 11 11 - 14 17 36 48 0 65 - 45 44 44 41
+91 92 87 92 17 84 76 74 0 - 14 12 10 10 10 6 12 15 19 35 49 110 105 104 105 42 43
+91 89 91 86 83 - 15 14 - 0 9 - 4 9 9 4 12 0 17 20 32 109 108 0 65 106 -
+88 89 85 84 81 0 75 75 12 12 7 9 7 - 3 2 0 - 0 19 21 30 0 - 0 31 107
+88 86 - 79 78 - 16 75 14 1 7 5 7 3 0 - 1 0 14 19 18 23 29 0 30 29 33
+88 85 85 79 77 76 76 15 - 0 - 6 4 2 - 0 1 - 2 15 17 - 26 27 - 32 32
+
+[reason]
+ix ix ix ix ix ix ix ix ix ix - im ix ix ix ix ix ix ix - ac wx wx wx wx i1 wx
+ci im id id cb wx i1 wx im wx wx wx ci id cb wx wx wx wx ac - ix ix ix i1 - i1
+im ix ix ix - i1 - i1 ix ix ix - id ix - id ix ix ix - ac wx wx ix ix i1 wx
+im ci wx ci id wx i1 - im ci wx im ix ix id ci ix id wx ac - ix wx wx ix im -
+ie p3 im ix ix ix ix ix im ix ix wx ci id ix - ac - ac - ac ix ix wx im wx ix
+ix wx im wx wx wx wx wx wx id ix ix ix ix ix wx wx ix id ix wx wx ix ix ix wx ix
+ix ci ix im ix ix ix ix ix - id wx wx wx wx im ix ix wx ix ix im wx wx ix wx ix
+ix id ix wx wx id wx wx wx wx wx ie ie ie ie p3 im i1 wx id ci - ix im ix im ix
+ix cb ix ix ac - ie ie ie ie ie ie ic im wx im i1 - i1 - wx ac ix ci im wx ix
+ix wx im ix - ac im wx ci id id id ci ix ac - p3 i1 p3 ix cb - im wx ix - im
+ix im ix im i1 im ix im ix ix ix ix wx ix - ac im wb ci im i1 ix ci p3 ix wx wx
+- ac - i1 - i1 - ci wx wx wx ix wx im wx ix ix im p3 i1 - i1 wx im im wx -
+wx im wx im i1 im im ix ix ix wx ix im ix im - id wx ix im i1 ic - p3 im ix ix
+wx ix ci ix ci ix wx wx ac - wx ix wx ix wx id ix ix ix wx p3 im im pk im ci id
+wx ix wx ix id - id ix - ac id - cb ix wx ix ix i1 wx wx ix p3 wv i1 ic p3 -
+wx ix id ix ix ac im ix im ix ix wx im - id ix i1 - i1 ix ix wx i1 - i1 p3 ix
+wx ix - id ix - ci im wx wx ix ci ix id ac - wx i1 wx ix wx wx ix i1 wx ci wx
+wx wx wx wx wx im ix ix - ac - id ix ix - ac wx - ix ix id - ix id - ix im

--- a/project/assets/main/nurikabe/official/generated/425.txt.info
+++ b/project/assets/main/nurikabe/official/generated/425.txt.info
@@ -1,1 +1,37 @@
-{"cells":80,"difficulty":0.0,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.00
+width 9
+height 7
+author 
+
+[solution]
+ . . 4## 2## 2## 2##
+ .###### .## .## .##
+## . 2##############
+###### 1## .## . 2##
+## . 2#### .###### 2
+###### 5 . .## 1## .
+## . 2##############
+######## 1## 2 .## 1
+
+[order]
+3 2 - 0 - 0 - 0 - 7
+3 2 0 1 2 1 2 1 6 2
+2 2 - 0 2 8 2 2 5 1
+8 1 0 - 0 9 3 4 - 0
+2 2 - 0 1 2 10 0 0 -
+9 1 0 - 2 2 0 - 0 2
+12 12 - 0 0 1 10 0 8 0
+13 2 11 0 - 0 - 9 0 -
+
+[reason]
+ix ix - ac - ac - ac - im
+ix im ac wx ix wx ix wx p3 ci
+im ix - i1 im wx im ci im wx
+wx wx i1 - i1 p3 ci p3 - ac
+im ix - i1 wx ix im i1 ac -
+wx wx ac - ix ix i1 - i1 ix
+im ix - ac i1 wx im i1 wx i1
+wx ci wx i1 - i1 - p3 i1 -

--- a/project/assets/main/nurikabe/official/generated/426.txt.info
+++ b/project/assets/main/nurikabe/official/generated/426.txt.info
@@ -1,1 +1,43 @@
-{"cells":90,"difficulty":15.7521867896878,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 15.75
+width 8
+height 9
+author 
+
+[solution]
+############ .## .
+## 4 . . .## 2## 3
+ 2############## .
+ .## . . .## 2 .##
+#### . .##########
+13 . . .## . 2## .
+ . . . .###### 3 .
+########## 4######
+ 3## 2 .## . . .##
+ . .##############
+
+[order]
+1 1 1 4 17 2 29 22 21
+0 - 2 25 28 28 - 0 -
+- 0 27 16 26 24 0 20 23
+2 2 27 15 19 18 - 20 20
+2 3 27 27 14 2 0 5 5
+- 27 27 27 2 2 - 0 6
+27 27 27 13 10 2 0 - 7
+27 26 12 12 10 - 12 8 8
+- 0 - 11 10 11 9 6 5
+28 28 12 5 10 10 10 5 5
+
+[reason]
+wx wx wx wx Bh ci ix Bg ix
+ac - ix Bi ix im - ac -
+- ac iB cb wv iC ac im ix
+ix im is ik p3 Bj - ix im
+im wx is is wb im ac ur ur
+- is is is im ix - ac p3
+is is is p3 uL im ac - ie
+iB wv im im uL - im im im
+- ac - p3 uL p3 ie p3 ur
+ix ix im ur uL uL uL ur ur

--- a/project/assets/main/nurikabe/official/generated/427.txt.info
+++ b/project/assets/main/nurikabe/official/generated/427.txt.info
@@ -1,1 +1,40 @@
-{"cells":99,"difficulty":0.0,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.00
+width 10
+height 8
+author 
+
+[solution]
+ . . 3#### 4 .## 3## 3
+######## 3## .## .## .
+## .## . .## .## .## .
+## .##################
+## . . .## .## . . .##
+#### 6#### .## 4######
+## 1## 1## . 4#### .##
+ 1############ 4 . .##
+#### . . . . 5########
+
+[order]
+21 17 - 1 0 - 2 9 - 0 -
+18 20 15 1 - 0 11 10 11 1 2
+20 20 14 14 2 11 11 11 11 2 2
+19 20 16 14 11 9 11 12 11 14 2
+19 17 2 8 4 9 9 13 15 15 15
+1 0 - 0 7 3 0 - 14 11 14
+0 - 0 - 2 2 - 0 1 11 9
+- 0 1 0 6 1 0 - 2 2 9
+2 3 4 5 2 2 - 0 1 9 9
+
+[reason]
+ix ix - wx ac - ix id - ac -
+ci im wx wx - ac ix wx ix wx ix
+im ix im ix ix im ix im ix im ix
+wx ix wx im wx im im wx im wx im
+wx ix ix p3 ci ix im p3 ix ix im
+wx i1 - i1 wx ix ac - wx im wx
+i1 - i1 - i1 ix - ac wx ix wx
+- i1 wx i1 im wx ac - ix ix wx
+i1 wx p3 ie ix ix - ac wx wx wx

--- a/project/assets/main/nurikabe/official/generated/428.txt.info
+++ b/project/assets/main/nurikabe/official/generated/428.txt.info
@@ -1,1 +1,64 @@
-{"cells":170,"difficulty":3.98263225682029,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.98
+width 9
+height 16
+author 
+
+[solution]
+######## 8 . . .## 4
+## .## 4###### .## .
+## 2## . . .## .## .
+ 7############ .## .
+ . .## 3 . .## .####
+ .## 3########## 4##
+ .## . .## 7 .## .##
+ .###### 4## .## .##
+ .## 3## .## .## .##
+#### .## .## .######
+ .## .## .## . .## 7
+ .#### 1########## .
+ .## 5#### .## 7## .
+ 4## .## 4 .## .## .
+#### . .## .## .## .
+## 1## .###### .## .
+########## . . .## .
+
+[order]
+5 4 1 0 - 2 12 12 13 -
+1 4 2 - 0 10 11 15 14 15
+0 - 2 4 9 10 10 15 17 15
+- 0 6 5 9 10 17 18 16 18
+2 7 0 - 9 15 15 18 18 18
+8 3 - 0 13 10 17 18 - 19
+8 9 4 12 0 - 12 19 20 19
+12 9 5 12 - 0 20 21 20 21
+12 12 - 2 13 21 22 21 22 21
+12 52 13 23 22 23 22 23 22 23
+53 24 51 0 24 23 24 36 36 -
+54 50 0 - 0 26 35 25 37 38
+48 28 - 0 33 34 36 - 39 38
+- 2 29 30 - 35 41 40 41 40
+55 0 31 31 33 42 38 42 43 42
+0 - 0 35 32 42 56 44 46 44
+27 0 36 35 50 51 49 57 45 47
+
+[reason]
+wx im wx ac - ix ix ix id -
+wx ix ci - ac im wx ix wx ix
+ac - cb ix ix ix im ix wx ix
+- ac wx id wx wx wx ix ci ix
+ix p3 ac - ix ix im ix im im
+ix cb - ac wx ci wx im - wx
+ix wx ix ix ac - ix wx ix wx
+ix wx id im - ac ix wx ix wx
+ix im - cb ix wx ix wx ix wx
+im im ix id ix wx ix wx im wx
+p3 ci p3 i1 ix wx ix ix im -
+ie wb i1 - i1 wx wx ci wx ix
+ix ic - i1 wx p3 id - id ix
+- cb ix id - ix id ix id ix
+im i1 ix ix id ix ci ix id ix
+i1 - i1 ix ci im wx ix id ix
+wb i1 wx im ur p3 ik ix ci ix

--- a/project/assets/main/nurikabe/official/generated/429.txt.info
+++ b/project/assets/main/nurikabe/official/generated/429.txt.info
@@ -1,1 +1,31 @@
-{"cells":54,"difficulty":6.63127411275794,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 6.63
+width 8
+height 5
+author 
+
+[solution]
+ .############## .
+ .## .## .## .## 5
+ .## .## 2## 2## .
+ .## 3#### 1## . .
+ .#### .##########
+ . 7## 2## 1## 2 .
+
+[order]
+9 7 9 10 9 12 14 18 11
+6 8 9 2 9 1 14 2 -
+6 5 6 8 - 0 - 13 13
+4 5 - 2 0 - 0 17 15
+4 3 1 2 1 0 1 16 2
+4 - 0 - 0 - 0 - 19
+
+[reason]
+ix ci im wx im Bh im im ix
+ix wx ix ci ix wx ix ci -
+ix wx ix id - i1 - iB ix
+ix wx - im i1 - i1 p3 ix
+ix wx wx ix wx i1 wx wv ci
+ix - ac - ac - ac - ix

--- a/project/assets/main/nurikabe/official/generated/43.txt.info
+++ b/project/assets/main/nurikabe/official/generated/43.txt.info
@@ -1,7 +1,7 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
-difficulty 12.48
+difficulty 11.61
 width 10
 height 12
 author poobslag v02
@@ -26,27 +26,27 @@ author poobslag v02
 12 11 2 7 10 5 0 - 0 8 7
 12 8 8 - 0 11 - 0 - 25 25
 12 13 8 0 - 2 12 1 20 15 26
-14 41 40 40 4 13 12 20 20 20 -
-36 44 42 14 39 13 22 21 24 23 27
-44 43 16 40 38 22 22 0 23 28 27
-4 10 16 9 19 37 0 - 0 29 30
+14 40 39 39 4 13 12 20 20 20 -
+43 43 41 14 36 13 22 21 24 23 27
+43 42 16 38 37 22 22 0 23 28 27
+4 10 16 9 19 44 0 - 0 29 30
 4 4 8 17 17 31 50 0 23 46 52
 - 0 - 6 18 33 51 51 34 32 52
 2 3 0 6 3 5 - 45 47 33 47
 2 0 - 2 4 0 1 49 35 35 -
-2 - 0 1 0 - 0 - 49 19 48
+2 - 0 1 0 - 0 - 49 15 48
 
 [reason]
 ix ix - id ix - id ix ix ix ix
 ix wx ci ci ix wx ac - ac wx ci
 ix im ix - ac wx - ac - ix im
-ix wx im ac - cb ix wx ix ic wx
+ix wx im ac - cb ix wx ix wb wx
 ix p3 im ix ix wx ix iB ik iB -
-Bi is wx ci id wx ix wx p3 wb ix
+is is wx ci Bj wx ix wx p3 wb ix
 is ie ik ie p3 im ix i1 wb wx ix
-im wx iB ci iC Bw i1 - i1 p3 ix
+im wx iB ci iC wx i1 - i1 p3 ix
 ix im ix ix im pk wx i1 iC Bi is
 - ac - im wx ul ix im ik ik is
-im wx ac ix ci p3 - Bj ic uL ic
+im wx ac ix ci p3 - Bg ic uL ic
 ix ac - ix wx i1 wx is ik iB -
 ix - ac wx i1 - i1 - is iC ix

--- a/project/assets/main/nurikabe/official/generated/430.txt.info
+++ b/project/assets/main/nurikabe/official/generated/430.txt.info
@@ -1,1 +1,82 @@
-{"cells":483,"difficulty":7.42670278062644,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 7.43
+width 20
+height 22
+author 
+
+[solution]
+ . .14###### . . . . . . 7################
+ . . .## .################## . . . . . .##
+ . . .## 2## .## . 2## . 4############ 7##
+#### . .#### 6###### . .## .## . . . .####
+## 1## . .## .## .######## 2######## 5## .
+######## .## .## . . . . 6## . . . 4#### .
+ .## .#### . .###################### .## .
+ .## . .######## . . 3## . . . . .## .## .
+ .#### 4## . . .######## .###### 7## .## .
+ .## .######## .## . . 3#### . .#### .## .
+ .## .## . .## .########## 1## . .## 5## 7
+ .## 3#### 3## 6## . . .######## . .######
+ .#### .#### .######## .## . . 3## . . .##
+ .## . .## . .## . .## .##############10##
+ .## .#### .###### 3## . . . 9## . 5 .## .
+ .## .## . .## .#### .######## . .###### .
+ .## .## 7#### . .## 2## . .######## 1## .
+12## 7#### . 2## .###### 3#### .## .#### .
+###### . 2###### 5## .#### .## .## . .## 5
+## .######## . .#### . .## 2## .#### . 5##
+## . . . . 6## . . 5## . 5#### . . 6######
+########################## .######## 1## 2
+ . . . . . . . . . . .12## . . . 5###### .
+
+[order]
+118 118 - 117 103 72 72 72 67 67 63 63 - 61 57 58 54 54 50 50 50
+118 118 118 103 103 98 72 70 69 64 65 62 0 60 60 56 56 52 52 49 48
+118 118 97 97 - 74 73 69 69 - 58 56 - 54 57 56 54 54 47 - 48
+101 0 97 102 102 114 - 74 65 67 67 63 54 54 2 56 56 49 46 2 47
+0 - 0 104 113 114 115 76 70 69 64 65 0 - 53 56 50 0 - 45 47
+95 0 105 111 112 116 115 76 75 72 67 58 - 0 58 52 46 - 0 46 44
+94 93 106 107 100 108 110 88 73 74 69 63 57 60 54 47 45 44 44 43 44
+92 95 96 99 107 87 109 75 75 72 - 63 61 56 49 46 44 43 41 43 39
+83 91 90 - 107 108 86 86 75 68 69 62 65 50 42 43 - 35 41 36 34
+83 82 90 82 84 88 85 83 72 72 67 - 65 0 44 41 40 40 34 33 29
+78 81 81 89 89 83 81 80 74 66 66 63 0 - 0 41 39 33 - 0 -
+75 77 - 80 81 - 0 - 67 67 65 61 46 0 43 36 34 32 27 28 28
+75 74 74 80 76 71 80 79 59 67 60 50 44 44 39 - 30 29 29 26 25
+72 74 72 75 79 78 70 69 69 58 49 47 46 40 37 36 30 30 24 - 24
+72 69 72 69 77 78 56 54 56 - 32 47 41 39 - 33 32 - 23 10 24
+67 69 67 58 56 53 51 54 49 24 32 32 38 27 34 34 27 26 0 22 9
+67 66 56 55 - 28 52 50 29 30 - 12 26 37 36 21 22 0 - 0 9
+- 0 - 54 0 54 - 21 29 28 22 24 - 11 19 21 7 21 0 8 2
+65 63 54 54 - 52 27 28 - 20 22 18 11 11 2 18 19 6 6 0 -
+60 63 55 54 29 29 29 26 17 21 19 17 0 - 10 18 8 5 2 - 0
+61 56 56 31 30 - 24 22 22 - 15 14 - 0 17 9 6 - 0 1 1
+35 58 33 31 30 28 24 24 21 16 17 2 13 15 11 8 4 0 - 0 -
+60 34 32 32 29 26 26 22 18 18 15 - 14 12 9 5 - 3 0 2 2
+
+[reason]
+is is - wv im im ix ix ix ix ix ix - wx ci wx wx wx wx wx wx
+is is is im ix ur im wx im cb wx wx ac im ix ix ix ix ix ix wx
+is is ik iB - id p3 im ix - id ix - im wx im wx wx id - wx
+Bh i1 ik ik iB wx - wx ci im ix ix im ix ci ix ix ix ix cb im
+i1 - i1 ik ik cb ix im p3 wx ci wx ac - ci im wx ac - ci ix
+im i1 wx iC p3 im ix im ix ix ix ix - ac ix ix ix - ac wx ix
+pk ci p3 im iC p3 p3 wx ci id id wx cb wx wx wx wx im ix wx ix
+ix im p3 ul im ci im im ix ix - id ix ix ix ix ix wx ix wx ix
+ix wx im - im p3 ix ix im ci id ci ix wx ci id - cb ix wx ix
+ix wx ix ci ci wx wx ix im ix ix - im i1 ix ix id wx ix wx ix
+ix wx ix im ix ix wx ix wx ci wx id i1 - i1 ix ix id - ac -
+ix id - im wx - ac - im ix ix ix wx i1 wx id ix ix cb wx wx
+ix wx id ix ci cb ix wx ci im wx ix im ix ix - id ix ix ix wx
+ix wx ix ix wx ix p3 im ix ix wx ix wx wx wx wx wx wx id - im
+ix wx ix wx wx ix wx im wx - im ix ix ix - id ix - p3 ci ix
+ix wx ix wx ix p3 ci ix wx ci ix im im ci im ix p3 wx i1 wx ix
+ix wx ix wx - ci id ix ix id - cb ix p3 wx im wx i1 - i1 ix
+- ac - im ac ix - cb ix wx im wx - im wx ix ci ix i1 wx ix
+wx im im ix - wx ci id - ci ix wx im ix ci ix wx ix ix ac -
+ci ix wx im cb im ix ix cb id ix ix ac - cb ix wx id ix - ac
+wx ix ix ix ix - id ix ix - id ix - ac wx ix ix - i1 wx wx
+ci wx wx wx wx id wx wx wx cb wx cb ci ix wx wx wx i1 - i1 -
+ix ix ix ix ix ix ix ix ix ix ix - id ix ix ix - wx i1 im ix

--- a/project/assets/main/nurikabe/official/generated/431.txt.info
+++ b/project/assets/main/nurikabe/official/generated/431.txt.info
@@ -1,1 +1,40 @@
-{"cells":135,"difficulty":6.31244414919625,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 8.18
+width 14
+height 8
+author 
+
+[solution]
+ .############ 4 . .## 2## 6 .
+ .## .## .## 2#### .## .#### .
+ .## .## .## .## 1###### 7## .
+ 4## 3## 3######## .## . .## .
+## 4## 4## 3## 3## 2## . .## .
+## .## .## .## .###### . .####
+## .## .## .## .## .###### 2##
+## .## .######## 3 .## 1## .##
+########## 2 .###### 1########
+
+[order]
+3 3 2 4 3 1 0 - 2 2 5 - 0 - 9
+2 2 2 2 3 3 - 0 0 6 2 6 1 7 9
+2 1 2 1 2 2 5 0 - 0 7 6 - 10 9
+- 0 - 0 - 0 5 7 0 22 21 22 11 10 11
+0 - 0 - 0 - 0 - 0 - 23 26 26 11 11
+1 2 1 2 1 2 10 9 16 20 24 25 26 15 11
+5 2 5 2 5 11 3 17 11 20 13 0 15 - 15
+5 6 5 6 6 11 9 17 - 18 0 - 2 14 13
+7 6 7 6 8 - 12 12 19 0 - 0 1 13 13
+
+[reason]
+ix wx im wx im wx ac - ix ix id - ac - ix
+ix im ix im ix im - ac i1 ix ci ix wx wx ix
+ix wx ix wx ix ci ix i1 - i1 wx im - wx ix
+- ac - ac - ac im wx i1 p3 ci p3 ix wx ix
+ac - ac - ac - ac - ac - im is is im ix
+wx ix wx ix wx ix id ix Bj im wx p3 is im im
+wx ix wx ix wx ix ci ix ci ix iC i1 im - im
+wx ix wx ix im im ci im - ix i1 - i1 p3 ur
+wx im wx im wx - ix im wx i1 - i1 wx ur ur

--- a/project/assets/main/nurikabe/official/generated/432.txt.info
+++ b/project/assets/main/nurikabe/official/generated/432.txt.info
@@ -1,1 +1,64 @@
-{"cells":221,"difficulty":3.10098368328955,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.10
+width 12
+height 16
+author 
+
+[solution]
+ 7 . .## . .###### 4 . . .
+#### .## 3#### . 3########
+ 6## .#### 3## .#### 2 .##
+ .## . .## .#### 2 .######
+ .######## .## 5#### 5## 7
+ .## 2## 5#### . .## .## .
+ .## .## . .#### .## .## .
+ .#### 5## . .## .## .## .
+#### . .############ .## .
+## . .## 2## 3## . 2#### .
+######## .## . .#### 3## .
+## . . 4########## . .####
+## .#### 9 . . .###### 4##
+###### 1###### . . .## .##
+ 2## 1## 1## 3#### .## .##
+ .########## . .## .## .##
+#### . . 3################
+
+[order]
+- 2 2 5 4 6 4 1 0 - 2 5 5
+0 1 6 3 - 0 7 2 - 0 4 4 5
+- 7 6 7 0 - 3 8 0 2 - 5 5
+8 7 8 12 12 4 10 0 - 2 0 4 10
+8 10 10 9 12 14 11 - 0 2 - 0 -
+12 9 - 0 - 14 15 12 25 28 4 11 12
+12 12 12 12 15 17 18 24 29 28 29 14 12
+13 13 12 - 16 19 22 22 29 29 29 31 15
+13 21 19 17 14 21 20 31 2 30 36 30 36
+25 25 22 18 - 0 - 31 31 - 0 38 36
+26 23 24 15 19 19 36 40 31 0 - 37 40
+27 25 16 - 0 21 38 37 42 42 38 2 40
+26 28 1 0 - 2 22 40 43 39 40 - 41
+29 28 0 - 0 1 24 44 46 51 52 42 41
+- 0 - 0 - 0 - 45 50 53 52 53 44
+31 30 2 1 0 36 46 49 49 53 53 53 53
+31 32 33 34 - 35 48 47 50 53 54 53 54
+
+[reason]
+- ix ix id ix ix wx wx ac - ix ix ix
+ac wx ix cb - ac wx ix - ac id ci im
+- wx ix wx ac - ci ix ac im - ix im
+ix wx ix ix im ix wx ac - ix ac wx wx
+ix wx id ci ci ix wx - ac im - ac -
+ix cb - ac - im wx ix ix wx ix wx ix
+ix im ix im ix ix wx wx ix wx ix wx ix
+ix im im - id ix ix im ix im ix wx ix
+im wx ix ix cb wx ci wx ci wx ix ci ix
+im ix ix id - ac - im ix - ac wx ix
+wx ci wx ci ix im ix ix im ac - ci ix
+wx ix ix - ac wx id ci im ix ix cb im
+ci ix wx i1 - ix ix ix wx ci id - wx
+wx im i1 - i1 wx id ix ix ix wx ix wx
+- ac - i1 - ac - id wx ix wx ix wx
+ix wx i1 wx ac wx ix ix im ix im ix im
+im wx p3 ie - im wx ci wx im wx im wx

--- a/project/assets/main/nurikabe/official/generated/433.txt.info
+++ b/project/assets/main/nurikabe/official/generated/433.txt.info
@@ -1,1 +1,46 @@
-{"cells":77,"difficulty":0.465590598453179,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.47
+width 6
+height 10
+author 
+
+[solution]
+ . 7## . 5####
+ .#### .## 3##
+ .## . .## .##
+ .######## .##
+ . .## . 2####
+############ 7
+ .## 2## 3## .
+ 2## .## .## .
+## 4#### .## .
+## . . .#### .
+########## . .
+
+[order]
+13 - 4 2 - 0 1
+13 12 5 6 0 - 1
+13 11 11 6 7 2 1
+13 14 8 9 3 8 4
+16 15 9 9 - 8 9
+2 17 16 9 0 10 -
+2 2 - 0 - 12 11
+- 0 18 18 13 14 13
+0 - 18 16 19 19 16
+1 19 21 21 19 23 20
+20 20 20 21 22 24 25
+
+[reason]
+ix - id ix - ac wx
+ix wx wx ix ac - wx
+ix im ix ix wx ix wx
+ix wx ci im ci ix wx
+ix p3 im ix - im wx
+im im wx im ac wx -
+ix im - ac - id ix
+- ac ix im ix id ix
+ac - im ci ix im ix
+wx ix ix ix im wx ix
+wx wx wx im wx p3 ie

--- a/project/assets/main/nurikabe/official/generated/434.txt.info
+++ b/project/assets/main/nurikabe/official/generated/434.txt.info
@@ -1,1 +1,76 @@
-{"cells":231,"difficulty":8.68019104078444,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 9.30
+width 10
+height 20
+author 
+
+[solution]
+######################
+## . . . .## . . . 6##
+######## 5## .########
+21## . 3#### .## . 2##
+ .## .## . 2######## 6
+ .########## . . . . .
+ .## . . . 4##########
+ .############ . 4## 3
+ . .## . 2## . .## . .
+ .## 1################
+ .###### 4 . . .## .##
+ .## 2 .########## 2##
+ . .###### 1## . 2####
+ .## .## .######## .##
+ .## 2## . . . .## .##
+ .############ 6## 3##
+ .## . . . . 5## 2## 3
+ .############## .## .
+ .## . .## . . 3#### .
+ .#### 3######## 1####
+ . .#### . . 3###### 1
+
+[order]
+31 27 29 25 25 18 25 25 27 27 28
+30 30 26 26 17 15 17 26 26 - 27
+32 25 22 0 - 15 14 12 2 0 1
+- 17 15 - 0 12 11 2 2 - 0
+33 22 21 14 14 - 10 9 2 0 -
+33 24 19 20 12 0 10 10 7 7 2
+33 23 23 18 18 - 10 9 9 6 5
+33 34 23 17 12 17 11 10 - 0 -
+36 35 0 17 - 15 15 12 8 8 7
+37 0 - 0 0 16 13 14 9 5 7
+37 39 0 16 - 15 15 6 5 5 2
+44 38 - 40 16 0 14 5 0 - 4
+44 59 41 39 0 - 0 5 - 0 3
+46 43 42 12 12 0 7 2 2 2 2
+46 43 - 10 9 9 3 2 1 2 1
+45 51 43 10 10 5 0 - 0 - 0
+53 49 49 12 7 7 - 0 - 0 -
+53 50 13 47 9 5 5 1 2 1 2
+52 55 54 48 7 7 2 - 0 2 2
+58 56 55 - 5 4 4 0 - 0 0
+58 57 6 5 5 5 - 3 0 0 -
+
+[reason]
+wx ci wx ic ic wx ic ic im im wx
+im ix ix ix ix wx ie ie ie - im
+wx ic im ac - wx ie wx im ac wx
+- id ix - ac id p3 im ix - ac
+ix im p3 im ix - im wx im ac -
+ix wx ci wx wx ac ix ix ix ix ix
+ix im ix ix ix - im wx wx wx id
+ix wx im im cb wx wx ix - ac -
+ie p3 i1 ix - im ix ix im ix ix
+ix i1 - i1 ac im ci id wx im wx
+ix wx i1 im - ie ie p3 im ix ci
+ix cb - p3 im i1 wx im ac - wx
+ix ix im ci i1 - i1 ix - ac wx
+ix im p3 im ix i1 wx ci im ix im
+ik im - id ix ix ix ix wx ix wx
+ik ic im wx wx wx ac - ac - ac
+ix im ix ix ix ix - ac - ac -
+ik wb ci Bg wx ci wx wx ix wx ix
+ik im Bi p3 im ix ix - i1 im ix
+ie wb im - im wx wx i1 - i1 i1
+ie p3 wx im ix ix - wx i1 i1 -

--- a/project/assets/main/nurikabe/official/generated/435.txt.info
+++ b/project/assets/main/nurikabe/official/generated/435.txt.info
@@ -1,1 +1,67 @@
-{"cells":252,"difficulty":7.21636096953142,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 7.14
+width 13
+height 17
+author 
+
+[solution]
+###### 8 . . . . . . .#### 3
+## . 3################ 2## .
+## .#### . . . . . .## .## .
+#### 9 . .##################
+ 2######## 4 . . .## .## .##
+ .## 3 .########## 3 .## .##
+## 2## .## 9 . .###### 4 .##
+## .#### 8#### . . .########
+#### 8## . .###### .## .## .
+ 9## .## . . . .## .## 2## .
+ .## .######## .## .###### 3
+ .## .## 5## 1######## .####
+ .## .## .###### . 2## . . .
+ .## .## .## . 2########## 5
+ .## .## .###### 1## . . 3##
+ .## .## .## 1#### 1########
+ .############ .###### .## 1
+ .## 1## . . . . . 7## 2####
+
+[order]
+4 1 0 - 2 19 19 22 22 25 25 25 26 -
+4 2 - 0 18 18 20 20 24 23 25 - 0 27
+3 6 0 7 17 19 19 22 22 25 25 27 27 27
+7 6 - 7 10 15 20 20 22 23 29 27 28 27
+- 8 0 9 8 - 17 22 22 22 30 49 43 42
+9 0 - 2 15 0 18 18 22 - 50 47 48 44
+9 - 0 17 0 - 2 59 58 51 24 - 45 44
+2 10 10 17 - 0 60 60 66 52 57 44 44 15
+15 10 - 2 18 63 62 65 68 69 10 45 15 15
+- 16 15 19 55 64 61 67 68 69 46 - 6 15
+17 16 20 54 31 72 0 71 70 43 42 9 10 -
+17 22 37 21 - 0 - 0 15 35 9 9 5 4
+24 37 36 32 31 31 0 33 34 - 7 6 6 2
+39 38 37 32 31 31 32 - 0 10 3 7 0 -
+39 40 53 32 31 31 0 0 - 0 9 2 - 0
+41 54 33 32 16 0 - 0 0 - 2 2 1 0
+56 42 0 18 14 15 0 11 10 0 1 2 0 -
+56 0 - 0 17 13 13 12 2 - 0 - 1 0
+
+[reason]
+wx wx ac - ix ix ix ix ix ix ix im wx -
+wx ix - ac wx wx wx wx wx ci im - cb ix
+ci ix ac wx ix ix ix ix ix ix im ix im ix
+wx im - ix ix id wx wx im wx wx im wx im
+- wx ac id cb - ix ix ix im p3 im p3 ur
+ix ac - ix wx ac wx wx im - ie cb ix uL
+im - ac ix ac - ix p3 uL im cb - p3 uL
+ci ix im im - ac uL ul ix pk wb uL uL im
+wx im - cb ix p3 uL wx wx ix ci p3 im ix
+- wx ix wx p3 ix ik ix cb ix im - cb ix
+ix wx ix im uL im i1 p3 im p3 ur im wx -
+ix wx ix cb - i1 - i1 ci im im ix wx id
+ix iB ik im ul uL i1 im p3 - id ix ix ix
+ix wx ik im ul uL p3 - i1 wx ci wx ac -
+ix wx ix im ul uL i1 i1 - i1 ix ix - ac
+ix im p3 im p3 i1 - i1 i1 - i1 im wx i1
+ix wb i1 wx ci wx i1 p3 wx ac wx ix i1 -
+ix i1 - i1 ix ix ix ie ix - ac - wx i1

--- a/project/assets/main/nurikabe/official/generated/436.txt.info
+++ b/project/assets/main/nurikabe/official/generated/436.txt.info
@@ -1,1 +1,58 @@
-{"cells":270,"difficulty":3.1020785219623,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.10
+width 17
+height 14
+author 
+
+[solution]
+ . .############## . . . . .###### .
+ 3## 6 . . . . .######## 6#### 1## 2
+################## .## .#### .######
+## . . . .## 1## . .## . 3## .## 2 .
+## 5########## 5 .########## 3######
+#### . . .## .###### .## 2 .## . .##
+ .## 4###### .## . . .########## .##
+ .#### . .## .## .###### .## .## .##
+ .## . .#### .## .## .## .## .## 5##
+ .## .## . . .## .## .## .## . 4## .
+ .## 6## .###### 8## .## .######## .
+ .###### 9## . .#### .## . . . .## .
+ .## . .## 4 .## 1## 5######## .## .
+ .## .################ .## 1## .## .
+ 9## 4## 6 . . . . .## . 3####11## 6
+
+[order]
+30 30 30 31 35 35 40 39 42 48 49 51 51 53 53 0 41 41
+- 0 - 32 33 38 38 41 41 47 50 47 - 52 0 - 0 -
+29 29 28 32 33 37 0 40 44 47 43 47 0 40 40 0 54 40
+26 27 30 30 35 0 - 0 43 45 46 27 - 26 35 38 - 55
+26 - 26 32 28 36 0 - 38 42 41 42 0 34 - 23 24 24
+22 24 25 27 35 35 35 35 36 40 41 34 - 33 25 25 22 21
+22 20 - 24 23 32 35 32 35 38 36 35 30 32 19 21 19 10
+19 21 18 22 25 25 30 32 30 32 30 30 30 17 19 18 9 8
+10 18 16 19 21 26 30 29 30 29 30 29 30 18 16 0 - 7
+7 9 7 15 13 22 27 29 15 29 27 29 16 15 7 - 0 7
+5 6 - 2 6 12 24 11 - 14 27 15 13 9 9 6 6 5
+5 4 4 5 - 0 10 25 0 26 13 12 10 10 7 5 4 5
+2 4 2 5 0 - 4 0 - 0 - 12 12 0 4 2 4 2
+2 1 2 1 6 2 9 9 0 10 3 12 0 - 0 2 1 2
+- 0 - 0 - 7 7 10 10 10 10 2 - 0 1 - 0 -
+
+[reason]
+ix ix im wx wx wx wx ci wx p3 ie ie ie ix im i1 im ix
+- ac - ix ix ix ix ix im im wx im - wx i1 - i1 -
+wx wx cb wx wx wx i1 wx wx ix ci ix ac im ix i1 wx ci
+wx ix ix ix ix i1 - i1 ix ix id ix - cb ix id - ix
+wx - id wx ci wx i1 - ix wx im wx ac im - ci id wx
+im wx ix ix ix im ix im wx wx ix im - p3 im ix ix wx
+ix ci - id ci wx ix wx ix ix p3 wx im wx im wx ix wx
+ix wx id ix ix im ix wx ix wx im im ix ci ix wx ix wx
+ix id ix ix id wx ix wx ix wx ix wx ix wx ix ac - im
+ix id ix id ix ix ix wx ix wx ix wx ix wx ix - ac ix
+ix id - cb ix wx wx ci - cb ix wx ix wx wx id wx ix
+ix wx id im - ac ix ix i1 wx ix cb ix ix ix ix wx ix
+ix wx ix ix ac - ix i1 - i1 - im wx i1 wx ix wx ix
+ix wx ix wx wx cb wx wx i1 im ci ix i1 - i1 ix wx ix
+- ac - ac - ix ix ix ix ix im ix - i1 wx - ac -

--- a/project/assets/main/nurikabe/official/generated/437.txt.info
+++ b/project/assets/main/nurikabe/official/generated/437.txt.info
@@ -1,1 +1,37 @@
-{"cells":48,"difficulty":0.0,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.00
+width 5
+height 7
+author 
+
+[solution]
+ . 2###### 1
+#### 2 .####
+ 1###### 1##
+## 3 .######
+#### .## 2 .
+## 4########
+## . . .## .
+########## 2
+
+[order]
+4 - 0 1 0 -
+0 0 - 2 0 0
+- 0 3 0 - 0
+0 - 4 6 0 4
+1 0 7 5 - 15
+8 - 7 11 14 6
+8 9 11 11 0 13
+10 10 10 11 12 -
+
+[reason]
+ix - ac wx i1 -
+i1 ac - p3 i1 i1
+- i1 im i1 - i1
+i1 - ix wx i1 wx
+wx ac ix ci - ix
+wx - im im wx ci
+wx ix ix ix ci ix
+wx wx wx im wx -

--- a/project/assets/main/nurikabe/official/generated/438.txt.info
+++ b/project/assets/main/nurikabe/official/generated/438.txt.info
@@ -1,1 +1,43 @@
-{"cells":120,"difficulty":8.53872632753433,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 8.54
+width 11
+height 9
+author 
+
+[solution]
+ .######################
+ .## 1## 1## .## .## .##
+ .######## . .## .## .##
+ .## . .## .#### 3## .##
+ .#### 3## 5## .#### 4##
+ .## .## .#### .## .####
+ .## .## . 3## .## .## 1
+ 8## 3######## 4## 3####
+###### . . .####13## 1##
+ . . . . . . . . .######
+
+[order]
+39 13 0 10 0 13 13 13 13 13 13 13
+20 0 - 0 - 2 14 13 14 8 14 9
+17 38 0 36 0 35 15 16 15 15 7 6
+22 37 37 32 32 31 34 16 - 6 5 4
+22 32 31 - 0 - 30 33 12 2 - 4
+22 30 31 29 31 0 32 11 2 2 2 0
+19 27 28 30 28 - 2 11 1 2 0 -
+- 0 - 26 24 26 28 - 0 - 0 0
+26 21 18 26 23 26 3 0 - 0 - 0
+26 18 18 18 25 5 2 2 2 1 0 3
+
+[reason]
+ix ur i1 wb i1 ur ur ur ur ur ur ur
+pk i1 - i1 - i1 p3 ur p3 ci p3 wx
+pk wx i1 wx i1 ix ie im ie im ix wx
+ul im ix ix wx ix wx im - id ix wx
+ul wx im - ac - ci ix wx im - wx
+ul wx ix ci ix ac wx ik im ix im i1
+ul wx ix id ix - cb ix wx ix i1 -
+- ac - iB cb iB wx - ac - i1 i1
+iB wv iB is ik is wx ac - i1 - i1
+is ik ik ik ib ix ix ix ix wx i1 wx

--- a/project/assets/main/nurikabe/official/generated/439.txt.info
+++ b/project/assets/main/nurikabe/official/generated/439.txt.info
@@ -1,1 +1,58 @@
-{"cells":195,"difficulty":13.8966405126521,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 13.90
+width 12
+height 14
+author 
+
+[solution]
+ . . 4## . 4#### 1#### . .
+ .###### .## 5#### 1#### .
+#### 1## .## .## 2## 5## 4
+## .######## .## .## .####
+## 2## . .## .###### . .##
+#### 4 .#### .## 2 .## .##
+ . 5#### 4################
+ .## 6## .## 5 . . . .## 9
+ .## .## . .############ .
+ .## .###### 1## .## . . .
+#### . . .###### .## .####
+## .######## 5 . .## .## 4
+## . .## 4 .######## .## .
+#### . 5## . .## 1## .## .
+ 1###################### .
+
+[order]
+15 7 - 5 3 - 0 0 - 0 1 14 15
+14 13 0 6 7 0 - 1 0 - 0 13 15
+9 0 - 0 7 7 3 2 - 0 - 0 -
+3 7 0 9 7 8 9 3 3 1 3 13 16
+5 - 0 7 10 10 9 10 3 5 17 28 27
+1 0 - 3 5 11 11 11 - 31 29 25 24
+3 - 0 1 - 13 11 33 32 12 30 24 24
+3 0 - 5 17 7 - 12 35 55 55 55 -
+3 5 7 18 17 37 0 34 53 54 55 56 57
+7 4 19 18 36 0 - 0 53 24 24 60 57
+7 20 19 42 38 43 0 49 53 51 24 58 59
+21 22 43 43 43 3 - 40 50 52 24 26 -
+23 45 44 0 - 45 39 49 0 61 24 61 60
+0 49 50 - 0 45 47 0 - 0 22 61 62
+- 0 51 51 49 48 46 41 0 21 21 21 62
+
+[reason]
+ie ix - id ix - ac i1 - i1 wx p3 ie
+p3 ic i1 wx ix ac - wx i1 - ac ic ie
+wx i1 - i1 ix im ix wx - ac - ac -
+ci ix i1 wx im wx ix im ix wx ix ic im
+wx - ac ix ix im ix wx im wx ix p3 ic
+wx ac - ix id im ix im - p3 im p3 uL
+ix - ac wx - ic im wx im ci uL uL uL
+ix ac - wx ix cb - ix ix ix ix im -
+ix wx ix wx ix ix i1 Bw im wx im wx ix
+ix ci ix wx Bj i1 - i1 ix uL ul ix ix
+im wx ix Bi pk im i1 wx ix cb ul cb id
+ur p3 im im im cb - ix ix id ul id -
+wx ie p3 ac - ix Bg wx i1 im ul im ix
+i1 wx ie - ac ix p3 i1 - i1 p3 im ix
+- i1 im im wx im ci ur i1 ur ur ur ix

--- a/project/assets/main/nurikabe/official/generated/44.txt.info
+++ b/project/assets/main/nurikabe/official/generated/44.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.21

--- a/project/assets/main/nurikabe/official/generated/440.txt.info
+++ b/project/assets/main/nurikabe/official/generated/440.txt.info
@@ -1,1 +1,46 @@
-{"cells":154,"difficulty":2.42927842630253,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 2.43
+width 13
+height 10
+author 
+
+[solution]
+ . 4## 3 .############## . .
+ . .## .#### 1## . .## .## .
+########## .###### 3## 2## 4
+ . .## .## . .## .##########
+ .#### 2#### .## .## . . . 4
+ .## .## .## .## 3##########
+ .## .## .## 6#### . . . .##
+ .## .## 3#### .######## .##
+ .## 4#### 4 . .## . 2## .##
+ .#### .############## 8 .##
+ 9## 3 .## 2 .## . . 3######
+
+[order]
+30 - 0 - 32 29 0 28 26 27 20 17 18 18
+30 16 1 16 31 0 - 0 26 25 17 17 17 2
+14 13 15 12 23 24 0 25 23 - 0 - 0 -
+12 13 12 12 12 22 23 19 23 20 17 15 1 0
+12 11 10 - 10 21 20 21 18 17 17 12 12 -
+9 10 10 8 10 10 20 10 - 17 15 15 10 10
+9 7 7 9 6 9 - 18 17 17 17 12 9 6
+5 6 6 5 - 0 4 18 7 2 15 6 5 6
+2 4 - 5 0 - 2 6 17 17 - 0 5 4
+2 1 0 5 3 0 5 6 2 1 0 - 2 4
+- 0 - 2 4 - 5 2 2 2 - 0 1 4
+
+[reason]
+is - ac - p3 wx i1 wx ci im wx im ix ix
+is p3 wx p3 wx i1 - i1 p3 ix im ix im ix
+im ci wx im wx ix i1 wx im - ac - ac -
+ix p3 im ix im p3 ix ci ix wx im id wx ac
+ix wx im - im wx ix wx ix im ix ix ix -
+ix im ix ci ix im ix cb - im wx wx cb wx
+ix wx ix id ix id - im im ix ix ix ix wx
+ix wx ix cb - ac id ix ci ci wx wx ix wx
+ix id - im ac - ix ix im ix - ac ix wx
+ix wx ac ix ci ac im wx im wx ac - ix wx
+- ac - ix id - ix im ix ix - ac wx wx

--- a/project/assets/main/nurikabe/official/generated/441.txt.info
+++ b/project/assets/main/nurikabe/official/generated/441.txt.info
@@ -1,1 +1,37 @@
-{"cells":72,"difficulty":4.54326295229363,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 4.54
+width 8
+height 7
+author 
+
+[solution]
+ 4 . . .## . . . .
+############## . .
+ 3 . .## 2 .## . .
+###### 4###### . .
+ 2 .## . . .#### .
+############ 1## .
+ .## . . 3###### .
+ 2########## 1##14
+
+[order]
+- 2 2 3 3 5 6 9 22
+0 1 2 3 4 2 8 22 22
+- 2 2 0 - 7 7 22 22
+0 1 2 - 0 7 12 20 21
+- 15 14 7 10 13 0 19 2
+16 2 12 14 11 0 - 0 2
+17 0 13 14 - 15 0 1 2
+- 18 12 15 15 2 - 0 -
+
+[reason]
+- ix ix ix im p3 ie ie is
+ac wx im wx wx ci wx is is
+- ix ix ac - ix im is is
+ac wx im - ac im wb p3 ix
+- p3 im ix pk p3 i1 wx ix
+im ci ur im id i1 - i1 ix
+p3 ci p3 ie - im i1 wx ix
+- im ur im im i1 - ac -

--- a/project/assets/main/nurikabe/official/generated/442.txt.info
+++ b/project/assets/main/nurikabe/official/generated/442.txt.info
@@ -1,1 +1,37 @@
-{"cells":96,"difficulty":0.313924807573354,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 0.31
+width 11
+height 7
+author 
+
+[solution]
+########## . .## 2## 3 .
+## 3 . .#### 3## .#### .
+ 3######## .######## 1##
+ . .## 1## 2## 2 .######
+######## 2## 4###### .##
+ 3 . .## .## .## 4 . .##
+############ . .########
+ 5 . . . .######## 2 .##
+
+[order]
+1 1 1 5 5 5 5 4 - 0 - 2
+0 - 2 7 6 2 - 2 3 1 0 2
+- 0 8 0 1 2 1 5 2 0 - 0
+2 6 0 - 0 - 0 - 6 6 0 5
+5 3 6 0 - 0 - 0 6 12 13 14
+- 6 6 2 2 1 2 5 - 12 13 14
+0 1 6 7 2 5 6 11 11 9 13 15
+- 2 2 9 9 9 10 7 12 - 16 16
+
+[reason]
+wx wx wx wx im ix ix im - ac - ix
+ac - ix p3 wx im - ci p3 wx i1 ix
+- ac im i1 wx ix wx wx ci i1 - i1
+ix ix i1 - i1 - ac - ix im i1 wx
+id ci im i1 - ac - ac im wx p3 im
+- ix ix im ix wx ix id - ix ix im
+ac wx im wx im wx ix ix im cb wx wx
+- ix ix ix ix im wx ci wx - ix im

--- a/project/assets/main/nurikabe/official/generated/443.txt.info
+++ b/project/assets/main/nurikabe/official/generated/443.txt.info
@@ -1,1 +1,43 @@
-{"cells":100,"difficulty":10.1085418335316,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 10.11
+width 9
+height 9
+author 
+
+[solution]
+ . .###### . . 5 . .
+ .## 1## 1##########
+ .######## . 2## . 2
+ 5## 2 .############
+## 2###### . 5## . .
+## .## . . .## . . .
+############## . 8 .
+ . . .## 3 . .######
+ .############## 4 .
+ 5## 5 . . . .## . .
+
+[order]
+2 2 0 5 0 27 15 - 15 27
+2 0 - 0 - 2 15 26 14 21
+2 1 0 2 0 19 - 20 24 -
+- 0 - 2 2 18 0 23 22 25
+0 - 0 2 37 36 - 18 24 34
+1 2 2 3 17 35 34 34 34 34
+5 2 6 16 4 33 13 30 - 34
+2 6 6 6 - 10 32 31 0 34
+2 1 6 7 9 12 11 28 - 29
+- 0 - 8 8 10 13 13 38 38
+
+[reason]
+ix ix i1 wx i1 is ix - ix is
+ix i1 - i1 - i1 iB ic ic ic
+ix wx i1 im i1 p3 - im p3 -
+- ac - ix im uL ac wb ci im
+ac - ac im im ix - uL p3 is
+wx ix im p3 ie p3 iB is is is
+wx im im ur cb im ci ix - is
+ix ix ix im - ix p3 wv ac iB
+ix wx im wx id id ci Bh - ix
+- ac - ix ix ix ix im is is

--- a/project/assets/main/nurikabe/official/generated/444.txt.info
+++ b/project/assets/main/nurikabe/official/generated/444.txt.info
@@ -1,1 +1,40 @@
-{"cells":54,"difficulty":7.24092822049523,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 9.23
+width 5
+height 8
+author 
+
+[solution]
+ . . . . . 6
+############
+## . . . . 5
+############
+ . . . 4## 9
+########## .
+## . . . . .
+########## .
+ . . . 4## .
+
+[order]
+7 4 4 2 2 -
+5 6 3 3 1 0
+11 11 4 2 2 -
+12 5 10 3 1 0
+18 15 9 - 0 -
+16 17 14 8 19 2
+22 21 14 8 8 20
+22 24 13 8 13 25
+26 26 23 - 25 25
+
+[reason]
+ix ix ix ix ix -
+ci wx wx wx wx ac
+im ix ix ix ix -
+wx ci id id wx ac
+ix ix ix - ac -
+ci Bj iB iB wx ix
+wx ix ik ik ik ix
+wx ic iC iB wb ix
+ix ix ix - im ix

--- a/project/assets/main/nurikabe/official/generated/445.txt.info
+++ b/project/assets/main/nurikabe/official/generated/445.txt.info
@@ -1,1 +1,34 @@
-{"cells":70,"difficulty":4.10367830066513,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 4.10
+width 9
+height 6
+author 
+
+[solution]
+############ 1## 2 .
+ 1## . . .##########
+###### 4#### 3 . .##
+ .## .#### 1########
+ .## .## 1##14 . . .
+ .## .###### . . . .
+ 4## 4## . . . . . .
+
+[order]
+0 1 15 15 15 0 - 0 - 4
+- 0 14 15 14 10 0 1 2 2
+0 13 12 - 13 0 - 2 2 2
+12 3 12 11 0 - 0 1 2 7
+2 11 10 0 - 0 - 8 8 6
+2 1 10 9 0 1 8 8 8 8
+- 0 - 8 8 6 5 8 8 8
+
+[reason]
+i1 wx wx wx wx i1 - i1 - ix
+- i1 p3 ix p3 wx i1 wx im ci
+i1 wx im - wx i1 - ix ix im
+ix ci ix wx i1 - ac wx im wb
+ix wx ix i1 - i1 - is is ik
+ix wx ix wx i1 wx is is is is
+- ac - iB is ik ik is is is

--- a/project/assets/main/nurikabe/official/generated/446.txt.info
+++ b/project/assets/main/nurikabe/official/generated/446.txt.info
@@ -1,1 +1,52 @@
-{"cells":156,"difficulty":3.1159115546047,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.12
+width 11
+height 12
+author 
+
+[solution]
+ . .###### . . . . 5####
+ . .## 1############ 1##
+ . . .## . . . 4## 1####
+ . .################## 6
+10## 1## . 2## . . . . .
+############ 1##########
+## . . . 4#### . . 3## 3
+########## .########## .
+ . .## .## . .## . .## .
+ 3#### .#### . 5## 3####
+## 1## . . 5######## .##
+############## .## 3 .##
+ . . . . . 6## . 3######
+
+[order]
+39 39 38 0 19 19 7 3 3 - 0 1
+39 39 0 - 0 8 18 5 1 0 - 1
+39 37 36 0 22 19 17 - 0 - 0 1
+34 39 0 35 3 21 17 16 9 0 2 -
+- 0 - 0 22 - 0 16 12 7 7 3
+33 32 0 26 22 0 - 0 14 9 6 5
+32 32 32 27 - 25 0 16 13 - 0 -
+29 4 31 30 20 25 18 16 10 12 11 7
+3 28 23 30 24 19 17 13 13 9 8 10
+- 0 27 22 21 16 14 - 0 - 7 9
+0 - 0 22 17 - 14 7 9 0 7 4
+1 0 24 18 15 0 4 7 0 - 3 5
+25 25 19 16 7 - 5 3 - 0 1 5
+
+[reason]
+is is ic i1 im ix ix ix ix - i1 wx
+is is i1 - i1 ci id id wx i1 - wx
+is ie p3 i1 ix ix ix - i1 - i1 wx
+ix is i1 wb ci id wx im wx i1 wx -
+- i1 - i1 ix - i1 ix ix ix ix ix
+wx im i1 wx im i1 - i1 id id wx id
+im ix ix ix - im i1 ix ix - ac -
+im ci wx im ci ix wx im ci id im ix
+ix p3 ci ix wx ix ix im ix ix ci p3
+- i1 wx ix wx id ix - ac - im wx
+i1 - i1 ix ix - wx im wx ac ix ci
+wx i1 wx wx wx ac ci ix ac - ix wx
+ix ix ix ix ix - id ix - ac wx wx

--- a/project/assets/main/nurikabe/official/generated/447.txt.info
+++ b/project/assets/main/nurikabe/official/generated/447.txt.info
@@ -1,1 +1,40 @@
-{"cells":144,"difficulty":3.07911180025016,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.92
+width 15
+height 8
+author 
+
+[solution]
+ . . 3######## 9 . . . . . . . .
+######## . . 5##################
+ 6## 2## .#### 6 .## 6## 3 . .##
+ .## .## .## 4## .## . .###### .
+ .#### 3#### .## .#### . . .## .
+ .## . .## . .## .## 2######## .
+ .############## .## .## . .## 4
+ .## . 2## . .############ .####
+######## 5 . .## . . . 4## . . 6
+
+[order]
+12 6 - 4 4 1 0 - 2 2 6 6 12 12 17 20
+7 11 0 4 2 2 - 0 1 4 3 11 7 14 19 18
+- 0 - 8 6 1 0 - 2 4 - 0 - 12 19 19
+8 9 9 2 9 8 - 0 6 8 6 9 11 17 10 19
+11 14 9 - 9 11 9 8 9 14 8 12 17 17 17 9
+17 27 28 11 29 30 12 11 17 10 - 14 9 16 8 9
+26 23 2 12 23 13 31 17 17 17 17 11 15 6 8 -
+25 14 14 - 0 24 32 22 17 20 17 17 5 6 1 0
+27 17 1 0 - 2 33 21 21 19 19 - 4 2 2 -
+
+[reason]
+ix ix - wx wx wx ac - ix ix ix ix ix ix ix ix
+ci wx ac wx ix ix - ac wx wx cb wx cb id im ci
+- ac - id ix wx ac - ix id - ac - ix ix im
+ix im ix ci ix wx - ac ix id ix ix id im ci ix
+ix wx im - im wx ix wx ix wx id ix ix ix im ix
+ix im p3 ix im p3 ix wx ix cb - id ci im wx ix
+ix ic ci id ic ci im im ix im ix ci p3 ix wx -
+pk im ix - ac p3 p3 wx im wx im wx wx ix wx ac
+im wx wx ac - ix ix im ix ix ix - id ix ix -

--- a/project/assets/main/nurikabe/official/generated/448.txt.info
+++ b/project/assets/main/nurikabe/official/generated/448.txt.info
@@ -1,1 +1,46 @@
-{"cells":77,"difficulty":1.55431370690516,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 1.55
+width 6
+height 10
+author 
+
+[solution]
+ 6 . . . .####
+ .########## .
+#### . . 4## 2
+ .## .########
+ .#### . . . 4
+ .## .########
+ 4## 2## 2## 2
+######## .## .
+## 3 . .######
+ 5######## . 2
+ . . . .######
+
+[order]
+- 16 16 18 18 3 2
+15 14 17 17 18 2 2
+12 13 11 18 - 0 -
+12 7 10 5 4 1 0
+6 9 5 5 2 2 -
+2 5 5 5 4 1 0
+- 0 - 0 - 0 -
+1 1 4 5 5 2 2
+0 - 2 5 5 3 2
+- 0 4 3 6 7 -
+2 2 2 5 5 4 8
+
+[reason]
+- ix ix ix ix wx im
+p3 iC wx wx im im ix
+im wx ie ie - ac -
+ix ci p3 im id wx ac
+ix wx im ix ix ix -
+ix im ix im id wx ac
+- ac - ac - ac -
+wx wx id im ix im ix
+ac - ix ix im wx im
+- ac wx ci wx p3 -
+ix ix ix ix im ci im

--- a/project/assets/main/nurikabe/official/generated/449.txt.info
+++ b/project/assets/main/nurikabe/official/generated/449.txt.info
@@ -1,1 +1,88 @@
-{"cells":400,"difficulty":20.0,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 20.00
+width 15
+height 24
+author 
+
+[solution]
+ . 3 .######################## .
+######## . . .## . .## .## .## .
+## .## .#### . 5## .## .## .## .
+## .## 2## 1###### .## .## .## .
+## .########## .## .## .## .## .
+## .## . . .## 2## 6## .## .## .
+## .###### .#### .#### .## .## 7
+## 6## .## . .## . .## 7## .####
+ .#### . 3## . 8## . 5## . .## .
+ .## 1##################10#### .
+ .###### . .## .## . . 3## .## .
+ .## .#### 3## .########## 2## .
+ .## . . 4#### .## . . . 4#### 5
+ .######## .## .########## .####
+ 7## . .## 2## .## .## .## . .##
+###### . 4#### 6## .## . 3## .##
+## .###### . .#### . 4###### 5##
+## . . . 5## 5## .###### . .####
+############ .## 2## .## 3#### 1
+## . . . 4## .###### . .## .####
+########## 1## . . 3## 4## . . 4
+## .## .########################
+## 2## . . . . .## . .## . 4 . .
+ 4############ . 8## 3##########
+ . . .## . 2########## . . 3## 1
+
+[order]
+156 - 155 148 7 131 131 130 14 126 7 7 7 7 7 124
+154 153 154 7 147 12 14 129 129 15 10 8 7 8 18 23
+7 153 7 153 7 0 146 - 27 27 10 9 10 9 18 24
+152 151 152 - 0 - 0 145 38 27 10 9 10 9 18 24
+145 151 150 144 148 0 7 145 33 13 10 9 10 9 18 24
+145 141 149 149 143 142 141 - 0 - 10 9 10 9 18 22
+140 141 140 139 141 139 34 30 32 26 10 9 10 9 11 -
+139 - 139 139 136 134 35 31 29 25 0 - 9 9 18 122
+139 139 0 139 - 36 37 - 21 20 - 0 17 9 18 122
+139 0 - 0 132 45 133 132 31 28 19 0 - 16 44 122
+139 138 0 132 132 132 128 132 121 121 40 - 0 42 2 122
+106 137 135 134 0 - 129 127 126 41 119 39 0 - 43 122
+101 137 136 78 - 0 78 127 124 124 124 118 - 0 121 -
+98 102 93 91 77 77 2 126 126 124 123 122 117 119 115 115
+- 97 97 92 0 - 76 126 123 125 120 122 118 116 114 115
+99 95 96 2 - 0 67 - 124 122 121 119 - 47 114 112
+84 94 76 4 0 75 68 66 73 122 - 118 111 113 - 112
+95 77 5 2 - 0 - 73 72 61 89 90 112 110 107 0
+79 83 76 4 0 74 6 6 - 73 89 63 - 109 0 -
+79 80 84 2 - 0 75 71 59 70 70 63 53 109 1 0
+79 7 85 85 0 - 0 71 64 - 0 - 88 105 54 -
+1 80 2 86 87 0 76 71 62 58 52 69 112 103 100 108
+0 - 81 82 65 65 65 61 58 58 51 56 57 - 104 114
+- 0 2 62 61 46 60 59 - 0 - 3 49 0 1 0
+2 2 2 2 61 - 60 59 55 50 49 48 2 - 0 -
+
+[reason]
+ix - p3 wx ur wx wx wx uL wx ur ur ur ur ur ix
+wx im wx ur ix pk ul im ix pk im p3 ur p3 im pk
+ur ix ur ix ur i1 ix - iB ik im ul im ul im ul
+wx ix id - i1 - i1 im Bj ix im ul im ul im ul
+wx ix wx ci wx i1 ur ix wx ix im ul im ul im ul
+wx ix im ix ix p3 wx - ac - im ul im ul im ix
+wx ix wx im wx ix iC ci ix id im ul im ul id -
+im - im ix id ix p3 id ix Bi ac - uL ul im im
+ix im i1 ix - cb ul - id ix - ac ix ul im ix
+ix i1 - i1 im Bw wx im wx Bw wx ac - Bg wx ix
+ix wx i1 im ix ix ci ix im ix ix - ac Bi ci ix
+Bi im p3 wx ac - wx ix wx ci wx Bg ac - im ix
+Bi im ix ix - ac wx ix im ix ix ix - ac wx -
+ix Bw wx Bg im ix ci ix wx im wx im ci ix wx wx
+- im ix p3 ac - wx ix ci p3 ci ix id ix ix wx
+Bh im wx ix - ac Bw - wx ix id ix - Bg ix wx
+ci Bi wx id ac is pk Bg im ix - wx cb im - wx
+im ix ix ix - ac - im Bi ci im wx ix p3 Bh i1
+ur id wx id ac Bw ix iB - im ix iB - im i1 -
+ur p3 ie ix - i1 is im cb iB ix ix Bg ix wx i1
+ur ur im im i1 - i1 ix ix - ac - Bj ix Bi -
+wx p3 ci p3 im i1 wx im wx im Bw Bg wx Bg Bg Bj
+ac - im p3 ik ik ix ix im ix ix Bj p3 - ix ix
+- ac im wx im Bj wx ix - ac - ci im ac wx i1
+ix ix ix im ix - wx wx Bh wx im Bi ix - i1 -

--- a/project/assets/main/nurikabe/official/generated/45.txt.info
+++ b/project/assets/main/nurikabe/official/generated/45.txt.info
@@ -1,7 +1,7 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
-difficulty 5.90
+difficulty 5.52
 width 27
 height 14
 author poobslag v02
@@ -35,10 +35,10 @@ author poobslag v02
 - 0 - 33 34 35 31 20 21 20 2 2 2 26 - 0 - 26 24 40 39 16 13 12 15 19 18 19
 38 35 35 35 36 35 22 33 21 22 21 2 - 18 27 29 27 41 41 27 41 38 15 - 20 19 20 19
 38 39 35 38 36 37 38 33 24 22 26 27 19 29 31 44 43 51 41 41 41 41 35 21 20 21 20 21
-40 77 66 65 63 62 62 62 - 24 29 27 31 33 45 32 52 45 48 47 41 42 43 33 22 21 22 21
-70 77 74 67 64 - 62 61 61 31 29 33 35 47 45 55 52 50 49 45 45 45 43 31 31 24 22 24
-73 71 75 68 65 0 62 62 58 58 35 38 51 58 56 52 53 50 47 - 45 36 44 33 25 29 26 24
-76 72 69 67 67 - 64 60 60 57 57 52 57 57 59 54 - 51 46 46 45 45 35 31 31 27 27 27
+40 75 67 66 64 63 63 63 - 24 29 27 31 33 45 32 52 45 48 47 41 42 43 33 22 21 22 21
+71 75 75 68 65 - 63 62 62 31 29 33 35 47 45 55 52 50 49 45 45 45 43 31 31 24 22 24
+74 72 75 69 66 0 63 63 61 61 35 38 51 58 56 52 53 50 47 - 45 36 44 33 25 29 26 24
+76 73 70 68 68 - 65 62 62 60 60 52 59 59 57 54 - 51 46 46 45 45 35 31 31 27 27 27
 
 [reason]
 ix - wx wx wx wx wx wx wx ac - ix ix ix ix ix ix im - ix wx i1 wx ci wx wx im wx
@@ -53,6 +53,6 @@ wx im im ix im ix wx ix wx - ac - ac ix ci im id wx ix wx ci id - id ix ix wx -
 ix im ix im p3 ix ci ix wx ix wx im - cb ix id ix im ix ci ix wx id - wx ix wx ix
 ix wx im wx ci im wx im id ix ix wx ix wx ix id ix wx im im ix im ix ix wx ix wx ix
 ix is p3 im p3 im ix ix - id ix wx ix wx ix ci ix ci p3 wx im wx ix wx wx ix wx ix
-Bi is ik im ix - im ci wx wx ix wx ix wx im wx im im ie im ix ix ix im ix ix wx ix
-ic wb id wx wx ac im ix ix ix ix wx ix ix p3 ci p3 im ix - im ci wx wx ci wx wx ix
-ix Bi ix ix ix - wx wx wx ic ic wx ic ic im im - wx wx wx im ix ix ix ix ix ix ix
+Bi is is im ix - im wx wx wx ix wx ix wx im wx im im ie im ix ix ix im ix ix wx ix
+wv ic iB wx wx ac im ix ix ix ix wx ix ie p3 ci p3 im ix - im ci wx wx ci wx wx ix
+ix Bi ix ix ix - wx wx wx wx wx wx im im ur im - wx wx wx im ix ix ix ix ix ix ix

--- a/project/assets/main/nurikabe/official/generated/450.txt.info
+++ b/project/assets/main/nurikabe/official/generated/450.txt.info
@@ -1,1 +1,49 @@
-{"cells":192,"difficulty":3.16589490234826,"version":0.02}
+{"version":"0.02"}
+
+[metadata]
+difficulty 3.17
+width 15
+height 11
+author 
+
+[solution]
+ .###### . . . . . . . . 9######
+ .## 1#################### 9 .##
+ .#### . .## 2## . 8## . 6## .##
+ .## 4 .#### .## .## . .#### .##
+ .###### 5 .#### .## .## 5## .##
+ 6## . 2## . .## .## .## .## .##
+## 5######## .## .###### .## .##
+## .## 2## 3#### . .## . .## .##
+## .## .## . .############## .##
+## . .######## 2## 1## .## .####
+######## . .## .###### .## 2## 1
+ 8 . . . . .###### 1## 3########
+
+[order]
+8 8 0 9 10 11 14 14 5 5 2 2 - 0 1 4
+8 0 - 0 6 13 12 15 13 3 4 1 0 - 2 4
+5 6 0 6 6 6 - 16 14 - 4 2 - 0 5 4
+5 3 - 4 5 8 17 13 17 13 8 5 0 6 5 6
+2 4 2 0 - 6 17 18 17 18 14 6 - 7 8 6
+- 0 2 - 0 18 20 22 19 15 19 16 8 13 8 13
+0 - 2 0 14 19 24 21 24 20 19 20 17 13 14 13
+1 4 2 - 0 - 24 25 24 32 32 33 22 18 14 16
+5 4 2 4 4 25 30 30 31 0 35 23 34 17 19 16
+5 6 13 4 27 29 26 - 0 - 0 36 38 39 19 0
+8 8 7 14 28 33 32 32 32 0 1 37 2 - 0 -
+- 13 13 13 16 34 34 32 2 - 0 - 38 40 1 0
+
+[reason]
+ix im i1 wx p3 ie ie ix ix ix ix ix - ac wx wx
+ix i1 - i1 im wx cb im wx cb wx wx ac - ix wx
+ix wx i1 ix ix im - id ix - id ix - ac ix wx
+ix cb - ix id wx ix ci ix id ix ix ac wx ix wx
+ix wx im ac - ix im wx ix wx ix id - wx ix wx
+- ac ix - ac ix ix wx ix ci ix wx ix wx ix wx
+ac - im ac wx id ix ci ix wx im wx ix wx ix wx
+wx ix cb - ac - im wx ix ix im p3 ix wx ix wx
+wx ix ci ix im ix ix im wx i1 wx ci im ci ix wx
+wx ix ix im wx wx ci - i1 - i1 p3 im p3 im i1
+wx cb ci wx p3 p3 im ix im i1 wx ix cb - i1 -
+- ix ix ix ix ix im im i1 - ac - im im wx i1

--- a/project/assets/main/nurikabe/official/generated/46.txt.info
+++ b/project/assets/main/nurikabe/official/generated/46.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.81

--- a/project/assets/main/nurikabe/official/generated/47.txt.info
+++ b/project/assets/main/nurikabe/official/generated/47.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.12

--- a/project/assets/main/nurikabe/official/generated/48.txt.info
+++ b/project/assets/main/nurikabe/official/generated/48.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.62

--- a/project/assets/main/nurikabe/official/generated/49.txt.info
+++ b/project/assets/main/nurikabe/official/generated/49.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.42

--- a/project/assets/main/nurikabe/official/generated/5.txt.info
+++ b/project/assets/main/nurikabe/official/generated/5.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.47

--- a/project/assets/main/nurikabe/official/generated/50.txt.info
+++ b/project/assets/main/nurikabe/official/generated/50.txt.info
@@ -1,7 +1,7 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
-difficulty 17.82
+difficulty 16.24
 width 12
 height 7
 author poobslag v02
@@ -17,21 +17,21 @@ author poobslag v02
  5 . . . .################
 
 [order]
-28 26 - 26 34 0 9 0 13 14 10 15 17
-33 27 25 27 0 - 0 - 0 13 0 41 16
-1 32 24 31 30 0 19 0 - 0 - 0 16
-0 - 23 22 - 29 18 16 2 40 0 37 16
-- 0 6 20 8 21 30 35 39 16 16 16 38
-2 5 5 7 11 21 21 36 44 41 41 41 41
+28 25 - 25 34 0 9 0 13 14 10 15 17
+33 27 24 27 0 - 0 - 0 13 0 39 16
+1 32 26 31 30 0 23 0 - 0 - 0 16
+0 - 20 19 - 29 18 16 2 37 0 38 16
+- 0 6 21 8 22 30 35 41 16 16 16 40
+2 5 5 7 11 22 22 36 44 41 41 41 41
 3 4 6 6 7 12 47 45 - 46 46 43 48
 - 5 5 7 7 7 46 48 48 48 48 48 42
 
 [reason]
 ix ix - ix ix i1 wb i1 ur p3 pk ie ib
-p3 ic id ic i1 - i1 - ac ur i1 im ul
-wx im Bi p3 im i1 Bw i1 - i1 - i1 ul
-ac - p3 Bg - ix pk uL ix ix i1 Bw ul
-- ac wx Bj cb im im ic Bg ul ul ul ul
+p3 ic Bg ic i1 - i1 - ac ur i1 wx ul
+wx im ix p3 im i1 Bw i1 - i1 - i1 ul
+ac - Bi Bg - ix pk uL ix Bi i1 wx ul
+- ac wx wx cb im im ic im ul ul ul ie
 ix ix ix ix ix ix im p3 Bw im im im im
 id wx wx wx im wx p3 ie - ul ul pk im
 - ix ix ix ix im uL im im im im im uL

--- a/project/assets/main/nurikabe/official/generated/51.txt.info
+++ b/project/assets/main/nurikabe/official/generated/51.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.92

--- a/project/assets/main/nurikabe/official/generated/52.txt.info
+++ b/project/assets/main/nurikabe/official/generated/52.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.22

--- a/project/assets/main/nurikabe/official/generated/53.txt.info
+++ b/project/assets/main/nurikabe/official/generated/53.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.33

--- a/project/assets/main/nurikabe/official/generated/54.txt.info
+++ b/project/assets/main/nurikabe/official/generated/54.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.90

--- a/project/assets/main/nurikabe/official/generated/55.txt.info
+++ b/project/assets/main/nurikabe/official/generated/55.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 20.00

--- a/project/assets/main/nurikabe/official/generated/56.txt.info
+++ b/project/assets/main/nurikabe/official/generated/56.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 9.60

--- a/project/assets/main/nurikabe/official/generated/57.txt.info
+++ b/project/assets/main/nurikabe/official/generated/57.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.98

--- a/project/assets/main/nurikabe/official/generated/58.txt.info
+++ b/project/assets/main/nurikabe/official/generated/58.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 11.53

--- a/project/assets/main/nurikabe/official/generated/59.txt.info
+++ b/project/assets/main/nurikabe/official/generated/59.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.45

--- a/project/assets/main/nurikabe/official/generated/6.txt.info
+++ b/project/assets/main/nurikabe/official/generated/6.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 17.27

--- a/project/assets/main/nurikabe/official/generated/60.txt.info
+++ b/project/assets/main/nurikabe/official/generated/60.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.91

--- a/project/assets/main/nurikabe/official/generated/61.txt.info
+++ b/project/assets/main/nurikabe/official/generated/61.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.10

--- a/project/assets/main/nurikabe/official/generated/62.txt.info
+++ b/project/assets/main/nurikabe/official/generated/62.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.86

--- a/project/assets/main/nurikabe/official/generated/63.txt.info
+++ b/project/assets/main/nurikabe/official/generated/63.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.47

--- a/project/assets/main/nurikabe/official/generated/64.txt.info
+++ b/project/assets/main/nurikabe/official/generated/64.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 20.00

--- a/project/assets/main/nurikabe/official/generated/65.txt.info
+++ b/project/assets/main/nurikabe/official/generated/65.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.29

--- a/project/assets/main/nurikabe/official/generated/66.txt.info
+++ b/project/assets/main/nurikabe/official/generated/66.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.84

--- a/project/assets/main/nurikabe/official/generated/67.txt.info
+++ b/project/assets/main/nurikabe/official/generated/67.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.53

--- a/project/assets/main/nurikabe/official/generated/68.txt.info
+++ b/project/assets/main/nurikabe/official/generated/68.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.64

--- a/project/assets/main/nurikabe/official/generated/69.txt.info
+++ b/project/assets/main/nurikabe/official/generated/69.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.94

--- a/project/assets/main/nurikabe/official/generated/7.txt.info
+++ b/project/assets/main/nurikabe/official/generated/7.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/70.txt.info
+++ b/project/assets/main/nurikabe/official/generated/70.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/71.txt.info
+++ b/project/assets/main/nurikabe/official/generated/71.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.41

--- a/project/assets/main/nurikabe/official/generated/72.txt.info
+++ b/project/assets/main/nurikabe/official/generated/72.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.23

--- a/project/assets/main/nurikabe/official/generated/73.txt.info
+++ b/project/assets/main/nurikabe/official/generated/73.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.77

--- a/project/assets/main/nurikabe/official/generated/74.txt.info
+++ b/project/assets/main/nurikabe/official/generated/74.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.64

--- a/project/assets/main/nurikabe/official/generated/75.txt.info
+++ b/project/assets/main/nurikabe/official/generated/75.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 17.38

--- a/project/assets/main/nurikabe/official/generated/76.txt.info
+++ b/project/assets/main/nurikabe/official/generated/76.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 7.11

--- a/project/assets/main/nurikabe/official/generated/77.txt.info
+++ b/project/assets/main/nurikabe/official/generated/77.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.39

--- a/project/assets/main/nurikabe/official/generated/78.txt.info
+++ b/project/assets/main/nurikabe/official/generated/78.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.56

--- a/project/assets/main/nurikabe/official/generated/79.txt.info
+++ b/project/assets/main/nurikabe/official/generated/79.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 11.13

--- a/project/assets/main/nurikabe/official/generated/8.txt.info
+++ b/project/assets/main/nurikabe/official/generated/8.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 14.11

--- a/project/assets/main/nurikabe/official/generated/80.txt.info
+++ b/project/assets/main/nurikabe/official/generated/80.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 17.02

--- a/project/assets/main/nurikabe/official/generated/81.txt.info
+++ b/project/assets/main/nurikabe/official/generated/81.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 8.17

--- a/project/assets/main/nurikabe/official/generated/82.txt.info
+++ b/project/assets/main/nurikabe/official/generated/82.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 5.99

--- a/project/assets/main/nurikabe/official/generated/83.txt.info
+++ b/project/assets/main/nurikabe/official/generated/83.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.86

--- a/project/assets/main/nurikabe/official/generated/84.txt.info
+++ b/project/assets/main/nurikabe/official/generated/84.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.84

--- a/project/assets/main/nurikabe/official/generated/85.txt.info
+++ b/project/assets/main/nurikabe/official/generated/85.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.76

--- a/project/assets/main/nurikabe/official/generated/86.txt.info
+++ b/project/assets/main/nurikabe/official/generated/86.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.55

--- a/project/assets/main/nurikabe/official/generated/87.txt.info
+++ b/project/assets/main/nurikabe/official/generated/87.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 2.29

--- a/project/assets/main/nurikabe/official/generated/88.txt.info
+++ b/project/assets/main/nurikabe/official/generated/88.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 8.98

--- a/project/assets/main/nurikabe/official/generated/89.txt.info
+++ b/project/assets/main/nurikabe/official/generated/89.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.72

--- a/project/assets/main/nurikabe/official/generated/9.txt.info
+++ b/project/assets/main/nurikabe/official/generated/9.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00

--- a/project/assets/main/nurikabe/official/generated/90.txt.info
+++ b/project/assets/main/nurikabe/official/generated/90.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 10.46

--- a/project/assets/main/nurikabe/official/generated/91.txt.info
+++ b/project/assets/main/nurikabe/official/generated/91.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 4.55

--- a/project/assets/main/nurikabe/official/generated/92.txt.info
+++ b/project/assets/main/nurikabe/official/generated/92.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 9.35

--- a/project/assets/main/nurikabe/official/generated/93.txt.info
+++ b/project/assets/main/nurikabe/official/generated/93.txt.info
@@ -1,7 +1,7 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
-difficulty 16.00
+difficulty 15.54
 width 9
 height 16
 author poobslag v02

--- a/project/assets/main/nurikabe/official/generated/94.txt.info
+++ b/project/assets/main/nurikabe/official/generated/94.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.20

--- a/project/assets/main/nurikabe/official/generated/95.txt.info
+++ b/project/assets/main/nurikabe/official/generated/95.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.80

--- a/project/assets/main/nurikabe/official/generated/96.txt.info
+++ b/project/assets/main/nurikabe/official/generated/96.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 1.76

--- a/project/assets/main/nurikabe/official/generated/97.txt.info
+++ b/project/assets/main/nurikabe/official/generated/97.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 3.89

--- a/project/assets/main/nurikabe/official/generated/98.txt.info
+++ b/project/assets/main/nurikabe/official/generated/98.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 6.26

--- a/project/assets/main/nurikabe/official/generated/99.txt.info
+++ b/project/assets/main/nurikabe/official/generated/99.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.88

--- a/project/assets/test/nurikabe/example_474.txt.info
+++ b/project/assets/test/nurikabe/example_474.txt.info
@@ -1,4 +1,4 @@
-{"version":"0.01"}
+{"version":"0.02"}
 
 [metadata]
 difficulty 0.00


### PR DESCRIPTION
Newly generated puzzle.txt.info files were using an invalid outdated json format which didn't include solution metadata.

Updated puzzle.txt.info versions to 0.02.