### PR TITLE
IslandReachabilityMap: get_cycle_root, chain_cycle/impossible fix

### DIFF
--- a/project/src/demo/nurikabe/solver/demo_solver.gd
+++ b/project/src/demo/nurikabe/solver/demo_solver.gd
@@ -301,7 +301,7 @@ func _on_command_palette_command_entered(command: String) -> void:
 	match command.substr(0, 1):
 		"g", "j", "n", "p":
 			if not command.substr(1).is_valid_int():
-				_log_message("Invalid parameter: " % [command.substr(1)])
+				_log_message("Invalid parameter: %s" % [command.substr(1)])
 				return
 			var source: PuzzleArchive.Source
 			match command.substr(0, 1):

--- a/project/src/main/nurikabe/solver/solver.gd
+++ b/project/src/main/nurikabe/solver/solver.gd
@@ -602,7 +602,7 @@ func deduce_all_unreachable_squares() -> void:
 				add_deduction(cell, CELL_WALL, WALL_BUBBLE)
 				add_fun(FUN_FAST, 1.0)
 			IslandReachabilityMap.ClueReachability.CHAIN_CYCLE:
-				var nearest_clue: Vector2i = irm.get_nearest_clued_island_cell(cell)
+				var nearest_clue: Vector2i = irm.get_cycle_root(cell)
 				add_deduction(cell, CELL_WALL, ISLAND_CHAIN_BUFFER, [nearest_clue])
 				add_fun(FUN_THINK, 1.0)
 			IslandReachabilityMap.ClueReachability.CONFLICT:

--- a/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
+++ b/project/src/test/nurikabe/solver/test_solver_basic_techniques.gd
@@ -264,6 +264,7 @@ func test_deduce_unclued_lifeline_8() -> void:
 		"## . 7####   . . .10",
 	]
 	var expected: Array[String] = [
+		"(9, 3)->. unclued_lifeline (9, 5)",
 	]
 	assert_deductions(solver.deduce_unclued_lifeline, expected)
 


### PR DESCRIPTION
Added IslandReachabilityMap.get_cycle_root(). This avoids an edge case where people call 'get_nearest_clue' when no clue can reach a specific cell, because the cell is blocked by a chain cycle.

Fixed bug where IslandReachabilityMap sometimes reported cells unreachable due to a chain cycle as being completely blocked in by walls.

Fixed bug where IslandReachabilityMap's ghost propogation would sometimes propogate positive values, as though the cells were reachable. It now ensures all values are 0 or negative.

Fixed string replaceable entity typo in demo_solver.gd