### PR TITLE
Fixed ground error appearance; restored 'alpha_scissor' property

### DIFF
--- a/project/assets/main/nurikabe/tile_ground_error.tres
+++ b/project/assets/main/nurikabe/tile_ground_error.tres
@@ -4,7 +4,9 @@
 
 [resource]
 resource_name = "tile_ground_error"
-transparency = 4
+transparency = 2
+alpha_scissor_threshold = 0.5
+alpha_antialiasing_mode = 0
 cull_mode = 2
+shading_mode = 0
 albedo_texture = ExtResource("1_3dvhf")
-roughness = 0.5

--- a/project/assets/main/nurikabe/tile_island_error.tres
+++ b/project/assets/main/nurikabe/tile_island_error.tres
@@ -4,7 +4,9 @@
 
 [resource]
 resource_name = "tile_island_error"
-transparency = 4
+transparency = 2
+alpha_scissor_threshold = 0.5
+alpha_antialiasing_mode = 0
 cull_mode = 2
+shading_mode = 0
 albedo_texture = ExtResource("1_eqi5f")
-roughness = 0.5

--- a/project/assets/main/nurikabe/tile_island_half_error.tres
+++ b/project/assets/main/nurikabe/tile_island_half_error.tres
@@ -4,7 +4,9 @@
 
 [resource]
 resource_name = "tile_island_half_error"
-transparency = 4
+transparency = 2
+alpha_scissor_threshold = 0.5
+alpha_antialiasing_mode = 0
 cull_mode = 2
+shading_mode = 0
 albedo_texture = ExtResource("1_bqc3b")
-roughness = 0.5


### PR DESCRIPTION
This was broken in da5aafde8 when getting rid of the '_3d' suffixes. Godot restored the import defaults and got rid of the 'alpha_scissor' property.