### PR TITLE
Fixed wall expansion rule for Janko 11 (wall quota)

### DIFF
--- a/project/src/main/nurikabe/solver/solver.gd
+++ b/project/src/main/nurikabe/solver/solver.gd
@@ -932,11 +932,11 @@ func deduce_island(island: CellGroup) -> void:
 
 func deduce_wall_expansion(wall: CellGroup) -> void:
 	@warning_ignore("integer_division")
-	if wall.liberties.size() == 1 and (board.walls.size() >= 2 or wall.size() < board.cells.size() / 2):
+	if wall.liberties.size() == 1 and (board.walls.size() >= 2 or wall.size() < board.get_wall_quota()):
 		var squeeze_fill: SqueezeFill = SqueezeFill.new(board)
 		squeeze_fill.skip_cells(wall.cells)
 		squeeze_fill.push_change(wall.liberties.front(), CELL_WALL)
-		squeeze_fill.fill()
+		squeeze_fill.fill(999999 if board.walls.size() >= 2 else board.get_wall_quota() - wall.size() - 1)
 		for change: Vector2i in squeeze_fill.changes:
 			if should_deduce(board, change):
 				add_deduction(change, CELL_WALL, WALL_EXPANSION, [wall.root])

--- a/project/src/main/nurikabe/solver/solver_board.gd
+++ b/project/src/main/nurikabe/solver/solver_board.gd
@@ -206,6 +206,12 @@ func get_wall_chokepoint_map() -> SolverChokepointMap:
 		_build_wall_chokepoint_map)
 
 
+func get_wall_quota() -> int:
+	return _get_cached(
+		"wall_quota",
+		_build_wall_quota)
+
+
 func get_per_clue_chokepoint_map() -> PerClueChokepointMap:
 	return _get_cached(
 		"per_clue_chokepoint_map",
@@ -223,6 +229,7 @@ func set_clue(cell_pos: Vector2i, clue: int) -> void:
 		push_error("set_clue: invalid cell_pos (%s)" % [cell_pos])
 		return
 	
+	_cache.erase("wall_quota")
 	if clue == 0:
 		clues.erase(cell_pos)
 	else:
@@ -488,6 +495,18 @@ func _build_island_clues() -> Dictionary[Vector2i, int]:
 
 func _build_island_reachability_map() -> IslandReachabilityMap:
 	return IslandReachabilityMap.new(self)
+
+
+func _build_wall_quota() -> int:
+	var quota: int = cells.size()
+	for island: CellGroup in islands:
+		if island.clue == CELL_MYSTERY_CLUE:
+			@warning_ignore("integer_division")
+			quota = ceili(cells.size() / 2)
+			break
+		
+		quota -= island.clue
+	return quota
 
 
 func _clue_value_for_cells(island: Array[Vector2i]) -> int:

--- a/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
@@ -695,6 +695,19 @@ func test_deduce_all_walls_wall_expansion_1() -> void:
 	assert_deductions(solver.deduce_all_walls, expected)
 
 
+func test_deduce_all_walls_wall_expansion_last_wall() -> void:
+	grid = [
+		"####  ",
+		"## .  ",
+		" 4 .  ",
+	]
+	var expected: Array[String] = [
+		"(2, 0)->## wall_expansion (0, 0)",
+		"(2, 1)->## wall_expansion (0, 0)",
+	]
+	assert_deductions(solver.deduce_all_walls, expected)
+
+
 func test_deduce_all_walls_wall_expansion_mystery_clue() -> void:
 	grid = [
 		"     ?",

--- a/project/src/test/nurikabe/solver/test_solver_board.gd
+++ b/project/src/test/nurikabe/solver/test_solver_board.gd
@@ -667,6 +667,26 @@ func test_island_chain_map_cycle_janko_83() -> void:
 	board.cleanup()
 
 
+func test_wall_quota() -> void:
+	grid = [
+		"   1      ",
+		"         2",
+		"          ",
+		" 4        ",
+		"       3  ",
+	]
+	var board: SolverBoard = SolverTestUtils.init_board(grid)
+	assert_eq(15, board.get_wall_quota())
+	
+	board.set_clue(Vector2i(1, 0), 0)
+	assert_eq(16, board.get_wall_quota())
+	
+	board.set_clue(Vector2i(1, 0), 2)
+	assert_eq(14, board.get_wall_quota())
+	
+	board.cleanup()
+
+
 func assert_groups(actual_groups: Array[CellGroup], expected_props_list: Array[Dictionary]) -> void:
 	var actual_props_list: Array[Dictionary] = []
 	for actual_group: CellGroup in actual_groups:


### PR DESCRIPTION
For most puzzles, we can just expand the walls when there are 2 or more walls on the board. For the generator, we have one special exception to expand walls if the board is 50% empty. But for Janko 11 we also need one last rule, "expand the wall if the puzzle isn't finished."

I borrowed this concept from Stephan T. Lavavej's C9 Lecture, "Standard Template Library (STL)". He came up with the idea of counting the total wall size and comparing it to the clues.