### PR TITLE
Removed redundant wall weaver deduction.

### DIFF
--- a/project/src/main/monster/sim/deduction_scorer.gd
+++ b/project/src/main/monster/sim/deduction_scorer.gd
@@ -29,7 +29,6 @@ const UNCLUED_LIFELINE: Deduction.Reason = Deduction.Reason.UNCLUED_LIFELINE
 const UNCLUED_LIFELINE_BUFFER: Deduction.Reason = Deduction.Reason.UNCLUED_LIFELINE_BUFFER
 const UNREACHABLE_CELL: Deduction.Reason = Deduction.Reason.UNREACHABLE_CELL
 const WALL_CONNECTOR: Deduction.Reason = Deduction.Reason.WALL_CONNECTOR
-const WALL_WEAVER: Deduction.Reason = Deduction.Reason.WALL_WEAVER
 
 ## advanced techniques
 const ASSUMPTION: Deduction.Reason = Deduction.Reason.ASSUMPTION
@@ -73,7 +72,6 @@ const DEDUCTION_PRIORITY_FOR_REASON: Dictionary[Deduction.Reason, float] = {
 	UNCLUED_LIFELINE_BUFFER: 5.0,
 	UNREACHABLE_CELL: 5.0,
 	WALL_CONNECTOR: 5.0,
-	WALL_WEAVER: 5.0,
 	
 	# advanced techniques; low priority
 	ASSUMPTION: 0.0,
@@ -116,7 +114,6 @@ const DEDUCTION_DELAYS_MIN: Dictionary[Deduction.Reason, float] = {
 	UNCLUED_LIFELINE_BUFFER: 5.4,
 	UNREACHABLE_CELL: 5.4,
 	WALL_CONNECTOR: 5.4,
-	WALL_WEAVER: 5.4,
 	
 	# advanced techniques
 	ASSUMPTION: 10.8,
@@ -157,7 +154,6 @@ const DEDUCTION_DELAYS_MAX: Dictionary[Deduction.Reason, float] = {
 	UNCLUED_LIFELINE_BUFFER: 18.0,
 	UNREACHABLE_CELL: 18.0,
 	WALL_CONNECTOR: 18.0,
-	WALL_WEAVER: 18.0,
 	
 	# advanced techniques
 	ASSUMPTION: 60.0,

--- a/project/src/main/monster/sim/naive_scanners.gd
+++ b/project/src/main/monster/sim/naive_scanners.gd
@@ -36,7 +36,6 @@ const UNCLUED_LIFELINE: Deduction.Reason = Deduction.Reason.UNCLUED_LIFELINE
 const UNCLUED_LIFELINE_BUFFER: Deduction.Reason = Deduction.Reason.UNCLUED_LIFELINE_BUFFER
 const UNREACHABLE_CELL: Deduction.Reason = Deduction.Reason.UNREACHABLE_CELL
 const WALL_CONNECTOR: Deduction.Reason = Deduction.Reason.WALL_CONNECTOR
-const WALL_WEAVER: Deduction.Reason = Deduction.Reason.WALL_WEAVER
 
 ## advanced techniques
 const ASSUMPTION: Deduction.Reason = Deduction.Reason.ASSUMPTION

--- a/project/src/main/nurikabe/reason_code.gd
+++ b/project/src/main/nurikabe/reason_code.gd
@@ -29,7 +29,6 @@ const UNCLUED_LIFELINE: Deduction.Reason = Deduction.Reason.UNCLUED_LIFELINE
 const UNCLUED_LIFELINE_BUFFER: Deduction.Reason = Deduction.Reason.UNCLUED_LIFELINE_BUFFER
 const UNREACHABLE_CELL: Deduction.Reason = Deduction.Reason.UNREACHABLE_CELL
 const WALL_CONNECTOR: Deduction.Reason = Deduction.Reason.WALL_CONNECTOR
-const WALL_WEAVER: Deduction.Reason = Deduction.Reason.WALL_WEAVER
 
 ## advanced techniques
 const ASSUMPTION: Deduction.Reason = Deduction.Reason.ASSUMPTION
@@ -69,7 +68,6 @@ const CODES: Dictionary[String, Deduction.Reason] = {
 	"ur": UNREACHABLE_CELL,
 	"wb": WALL_BUBBLE,
 	"we": WALL_CONNECTOR,
-	"wv": WALL_WEAVER,
 	
 	# advanced techniques
 	"??": ASSUMPTION,

--- a/project/src/main/nurikabe/solver/deduction.gd
+++ b/project/src/main/nurikabe/solver/deduction.gd
@@ -38,7 +38,6 @@ enum Reason {
 	UNCLUED_LIFELINE_BUFFER, # add a wall to prevent an unclued island from becoming unreachable
 	UNREACHABLE_CELL, # add a wall where no clue can reach
 	WALL_CONNECTOR, # connect two walls through a chokepoint
-	WALL_WEAVER, # finish an island in a way which preserves wall connectivity
 	
 	# Advanced techniques - Require planning several moves ahead
 	ASSUMPTION, # unproven assumption made when bifurcating

--- a/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
+++ b/project/src/main/nurikabe/solver/per_clue_chokepoint_map.gd
@@ -106,27 +106,6 @@ func get_component_cells(island: CellGroup) -> Array[Vector2i]:
 	return get_chokepoint_map(island).get_component_cells(island.root)
 
 
-## Builds a GroupMap of all wall regions that would exist if this clue's entire reachable island area were filled
-## in.[br]
-## [br]
-## In effect, this "excludes" the clue's component cells by treating them as solid islands, and groups every remaining
-## wall or unreachable empty cell into contiguous wall components.[br]
-## [br]
-## Used to detect whether filling the island could create a split wall.
-func get_wall_exclusion_map(island: CellGroup) -> GroupMap:
-	var component_cell_set: Dictionary[Vector2i, bool] = {}
-	for component_cell: Vector2i in get_component_cells(island):
-		component_cell_set[component_cell] = true
-	var cells: Array[Vector2i] = []
-	for wall: CellGroup in board.walls:
-		for cell: Vector2i in wall.cells:
-			cells.append(cell)
-	for cell: Vector2i in board.empty_cells:
-		if not cell in component_cell_set:
-			cells.append(cell)
-	return GroupMap.new(cells)
-
-
 func _has_chokepoint_map(island: CellGroup) -> bool:
 	return _chokepoint_map_by_clue.has(island.root)
 

--- a/project/src/test/nurikabe/solver/test_island_reachability_map.gd
+++ b/project/src/test/nurikabe/solver/test_island_reachability_map.gd
@@ -28,6 +28,17 @@ func test_get_clue_reachability_avoids_cycles() -> void:
 	assert_eq(irm.get_clue_reachability(Vector2(1, 2)), IslandReachabilityMap.ClueReachability.CHAIN_CYCLE)
 
 
+func test_get_clue_reachability_avoids_cycles_2() -> void:
+	grid = [
+		"#### 4 .  ",
+		" 7####    ",
+		" .   .  ##",
+		"      ## 1",
+	]
+	var irm: IslandReachabilityMap = init_island_reachability_map()
+	assert_eq(irm.get_clue_reachability(Vector2(3, 2)), IslandReachabilityMap.ClueReachability.CHAIN_CYCLE)
+
+
 func test_get_clue_reachability_cycles_janko_3() -> void:
 	grid = [
 		"         3          ",

--- a/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
@@ -1,50 +1,5 @@
 extends TestSolver
 
-func test_deduce_all_clue_chokepoints_wall_weaver_1() -> void:
-	grid = [
-		"#### 4 .  ",
-		" 7####    ",
-		" .   .  ##",
-		"      ## 1",
-	]
-	var expected: Array[String] = [
-		"(3, 2)->## wall_weaver (0, 1)",
-	]
-	assert_deductions(solver.deduce_all_clue_chokepoints, expected)
-
-
-func test_deduce_all_clue_chokepoints_wall_weaver_2() -> void:
-	grid = [
-		"## 6    ##",
-		"##      ##",
-		"##    ## 4",
-		" 1##     .",
-		"##   3## .",
-		"          ",
-	]
-	var expected: Array[String] = [
-		"(1, 2)->## wall_weaver (1, 0)",
-		"(3, 1)->## wall_weaver (1, 0)",
-	]
-	assert_deductions(solver.deduce_all_clue_chokepoints, expected)
-
-
-func test_deduce_all_clue_chokepoints_wall_weaver_3() -> void:
-	grid = [
-		"###### . . . .",
-		"## 2## .#### .",
-		"## .####10## 7",
-		" 1##     .####",
-		"##        ## 3",
-		"## .         .",
-		"############  ",
-	]
-	var expected: Array[String] = [
-		"(1, 4)->## wall_weaver (4, 2)",
-		"(2, 3)->## wall_weaver (4, 2)",
-	]
-	assert_deductions(solver.deduce_all_clue_chokepoints, expected)
-
 
 func test_deduce_all_clue_chokepoints_adjacent() -> void:
 	grid = [
@@ -543,7 +498,7 @@ func test_deduce_all_unreachable_squares_3() -> void:
 		" . 7   .",
 	]
 	var expected: Array[String] = [
-		"(2, 0)->## island_chain_buffer (3, 1)",
+		"(2, 0)->## island_chain_buffer (0, 2)",
 		"(2, 2)->## island_divider (0, 2) (3, 1)",
 		"(3, 0)->## unreachable_cell (3, 1)",
 	]
@@ -559,6 +514,74 @@ func test_deduce_all_unreachable_squares_blocked() -> void:
 	]
 	var expected: Array[String] = [
 		"(4, 0)->## unreachable_cell (4, 2)",
+	]
+	assert_deductions(solver.deduce_all_unreachable_squares, expected)
+
+
+func test_deduce_all_unreachable_squares_island_chain_buffer_1() -> void:
+	# 7 can't touch the 1 without creating a split wall
+	grid = [
+		"#### 4 .  ",
+		" 7####    ",
+		" .   .  ##",
+		"      ## 1",
+	]
+	var expected: Array[String] = [
+		"(3, 2)->## island_chain_buffer (0, 1)",
+	]
+	assert_deductions(solver.deduce_all_unreachable_squares, expected)
+
+
+func test_deduce_all_unreachable_squares_island_chain_buffer_2() -> void:
+	# 6 can't touch the 1 or 4 without creating a split wall
+	grid = [
+		"## 6    ##",
+		"##      ##",
+		"##    ## 4",
+		" 1##     .",
+		"##   3## .",
+		"##        ",
+	]
+	var expected: Array[String] = [
+		"(1, 2)->## island_chain_buffer (1, 0)",
+		"(3, 1)->## island_chain_buffer (1, 0)",
+	]
+	assert_deductions(solver.deduce_all_unreachable_squares, expected)
+
+
+func test_deduce_all_unreachable_squares_island_chain_buffer_3() -> void:
+	# 10 can't touch the 1 or 2 without creating a split wall
+	grid = [
+		"###### . . . .",
+		"## 2## .#### .",
+		"## .####10## 7",
+		" 1##     .####",
+		"##        ## 3",
+		"## .         .",
+		"############  ",
+	]
+	var expected: Array[String] = [
+		"(1, 4)->## island_chain_buffer (4, 2)",
+		"(2, 3)->## island_chain_buffer (4, 2)",
+	]
+	assert_deductions(solver.deduce_all_unreachable_squares, expected)
+
+
+func test_deduce_all_unreachable_squares_island_chain_buffer_4() -> void:
+	# no deductions can be made, although this scenario caused a flawed deduction in the old 'wall weaver' logic
+	grid = [
+		" .  ################## 1##",
+		" .  ## . . . . . . .######",
+		" 4## 1############ . .10##",
+		"######## . .## .########  ",
+		" 3 . .## .#### .## .     .",
+		"###### 5 .## . .##   3## 3",
+		" 2 .######## .##    ####  ",
+		"###### . .## .##   . 6 .  ",
+		"## 2 .## 3## .##  ######  ",
+		"########## 9 .## 5 . . .  ",
+	]
+	var expected: Array[String] = [
 	]
 	assert_deductions(solver.deduce_all_unreachable_squares, expected)
 


### PR DESCRIPTION
This wall weaver deduction was incorrectly deducing some cells as walls which could not actually be deduced logically. The deduction is redundant with the new island cycle chain logic.

Deleted PerClueChokepointMap's wall exclusion map, which was only used by this wall weaver deduction.

Gut tests are failing. The failures stem from some bugs in the unreachable logic which has trouble distinguishing why things are unreachable. A fix is coming.