### PR TITLE
Generator: random_nearby_clue, liberties >= 2, split island

### DIFF
--- a/project/src/main/nurikabe/generator/placement.gd
+++ b/project/src/main/nurikabe/generator/placement.gd
@@ -12,6 +12,7 @@ enum Reason {
 	ISLAND_MOAT, # seal an open island with walls
 	SEALED_ISLAND_CLUE, # assign a clue number to a sealed island
 	WALL_GUIDE, # add a clue cell to constrain an open wall
+	RANDOM_CLUE, # add a clue cell at a random board position
 	
 	# advanced techniques
 	ISLAND_BUFFER, # add a clue cell to indirectly constrain an open island (knight's move)

--- a/project/src/main/nurikabe/generator/puzzle_mutator.gd
+++ b/project/src/main/nurikabe/generator/puzzle_mutator.gd
@@ -163,7 +163,7 @@ func mutate(solver: Solver) -> void:
 		picker.add(mutate_fix_unfinished.bind(solver), 4.0)
 	picker.add(_mutation_library.mutate_shrink_dead_end_wall.bind(solver.board))
 	picker.add(_mutation_library.mutate_break_wall_loop.bind(solver.board))
-	picker.add(_mutation_library.mutate_split_island.bind(solver.board))
+	picker.add(_mutation_library.mutate_cleave_island.bind(solver.board))
 	picker.add(_mutation_library.mutate_rebalance_neighbor_islands.bind(solver.board))
 	picker.add(_mutation_library.mutate_move_clue.bind(solver.board))
 	
@@ -184,7 +184,8 @@ func mutate_fix_errors(solver: Solver) -> bool:
 			break
 		var mutate_options: Array[Callable] = []
 		if not validation_errors.joined_islands.is_empty():
-			mutate_options.append(_mutation_library.mutate_fix_joined_islands)
+			mutate_options.append(_mutation_library.mutate_fix_joined_islands_collapse)
+			mutate_options.append(_mutation_library.mutate_fix_joined_islands_split)
 		if not validation_errors.pools.is_empty():
 			mutate_options.append(_mutation_library.mutate_fix_pools)
 		if not validation_errors.split_walls.is_empty():

--- a/project/src/test/nurikabe/generator/test_mutation_library_basic.gd
+++ b/project/src/test/nurikabe/generator/test_mutation_library_basic.gd
@@ -65,7 +65,7 @@ func test_get_possible_island_splits() -> void:
 	board.cleanup()
 
 
-func test_split_island_cell() -> void:
+func test_cleave_island_cell() -> void:
 	var grid: Array[String] = [
 		"15## 2## .",
 		" .## .## .",
@@ -78,7 +78,7 @@ func test_split_island_cell() -> void:
 	var island: CellGroup = board.get_island_for_cell(Vector2i(0, 0))
 	var island_split: MutationLibrary.IslandSplit = \
 			MutationLibrary.IslandSplit.new(MutationLibrary.SPLIT_CELL, Vector2i(0, 2))
-	mutation_library.split_island(board, island, island_split)
+	mutation_library.cleave_island(board, island, island_split)
 	
 	assert_board(board, [
 			" 2## 2##13",
@@ -90,7 +90,7 @@ func test_split_island_cell() -> void:
 	board.cleanup()
 
 
-func test_split_island_horizontal() -> void:
+func test_cleave_island_horizontal() -> void:
 	var grid: Array[String] = [
 		"15## .## .",
 		" .## 2## .",
@@ -103,7 +103,7 @@ func test_split_island_horizontal() -> void:
 	var island: CellGroup = board.get_island_for_cell(Vector2i(0, 2))
 	var island_split: MutationLibrary.IslandSplit = \
 			MutationLibrary.IslandSplit.new(MutationLibrary.SPLIT_HORIZONTAL, Vector2i(0, 2))
-	mutation_library.split_island(board, island, island_split)
+	mutation_library.cleave_island(board, island, island_split)
 	
 	assert_board(board, [
 			" 2## .## .",
@@ -115,7 +115,7 @@ func test_split_island_horizontal() -> void:
 	board.cleanup()
 
 
-func test_split_island_vertical() -> void:
+func test_cleave_island_vertical() -> void:
 	var grid: Array[String] = [
 		"15## .## .",
 		" .## 2## .",
@@ -128,7 +128,7 @@ func test_split_island_vertical() -> void:
 	var island: CellGroup = board.get_island_for_cell(Vector2i(0, 2))
 	var island_split: MutationLibrary.IslandSplit = \
 			MutationLibrary.IslandSplit.new(MutationLibrary.SPLIT_VERTICAL, Vector2i(1, 0))
-	mutation_library.split_island(board, island, island_split)
+	mutation_library.cleave_island(board, island, island_split)
 	
 	assert_board(board, [
 			" 5## .## .",

--- a/project/src/test/nurikabe/generator/test_mutation_library_fix.gd
+++ b/project/src/test/nurikabe/generator/test_mutation_library_fix.gd
@@ -59,7 +59,7 @@ func test_mutate_fix_enclosed_walls_ok() -> void:
 	board.cleanup()
 
 
-func test_mutate_fix_joined_islands() -> void:
+func test_mutate_fix_joined_islands_collapse() -> void:
 	var grid: Array[String] = [
 		" . 2######",
 		"## .## .##",
@@ -69,14 +69,14 @@ func test_mutate_fix_joined_islands() -> void:
 	]
 	var board: SolverBoard = SolverBoard.new()
 	board.from_grid_string("\n".join(grid))
-	mutation_library.mutate_fix_joined_islands(board)
+	mutation_library.mutate_fix_joined_islands_collapse(board)
 	
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).size(), 8)
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).clue, 8)
 	board.cleanup()
 
 
-func test_mutate_fix_joined_islands_single() -> void:
+func test_mutate_fix_joined_islands_collapse_single() -> void:
 	var grid: Array[String] = [
 		" . 2######",
 		"## .## .##",
@@ -84,10 +84,25 @@ func test_mutate_fix_joined_islands_single() -> void:
 	]
 	var board: SolverBoard = SolverBoard.new()
 	board.from_grid_string("\n".join(grid))
-	mutation_library.mutate_fix_joined_islands(board)
+	mutation_library.mutate_fix_joined_islands_collapse(board)
 	
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).size(), 8)
 	assert_eq(board.get_island_for_cell(Vector2i(0, 2)).clue, 8)
+	board.cleanup()
+
+
+func test_mutate_fix_joined_islands_split() -> void:
+	var grid: Array[String] = [
+		"###### ?##",
+		" ? . . .##",
+		"#### . . .",
+	]
+	var board: SolverBoard = SolverBoard.new()
+	board.from_grid_string("\n".join(grid))
+	mutation_library.mutate_fix_joined_islands_split(board)
+	
+	var validation_errors: SolverBoard.ValidationResult = board.validate(SolverBoard.VALIDATE_SIMPLE)
+	assert_eq([], validation_errors.joined_islands)
 	board.cleanup()
 
 


### PR DESCRIPTION
Added generate_random_nearby_clue to the puzzle generator. This helps combat the vertical stripes which arise from repeatedly expanding parallel islands.

generate_wall_guide and generate_island_guide now function on islands with more than 2 liberties. These generation techniques are just meant to shape islands/walls, so it's OK if it leaves them with more than one option.

Added mutate_fix_joined_islands_split, which fixes joined islands by randomly expanding each island over and over, performing island chain deductions to avoid contradictions.

Renamed 'split_island' to 'cleave_island'. The phase split_island was ambiguous and it's also a nice variable name.