### PR TITLE
Refactor: long lines, approach zone

### DIFF
--- a/project/src/main/monster/sim/find_puzzle_action.tscn
+++ b/project/src/main/monster/sim/find_puzzle_action.tscn
@@ -10,7 +10,6 @@
 
 [node name="FindPuzzleAction" type="Node" unique_id=693002983]
 script = ExtResource("1_5qtc1")
-verbose = true
 
 [node name="FSM" parent="." unique_id=303428373 instance=ExtResource("2_wskme")]
 unique_name_in_owner = true

--- a/project/src/main/monster/sim/find_puzzle_action_approach_state.gd
+++ b/project/src/main/monster/sim/find_puzzle_action_approach_state.gd
@@ -3,13 +3,23 @@ extends FindPuzzleActionState
 
 const LOOKAHEAD_DISTANCE: float = 4.0
 
+var _approach_zone: Rect2
+
+func enter() -> void:
+	var puzzle_aabb: AABB = action.target_game_board.get_global_aabb()
+	_approach_zone = Rect2(puzzle_aabb.position.x, puzzle_aabb.position.z,
+			puzzle_aabb.size.x, puzzle_aabb.size.z)
+	_approach_zone = _approach_zone.grow_individual(
+			FindPuzzleAction.PUZZLE_APPROACH,
+			FindPuzzleAction.PUZZLE_APPROACH,
+			FindPuzzleAction.PUZZLE_APPROACH,
+			FindPuzzleAction.PUZZLE_APPROACH_BOTTOM)
+
+
 func update(_delta: float) -> void:
 	if action.target_game_board == null:
 		change_state("seek")
 	
-	var puzzle_aabb: AABB = action.target_game_board.get_global_aabb()
-	var puzzle_rect: Rect2 = Rect2(puzzle_aabb.position.x, puzzle_aabb.position.z,
-			puzzle_aabb.size.x, puzzle_aabb.size.z + (FindPuzzleAction.PUZZLE_APPROACH_BOTTOM - FindPuzzleAction.PUZZLE_APPROACH))
 	var monster_pos_2d: Vector2 = Vector2(monster.global_position.x, monster.global_position.z)
 	
 	# calculate the input direction
@@ -20,14 +30,15 @@ func update(_delta: float) -> void:
 	# truncate the target path
 	var next_point: Vector2 = action.target_path.front()
 	var to_next: Vector2 = next_point - monster_pos_2d
-	while not action.target_path.is_empty() and monster.input.dir.length() >= 0.1 and to_next.dot(monster.input.dir) <= 0:
-		action.target_path.pop_front()
-		if not action.target_path.is_empty():
-			next_point = action.target_path.front()
-			to_next = next_point - monster_pos_2d
+	if monster.input.dir.length() >= 0.1:
+		while not action.target_path.is_empty() and to_next.dot(monster.input.dir) <= 0:
+			action.target_path.pop_front()
+			if not action.target_path.is_empty():
+				next_point = action.target_path.front()
+				to_next = next_point - monster_pos_2d
 	
 	# check if we reached the target
-	if action.target_path.is_empty() or _dist_to_rect(puzzle_rect, monster_pos_2d) < FindPuzzleAction.PUZZLE_APPROACH:
+	if action.target_path.is_empty() or _approach_zone.has_point(monster_pos_2d):
 		monster.solving_board = action.target_game_board
 		action.target_game_board = null
 		monster.try_set_direction(Vector2.ZERO)
@@ -52,12 +63,3 @@ func _get_lookahead_target() -> Vector2:
 
 func _snap_to_8_directions(dir: Vector2) -> Vector2:
 	return Vector2.from_angle(snappedf(dir.angle(), PI/4))
-
-
-static func _dist_to_rect(rect: Rect2, point: Vector2) -> float:
-	var result: float
-	if rect.has_point(point):
-		result = 0.0
-	else:
-		result = point.clamp(rect.position, rect.end).distance_to(point)
-	return result


### PR DESCRIPTION
Refactored approach zone logic. Computed on enter instead of every frame. The old approach created a 'puzzle rect' which confusingly factored in only the extra buffer zone for the bottom. The new approach creates an 'approach zone' which factors in all four buffer zones.