### PR TITLE
Sims stay away from bottom puzzle edge. Names fade.

### DIFF
--- a/project/src/main/monster/monster.gd
+++ b/project/src/main/monster/monster.gd
@@ -48,6 +48,8 @@ const STEP_RAY_HEIGHT: float = 0.8
 const STEP_RAY_THRESHOLD: float = 0.1
 const STEP_RAY_SPREAD: float = 0.25 * PI
 
+const FADE_DURATION: float = 0.20
+
 static var _next_id: int = 0
 
 @export var skin: MonsterSkin = MonsterSkin.PURPLE:
@@ -146,10 +148,14 @@ func _refresh_skin() -> void:
 
 
 func _on_click_area_mouse_entered() -> void:
-	_fade_tween = Utils.recreate_tween(self, _fade_tween)
-	_fade_tween.tween_property(%AnimatedSprite3D, "modulate:a", 0.33, 0.25)
+	_fade_tween = Utils.recreate_tween(self, _fade_tween).set_parallel()
+	_fade_tween.tween_property(%AnimatedSprite3D, "modulate:a", 0.33, FADE_DURATION)
+	_fade_tween.tween_property(%NameLabel, "modulate:a", 0.33, FADE_DURATION)
+	_fade_tween.tween_property(%NameLabel, "outline_modulate:a", 0.33, FADE_DURATION)
 
 
 func _on_click_area_mouse_exited() -> void:
-	_fade_tween = Utils.recreate_tween(self, _fade_tween)
-	_fade_tween.tween_property(%AnimatedSprite3D, "modulate:a", 1.0, 0.25)
+	_fade_tween = Utils.recreate_tween(self, _fade_tween).set_parallel()
+	_fade_tween.tween_property(%AnimatedSprite3D, "modulate:a", 1.0, FADE_DURATION)
+	_fade_tween.tween_property(%NameLabel, "modulate:a", 1.0, FADE_DURATION)
+	_fade_tween.tween_property(%NameLabel, "outline_modulate:a", 1.0, FADE_DURATION)

--- a/project/src/main/monster/sim/find_puzzle_action.gd
+++ b/project/src/main/monster/sim/find_puzzle_action.gd
@@ -3,6 +3,7 @@ extends GoapAction
 
 const FIND_TARGET_COOLDOWN: float = 3.0
 const PUZZLE_APPROACH: float = 1.25
+const PUZZLE_APPROACH_BOTTOM: float = 2.25
 
 const DESIRED_SIZE_MIN: float = 40.0
 const DESIRED_SIZE_MAX: float = 600.0
@@ -74,7 +75,7 @@ func perform(delta: float) -> bool:
 	if target_game_board != null:
 		var puzzle_aabb: AABB = target_game_board.get_global_aabb()
 		var puzzle_rect: Rect2 = Rect2(puzzle_aabb.position.x, puzzle_aabb.position.z,
-				puzzle_aabb.size.x, puzzle_aabb.size.z)
+				puzzle_aabb.size.x, puzzle_aabb.size.z + (PUZZLE_APPROACH_BOTTOM - PUZZLE_APPROACH))
 		var monster_pos_2d: Vector2 = Vector2(monster.global_position.x, monster.global_position.z)
 		
 		monster.input.move_to(puzzle_aabb.get_center())


### PR DESCRIPTION
When approaching puzzles from the bottom, sims now stay slightly further away from the puzzle. Because of the isometric view, it's annoying otherwise when their head blocks the puzzle.

Mousing over a player now fades out their name, so that names don't block the puzzle.

Decreased fade duration from 0.25 to 0.20.